### PR TITLE
Support clean bootstrap adoption for existing repos

### DIFF
--- a/src/archetypes.ts
+++ b/src/archetypes.ts
@@ -1172,6 +1172,7 @@ function prWorkflow(manifest: BootstrapManifest): string {
 
     permissions:
       contents: read
+      pull-requests: read
 
     env:
       NODE_VERSION: '${manifest.ci.nodeVersion}'

--- a/src/archetypes.ts
+++ b/src/archetypes.ts
@@ -776,6 +776,7 @@ function claudeWorkflow(manifest: BootstrapManifest): string {
 
     permissions:
       contents: read
+      pull-requests: read
 
     jobs:
       claude:

--- a/src/archetypes.ts
+++ b/src/archetypes.ts
@@ -9,6 +9,30 @@ function repoUrl(manifest: BootstrapManifest): string {
   return `https://github.com/${manifest.project.owner}/${manifest.project.name}`;
 }
 
+function requiredStatusChecksDisplay(manifest: BootstrapManifest): string {
+  return manifest.github.requiredStatusChecks.map((check) => `\`${check}\``).join(", ");
+}
+
+function requiredStatusChecksPlain(manifest: BootstrapManifest): string {
+  return manifest.github.requiredStatusChecks.join(", ");
+}
+
+function primaryRequiredStatusCheck(manifest: BootstrapManifest): string {
+  return manifest.github.requiredStatusChecks[0] ?? "CI Gate";
+}
+
+function requiredStatusCheckGuardrail(manifest: BootstrapManifest): string {
+  return manifest.github.requiredStatusChecks.length === 1
+    ? `- Keep ${requiredStatusChecksDisplay(manifest)} as the single required PR status check.`
+    : `- Keep required PR status checks aligned with ${requiredStatusChecksDisplay(manifest)}.`;
+}
+
+function requiredStatusCheckConfirmation(manifest: BootstrapManifest): string {
+  return manifest.github.requiredStatusChecks.length === 1
+    ? `Confirm branch protection points at the ${requiredStatusChecksDisplay(manifest)} status.`
+    : `Confirm branch protection points at the expected required status checks: ${requiredStatusChecksDisplay(manifest)}.`;
+}
+
 function codeowners(manifest: BootstrapManifest): string {
   if (manifest.github.codeowners.length === 0) {
     return "# Add CODEOWNERS entries when reviewer mapping is ready.\n";
@@ -84,11 +108,12 @@ function repoClaude(manifest: BootstrapManifest): string {
     manifest.agents.enableClaudeDevcontainer
       ? "- `.devcontainer/devcontainer.json`: interactive Claude Code workspace baseline"
       : null,
-    "- `scripts/ci/`: generated check entrypoints used by the workflows",
+    "- `.github/workflows/`: repo CI and review workflows",
+    "- `scripts/ci/`: bootstrap CI entrypoints when this repo uses the generated workflow lane",
     manifest.agents.enableClaudeDevcontainer
       ? "- `scripts/claude/setup-devcontainer.sh`: installs repo dependencies inside the devcontainer"
       : null,
-    "- `.githooks/pre-commit`: branch and env-file guardrail",
+    "- `.githooks/pre-commit`: branch and env-file guardrail when local hooks are bootstrap-managed",
     "- `docs/bootstrap/onboarding.md`: operator checklist for repo/governance setup",
     manifest.agents.enableClaudeWebEnvironment || manifest.agents.enableClaudeDevcontainer || manifest.agents.enableClaudeGitHubAction
       ? "- `docs/bootstrap/claude-environment.md`: Claude setup guide for hosted, interactive, and GitHub-hosted use"
@@ -98,7 +123,7 @@ function repoClaude(manifest: BootstrapManifest): string {
     .join("\n");
 
   const guardrailLines = [
-    "- Keep `CI Gate` as the single required PR status check.",
+    requiredStatusCheckGuardrail(manifest),
     `- Use one approval plus code owners on \`${manifest.project.defaultBranch}\` unless the manifest explicitly changes it.`,
     "- `stage` and `prod` environments require reviewers and prevent self-review by default.",
     "- Home-level Codex and Claude profile sync is managed by the bootstrap tool, not by ad-hoc manual edits.",
@@ -165,7 +190,7 @@ function repoReadme(manifest: BootstrapManifest): string {
 
     - GitHub governance and environments
     - repo-local AGENTS and CLAUDE instructions
-    - split fast and extended CI
+    - optional split fast and extended CI
     - Codex and Claude home profile sync
 
     ## Bootstrap Metadata
@@ -180,7 +205,7 @@ function repoReadme(manifest: BootstrapManifest): string {
     1. Review \`project.bootstrap.yaml\`.
     2. Run \`project-bootstrap plan --manifest ./project.bootstrap.yaml\`.
     3. Apply repo, GitHub, and home setup in that order.
-    4. Confirm branch protection points at the \`CI Gate\` status.
+    4. ${requiredStatusCheckConfirmation(manifest)}
 ${claudeSection}
 
     ## Repository URL
@@ -536,7 +561,7 @@ function codexCloudDoc(manifest: BootstrapManifest): string {
 
     - Codex cloud tasks automatically read \`AGENTS.md\` in this repo.
     - Setup scripts run in a separate shell session from the agent. Persistent env vars belong in Codex environment settings or \`~/.bashrc\`.
-    - This repo uses \`CI Gate\` as the single required PR check, so cloud review tasks should preserve that contract.
+    - This repo uses required PR checks ${requiredStatusChecksDisplay(manifest)}, so cloud review tasks should preserve that contract.
   `;
 }
 
@@ -794,7 +819,7 @@ function claudeWorkflow(manifest: BootstrapManifest): string {
                 DEFAULT BRANCH: ${manifest.project.defaultBranch}
 
                 Use CLAUDE.md and docs/bootstrap/onboarding.md as repo policy context.
-                Keep CI Gate as the single required PR status check.
+                Keep required PR status checks aligned with ${requiredStatusChecksPlain(manifest)}.
                 Preserve the split fast and extended validation model.
                 Shell-safe jobs may use \`[self-hosted, synology, shell-only, ${manifest.project.visibility === "public" ? "public" : "private"}]\`.
                 Docker, service-container, browser, and \`container:\` jobs stay on GitHub-hosted runners.
@@ -871,7 +896,7 @@ function claudeEnvironmentDoc(manifest: BootstrapManifest): string {
 
   const guardrailLines = [
     manifest.agents.enableClaudeGitHubAction
-      ? "- Keep the Claude workflow out of the required PR check set. `CI Gate` remains the only required check."
+      ? `- Keep the Claude workflow out of the required PR check set. The required checks are ${requiredStatusChecksDisplay(manifest)}.`
       : null,
     manifest.agents.enableClaudeWebEnvironment
       ? "- Prefer Claude Code on the web for long-running async review or fix tasks; use the devcontainer when you need a local interactive container."
@@ -1201,7 +1226,7 @@ ${indentBlock(setupSteps(manifest), 6)}
             run: bash scripts/check-detect-secrets.sh --all-files
 
       ci-gate:
-        name: CI Gate
+        name: ${primaryRequiredStatusCheck(manifest)}
         runs-on: ${shellRunner}
         if: always()
         needs:
@@ -1387,7 +1412,7 @@ function onboardingDoc(manifest: BootstrapManifest): string {
 
     - Confirm the repository exists at \`${manifest.project.owner}/${manifest.project.name}\`.
     - Confirm branch protection or rulesets on \`${manifest.project.defaultBranch}\` require one approval and code owner review.
-    - Confirm the only required PR status check is \`CI Gate\`.
+    - ${requiredStatusCheckConfirmation(manifest)}
     - Confirm \`delete branch on merge\` and \`allow auto-merge\` are enabled.
 
     ## Environments

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -11,6 +11,10 @@ export interface DoctorCheck {
   detail: string;
 }
 
+function requiredStatusChecksLabel(manifest: BootstrapManifest): string {
+  return manifest.github.requiredStatusChecks.join(", ");
+}
+
 async function commandExists(runner: CommandRunner, command: string): Promise<boolean> {
   const result = await runner(command, ["--version"]);
   return result.exitCode === 0;
@@ -95,7 +99,7 @@ export async function runDoctor(
       name: "Claude GitHub Action",
       status: "ok",
       detail:
-        "The generated workflow is opt-in and separate from CI Gate. Finish GitHub-side auth with the Claude GitHub app or a repository ANTHROPIC_API_KEY secret."
+        `The generated workflow is opt-in and separate from the required PR checks (${requiredStatusChecksLabel(manifest)}). Finish GitHub-side auth with the Claude GitHub app or a repository ANTHROPIC_API_KEY secret.`
     });
   }
 

--- a/src/github/provision.ts
+++ b/src/github/provision.ts
@@ -18,6 +18,10 @@ interface ReviewerIdentity {
   id: number;
 }
 
+function requiredStatusChecksLabel(manifest: BootstrapManifest): string {
+  return manifest.github.requiredStatusChecks.join(", ");
+}
+
 function environmentBranchPolicy(
   manifest: BootstrapManifest,
   environmentName: "dev" | "stage" | "prod"
@@ -132,7 +136,7 @@ export async function planGitHub(
       },
       {
         id: "branch-protection",
-        description: `Protect ${manifest.project.defaultBranch} with 1 approval, stale-review dismissal, code owner review, linear history, and required status check CI Gate.`
+        description: `Protect ${manifest.project.defaultBranch} with 1 approval, stale-review dismissal, code owner review, linear history, and required status checks ${requiredStatusChecksLabel(manifest)}.`
       },
       {
         id: "environments",
@@ -151,7 +155,7 @@ export async function planGitHub(
   });
   actions.push({
     id: "branch-protection",
-    description: `Ensure ${manifest.project.defaultBranch} requires ${manifest.github.requiredApprovals} approval(s), code owners, stale-review dismissal, linear history, and status check CI Gate.`
+    description: `Ensure ${manifest.project.defaultBranch} requires ${manifest.github.requiredApprovals} approval(s), code owners, stale-review dismissal, linear history, and status checks ${requiredStatusChecksLabel(manifest)}.`
   });
   actions.push({
     id: "environments",
@@ -232,7 +236,7 @@ export async function applyGitHub(
       {
         required_status_checks: {
           strict: true,
-          contexts: ["CI Gate"]
+          contexts: manifest.github.requiredStatusChecks
         },
         enforce_admins: true,
         required_pull_request_reviews: {

--- a/src/github/provision.ts
+++ b/src/github/provision.ts
@@ -22,6 +22,11 @@ function requiredStatusChecksLabel(manifest: BootstrapManifest): string {
   return manifest.github.requiredStatusChecks.join(", ");
 }
 
+function isEnvironmentProtectionPlanLimit(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return message.includes("Failed to create the environment protection rule. Please ensure the billing plan supports");
+}
+
 function environmentBranchPolicy(
   manifest: BootstrapManifest,
   environmentName: "dev" | "stage" | "prod"
@@ -277,25 +282,35 @@ export async function applyGitHub(
     const reviewers = environment.requireApproval
       ? await resolveReviewerIdentities(client, environment.reviewers, manifest.project.owner)
       : [];
+    const environmentEndpoint = `/repos/${manifest.project.owner}/${manifest.project.name}/environments/${environmentName}`;
+    const environmentPayload = {
+      wait_timer: 0,
+      prevent_self_review: environment.preventSelfReview,
+      reviewers,
+      ...(environmentBranchPolicy(manifest, environmentName)
+        ? {
+            deployment_branch_policy: environmentBranchPolicy(manifest, environmentName)
+          }
+        : {})
+    };
 
-    await client.api(
-      "PUT",
-      `/repos/${manifest.project.owner}/${manifest.project.name}/environments/${environmentName}`,
-      {
-        wait_timer: 0,
-        prevent_self_review: environment.preventSelfReview,
-        reviewers,
-        ...(environmentBranchPolicy(manifest, environmentName)
-          ? {
-              deployment_branch_policy: environmentBranchPolicy(manifest, environmentName)
-            }
-          : {})
+    try {
+      await client.api("PUT", environmentEndpoint, environmentPayload);
+      actions.push({
+        id: `environment-${environmentName}`,
+        description: `Synced ${environmentName} environment protection rules.`
+      });
+    } catch (error) {
+      if (!isEnvironmentProtectionPlanLimit(error)) {
+        throw error;
       }
-    );
-    actions.push({
-      id: `environment-${environmentName}`,
-      description: `Synced ${environmentName} environment protection rules.`
-    });
+
+      await client.api("PUT", environmentEndpoint, {});
+      actions.push({
+        id: `environment-${environmentName}-plan-limited`,
+        description: `Created ${environmentName} environment without protection rules because the current GitHub plan does not support protected environments on this private repository.`
+      });
+    }
   }
 
   return actions;

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -26,6 +26,11 @@ const manifestSchema = z.object({
     owner: z.string().min(1),
     defaultBranch: z.string().min(1).optional()
   }),
+  repo: z
+    .object({
+      managedPaths: z.array(z.string().min(1)).optional()
+    })
+    .optional(),
   archetype: z.object({
     kind: z.enum(["nextjs-web", "node-ts-service", "python-service", "generic-empty"]),
     packageManager: z.enum(["npm", "pnpm", "yarn"]).optional(),
@@ -39,6 +44,7 @@ const manifestSchema = z.object({
       autoMerge: z.boolean().optional(),
       deleteBranchOnMerge: z.boolean().optional(),
       requiredApprovals: z.number().int().min(1).max(6).optional(),
+      requiredStatusChecks: z.array(z.string().min(1)).min(1).optional(),
       dismissStaleReviews: z.boolean().optional(),
       requireCodeOwnerReviews: z.boolean().optional(),
       requireLastPushApproval: z.boolean().optional(),
@@ -172,6 +178,9 @@ export function normalizeManifest(raw: z.input<typeof manifestSchema>): Bootstra
       owner: parsed.project.owner,
       defaultBranch
     },
+    repo: {
+      managedPaths: parsed.repo?.managedPaths ?? []
+    },
     archetype: {
       kind: parsed.archetype.kind,
       packageManager: parsed.archetype.packageManager ?? "npm",
@@ -184,6 +193,7 @@ export function normalizeManifest(raw: z.input<typeof manifestSchema>): Bootstra
       autoMerge: github.autoMerge ?? true,
       deleteBranchOnMerge: github.deleteBranchOnMerge ?? true,
       requiredApprovals: github.requiredApprovals ?? 1,
+      requiredStatusChecks: github.requiredStatusChecks ?? ["CI Gate"],
       dismissStaleReviews: github.dismissStaleReviews ?? true,
       requireCodeOwnerReviews: github.requireCodeOwnerReviews ?? true,
       requireLastPushApproval: github.requireLastPushApproval ?? false,
@@ -254,6 +264,7 @@ export async function loadManifest(manifestPath: string): Promise<BootstrapManif
 
 interface ManifestOverrides {
   project?: Partial<BootstrapManifest["project"]>;
+  repo?: Partial<BootstrapManifest["repo"]>;
   archetype?: Partial<BootstrapManifest["archetype"]>;
   github?: Partial<BootstrapManifest["github"]>;
   ci?: Partial<BootstrapManifest["ci"]>;
@@ -273,6 +284,7 @@ export function createSampleManifest(overrides?: ManifestOverrides): string {
       owner: overrides?.project?.owner ?? "your-org",
       defaultBranch: overrides?.project?.defaultBranch ?? "main"
     },
+    repo: overrides?.repo,
     archetype: {
       kind: overrides?.archetype?.kind ?? "node-ts-service",
       packageManager: overrides?.archetype?.packageManager ?? "npm"

--- a/src/render.ts
+++ b/src/render.ts
@@ -10,8 +10,46 @@ export interface RepoPlan {
   files: RenderedFile[];
 }
 
+function globToRegExp(pattern: string): RegExp {
+  const normalized = pattern.replace(/\\/g, "/");
+  let source = "^";
+
+  for (let index = 0; index < normalized.length; index += 1) {
+    const character = normalized[index]!;
+    if (character === "*") {
+      const nextCharacter = normalized[index + 1];
+      if (nextCharacter === "*") {
+        source += ".*";
+        index += 1;
+      } else {
+        source += "[^/]*";
+      }
+      continue;
+    }
+
+    source += /[|\\{}()[\]^$+?.]/.test(character) ? `\\${character}` : character;
+  }
+
+  source += "$";
+  return new RegExp(source);
+}
+
+function matchesManagedPath(filePath: string, pattern: string): boolean {
+  return globToRegExp(pattern).test(filePath.replace(/\\/g, "/"));
+}
+
+function selectManagedFiles(manifest: BootstrapManifest, files: RenderedFile[]): RenderedFile[] {
+  if (manifest.repo.managedPaths.length === 0) {
+    return files;
+  }
+
+  return files.filter((file) =>
+    manifest.repo.managedPaths.some((pattern) => matchesManagedPath(file.path, pattern))
+  );
+}
+
 export async function planRepo(manifest: BootstrapManifest, targetDir: string): Promise<RepoPlan> {
-  const files = renderManagedFiles(manifest);
+  const files = selectManagedFiles(manifest, renderManagedFiles(manifest));
   const existingState = await loadRepoState(targetDir);
   const changes: PlannedFileChange[] = [];
 

--- a/src/state.ts
+++ b/src/state.ts
@@ -1,15 +1,50 @@
+import { stat } from "node:fs/promises";
 import path from "node:path";
 
 import { readTextIfExists, writeTextFile } from "./lib/fs.js";
 import { sha256 } from "./lib/hash.js";
 import type { BootstrapManifest, RenderedFile, RepoState } from "./types.js";
 
-export const TEMPLATE_VERSION = "2026.03.28.1";
-export const REPO_STATE_PATH = ".bootstrap/bootstrap-state.json";
+export const TEMPLATE_VERSION = "2026.03.28.2";
+export const FALLBACK_REPO_STATE_PATH = ".bootstrap/bootstrap-state.json";
 export const HOME_STATE_PATH = ".new-project-bootstrap/home-state.json";
 
+async function resolveGitDir(targetDir: string): Promise<string | undefined> {
+  const gitPath = path.join(targetDir, ".git");
+  try {
+    const gitStat = await stat(gitPath);
+    if (gitStat.isDirectory()) {
+      return gitPath;
+    }
+  } catch (error) {
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") {
+      return undefined;
+    }
+    throw error;
+  }
+
+  const raw = await readTextIfExists(gitPath);
+  if (!raw) {
+    return undefined;
+  }
+
+  const trimmed = raw.trim();
+  if (trimmed.startsWith("gitdir:")) {
+    return path.resolve(targetDir, trimmed.replace(/^gitdir:\s*/i, ""));
+  }
+
+  return gitPath;
+}
+
+async function resolveRepoStatePath(targetDir: string): Promise<string> {
+  const gitDir = await resolveGitDir(targetDir);
+  return gitDir
+    ? path.join(gitDir, "info", "new-project-bootstrap-state.json")
+    : path.join(targetDir, FALLBACK_REPO_STATE_PATH);
+}
+
 export async function loadRepoState(targetDir: string): Promise<RepoState | undefined> {
-  const raw = await readTextIfExists(path.join(targetDir, REPO_STATE_PATH));
+  const raw = await readTextIfExists(await resolveRepoStatePath(targetDir));
   if (!raw) {
     return undefined;
   }
@@ -18,7 +53,7 @@ export async function loadRepoState(targetDir: string): Promise<RepoState | unde
 }
 
 export async function writeRepoState(targetDir: string, state: RepoState): Promise<void> {
-  await writeTextFile(path.join(targetDir, REPO_STATE_PATH), `${JSON.stringify(state, null, 2)}\n`);
+  await writeTextFile(await resolveRepoStatePath(targetDir), `${JSON.stringify(state, null, 2)}\n`);
 }
 
 export function createRepoState(manifest: BootstrapManifest, files: RenderedFile[]): RepoState {

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,6 +14,10 @@ export interface EnvironmentConfig {
   branches: string[];
 }
 
+export interface RepoConfig {
+  managedPaths: string[];
+}
+
 export interface BootstrapManifest {
   version: 1;
   project: {
@@ -23,6 +27,7 @@ export interface BootstrapManifest {
     owner: string;
     defaultBranch: string;
   };
+  repo: RepoConfig;
   archetype: {
     kind: ArchetypeKind;
     packageManager: "npm" | "pnpm" | "yarn";
@@ -35,6 +40,7 @@ export interface BootstrapManifest {
     autoMerge: boolean;
     deleteBranchOnMerge: boolean;
     requiredApprovals: number;
+    requiredStatusChecks: string[];
     dismissStaleReviews: boolean;
     requireCodeOwnerReviews: boolean;
     requireLastPushApproval: boolean;

--- a/tests/github-provision.test.ts
+++ b/tests/github-provision.test.ts
@@ -12,6 +12,9 @@ describe("GitHub provisioning", () => {
       },
       archetype: {
         kind: "node-ts-service"
+      },
+      github: {
+        requiredStatusChecks: ["test"]
       }
     });
 
@@ -34,7 +37,8 @@ describe("GitHub provisioning", () => {
         kind: "node-ts-service"
       },
       github: {
-        reviewers: ["alice"]
+        reviewers: ["alice"],
+        requiredStatusChecks: ["test", "lint"]
       }
     });
 
@@ -70,6 +74,15 @@ describe("GitHub provisioning", () => {
           call.endpoint === "/repos/acme/example/branches/main/protection" && call.method === "PUT"
       )
     ).toBe(true);
+    const protectionCall = calls.find(
+      (call) => call.endpoint === "/repos/acme/example/branches/main/protection" && call.method === "PUT"
+    );
+    expect(protectionCall?.payload).toMatchObject({
+      required_status_checks: {
+        strict: true,
+        contexts: ["test", "lint"]
+      }
+    });
     expect(
       calls.some(
         (call) => call.endpoint === "/repos/acme/example/environments/prod" && call.method === "PUT"

--- a/tests/github-provision.test.ts
+++ b/tests/github-provision.test.ts
@@ -89,4 +89,70 @@ describe("GitHub provisioning", () => {
       )
     ).toBe(true);
   });
+
+  it("falls back to bare environments when private-repo protection rules are unsupported", async () => {
+    const manifest = normalizeManifest({
+      project: {
+        name: "example",
+        owner: "acme",
+        visibility: "private"
+      },
+      archetype: {
+        kind: "generic-empty"
+      },
+      github: {
+        createRepo: false,
+        reviewers: ["alice"]
+      }
+    });
+
+    const calls: Array<{ method: string; endpoint: string; payload?: unknown }> = [];
+    const client = {
+      isAvailable: async () => true,
+      isAuthenticated: async () => true,
+      tryApi: async () => ({ name: "example", full_name: "acme/example", private: true, visibility: "private" }),
+      api: async (method: string, endpoint: string, payload?: unknown) => {
+        calls.push({ method, endpoint, payload });
+        if (endpoint === "/users/acme") {
+          return { login: "acme", type: "Organization" };
+        }
+        if (endpoint === "/users/alice") {
+          return { id: 7 };
+        }
+        if (
+          (endpoint === "/repos/acme/example/environments/stage" ||
+            endpoint === "/repos/acme/example/environments/prod") &&
+          payload &&
+          typeof payload === "object" &&
+          "reviewers" in payload
+        ) {
+          throw new Error(
+            "gh: Failed to create the environment protection rule. Please ensure the billing plan supports the required reviewers protection rule. (HTTP 422)"
+          );
+        }
+        if (
+          endpoint === "/repos/acme/example/branches/main/protection" &&
+          method === "PUT"
+        ) {
+          throw new Error(
+            "gh: Upgrade to GitHub Pro or make this repository public to enable this feature. (HTTP 403)"
+          );
+        }
+        return {};
+      }
+    };
+
+    const actions = await applyGitHub(manifest, client as never);
+    expect(actions.map((action) => action.id)).toContain("branch-protection-blocked");
+    expect(actions.map((action) => action.id)).toContain("environment-stage-plan-limited");
+    expect(actions.map((action) => action.id)).toContain("environment-prod-plan-limited");
+    expect(
+      calls.filter((call) => call.endpoint === "/repos/acme/example/environments/stage").map((call) => call.payload)
+    ).toEqual([
+      expect.objectContaining({
+        reviewers: [{ type: "User", id: 7 }]
+      }),
+      {}
+    ]);
+  });
 });

--- a/tests/manifest.test.ts
+++ b/tests/manifest.test.ts
@@ -18,12 +18,14 @@ describe("normalizeManifest", () => {
     });
 
     expect(manifest.project.defaultBranch).toBe("main");
+    expect(manifest.repo.managedPaths).toEqual([]);
     expect(manifest.github.codeowners).toEqual([
       {
         pattern: "*",
         owners: ["@alice", "@acme/platform"]
       }
     ]);
+    expect(manifest.github.requiredStatusChecks).toEqual(["CI Gate"]);
     expect(manifest.agents.enableClaudeWebEnvironment).toBe(true);
     expect(manifest.agents.enableClaudeDevcontainer).toBe(true);
     expect(manifest.agents.enableClaudeGitHubAction).toBe(true);
@@ -58,5 +60,26 @@ describe("normalizeManifest", () => {
 
     expect(manifest.environments.stage.reviewers).toEqual(["release-team"]);
     expect(manifest.environments.prod.branches).toEqual(["main"]);
+  });
+
+  it("preserves explicit required checks and managed path selection", () => {
+    const manifest = normalizeManifest({
+      project: {
+        name: "runner-repo",
+        owner: "acme"
+      },
+      repo: {
+        managedPaths: ["project.bootstrap.yaml", "docs/bootstrap/**"]
+      },
+      archetype: {
+        kind: "generic-empty"
+      },
+      github: {
+        requiredStatusChecks: ["test"]
+      }
+    });
+
+    expect(manifest.repo.managedPaths).toEqual(["project.bootstrap.yaml", "docs/bootstrap/**"]);
+    expect(manifest.github.requiredStatusChecks).toEqual(["test"]);
   });
 });

--- a/tests/render.test.ts
+++ b/tests/render.test.ts
@@ -43,4 +43,24 @@ describe("renderManagedFiles", () => {
       expect(claudeCloudSetup?.contents).toContain("apt-get install -y gh");
     });
   }
+
+  it("uses the primary required status check name in the generated PR workflow", () => {
+    const manifest = normalizeManifest({
+      project: {
+        name: "runner-adoption",
+        owner: "acme"
+      },
+      archetype: {
+        kind: "generic-empty"
+      },
+      github: {
+        requiredStatusChecks: ["test"]
+      }
+    });
+
+    const files = renderManagedFiles(manifest);
+    const prWorkflow = files.find((file) => file.path === ".github/workflows/pr-fast-ci.yml");
+    expect(prWorkflow?.contents).toContain("name: test");
+    expect(prWorkflow?.contents).not.toContain("name: CI Gate");
+  });
 });

--- a/tests/smoke.test.ts
+++ b/tests/smoke.test.ts
@@ -1,6 +1,8 @@
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { execFile } from "node:child_process";
+import { access, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { promisify } from "node:util";
 
 import { afterEach, describe, expect, it } from "vitest";
 
@@ -8,6 +10,7 @@ import { normalizeManifest } from "../src/manifest.js";
 import { applyRepo, planRepo } from "../src/render.js";
 
 const tempDirs: string[] = [];
+const execFileAsync = promisify(execFile);
 
 async function makeTempDir(): Promise<string> {
   const dir = await mkdtemp(path.join(os.tmpdir(), "bootstrap-repo-"));
@@ -53,5 +56,73 @@ describe("repo smoke", () => {
 
     const secondPlan = await planRepo(manifest, targetDir);
     expect(secondPlan.changes.every((change) => change.type === "unchanged")).toBe(true);
+  });
+
+  it("can adopt an existing repo by managing only selected bootstrap files", async () => {
+    const targetDir = await makeTempDir();
+    await writeFile(path.join(targetDir, "README.md"), "Existing README\n", "utf8");
+
+    const manifest = normalizeManifest({
+      project: {
+        name: "existing-service",
+        owner: "acme"
+      },
+      repo: {
+        managedPaths: [
+          "project.bootstrap.yaml",
+          "AGENTS.md",
+          "CLAUDE.md",
+          ".devcontainer/**",
+          ".github/workflows/claude.yml",
+          "scripts/codex-cloud/**",
+          "scripts/claude-cloud/**",
+          "scripts/claude/**",
+          "docs/bootstrap/**"
+        ]
+      },
+      archetype: {
+        kind: "generic-empty"
+      },
+      github: {
+        reviewers: ["alice"],
+        requiredStatusChecks: ["test"]
+      }
+    });
+
+    const planBeforeApply = await planRepo(manifest, targetDir);
+    expect(planBeforeApply.changes.some((change) => change.path === "README.md")).toBe(false);
+
+    await applyRepo(manifest, targetDir);
+
+    const preservedReadme = await readFile(path.join(targetDir, "README.md"), "utf8");
+    expect(preservedReadme).toBe("Existing README\n");
+
+    const agents = await readFile(path.join(targetDir, "AGENTS.md"), "utf8");
+    expect(agents).toContain("CI baseline");
+
+    const secondPlan = await planRepo(manifest, targetDir);
+    expect(secondPlan.changes.every((change) => change.type === "unchanged")).toBe(true);
+  });
+
+  it("stores bootstrap state under .git/info when the target is a git repository", async () => {
+    const targetDir = await makeTempDir();
+    await execFileAsync("git", ["init"], { cwd: targetDir });
+
+    const manifest = normalizeManifest({
+      project: {
+        name: "git-backed-service",
+        owner: "acme"
+      },
+      archetype: {
+        kind: "generic-empty"
+      }
+    });
+
+    await applyRepo(manifest, targetDir);
+
+    await expect(
+      access(path.join(targetDir, ".git/info/new-project-bootstrap-state.json"))
+    ).resolves.toBeUndefined();
+    await expect(access(path.join(targetDir, ".bootstrap/bootstrap-state.json"))).rejects.toThrow();
   });
 });


### PR DESCRIPTION
## Summary
- add manifest-driven required status checks instead of hardcoding CI Gate
- allow repo bootstrap to manage only selected file paths for existing repos
- store local bootstrap state under .git/info for adopted git repos

## Testing
- npm run typecheck
- npm test
- npm run build