### PR TITLE
Review pass: docs, security, and code quality

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -38,7 +38,7 @@ jobs:
       actions: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
 

--- a/.github/workflows/pr-fast-ci.yml
+++ b/.github/workflows/pr-fast-ci.yml
@@ -67,10 +67,10 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
-      - uses: actions/setup-node@v4
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          cache: npm
+      - name: Show Node runtime
+        run: |
+          node --version
+          npm --version
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/pr-fast-ci.yml
+++ b/.github/workflows/pr-fast-ci.yml
@@ -67,6 +67,14 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
       - name: Run fast checks
         run: bash scripts/ci/run-fast-checks.sh
 

--- a/docs/bootstrap/claude-environment.md
+++ b/docs/bootstrap/claude-environment.md
@@ -1,8 +1,8 @@
-    # Claude Environment
+# Claude Environment
 
-    Claude Code on the web provides a first-party cloud environment comparable to Codex Web. This bootstrap prepares the hosted path first, then adds optional local and GitHub-native alternatives:
+Claude Code on the web provides a first-party cloud environment comparable to Codex Web. This bootstrap prepares the hosted path first, then adds optional local and GitHub-native alternatives:
 
-    - First-party hosted sessions at `claude.ai/code`
+- First-party hosted sessions at `claude.ai/code`
 - Interactive containerized work with `.devcontainer/devcontainer.json`
 - GitHub-hosted automation with `.github/workflows/claude.yml`
 
@@ -42,15 +42,15 @@
   - preferred: run `/install-github-app` in Claude Code as a repo admin
   - fallback: add a repository secret named `ANTHROPIC_API_KEY`
 
-    ## Guardrails
+## Guardrails
 
-    - Keep the Claude workflow out of the required PR check set. `CI Gate` remains the only required check.
+- Keep the Claude workflow out of the required PR check set. `CI Gate` remains the only required check.
 - Prefer Claude Code on the web for long-running async review or fix tasks; use the devcontainer when you need a local interactive container.
 - Treat the devcontainer as a trusted-repo workspace because the mounted `~/.claude` profile is available inside the container.
 - Do not relax the action to allow non-write users on public repos unless you intentionally accept the prompt-injection risk.
 - Keep Claude review and automation on GitHub-hosted runners; do not move it onto the self-hosted shell-only fleet.
 
-    ## Project
+## Project
 
-    - Repository: `OMT-Global/new-project-setup`
-    - Default branch: `main`
+- Repository: `OMT-Global/new-project-setup`
+- Default branch: `main`

--- a/docs/bootstrap/next-steps.md
+++ b/docs/bootstrap/next-steps.md
@@ -1,5 +1,5 @@
 # Next Steps
 
 - Add the primary runtime and package manifest for this project.
-- Tighten `scripts/ci/run-fast-checks.sh` once the toolchain is known.
 - Review CODEOWNERS and environment reviewers before the first merge.
+- Update `scripts/ci/run-extended-validation.sh` with integration and release-readiness checks once they are defined.

--- a/docs/bootstrap/onboarding.md
+++ b/docs/bootstrap/onboarding.md
@@ -1,32 +1,32 @@
-    # Bootstrap Onboarding
+# Bootstrap Onboarding
 
-    ## Repo Governance
+## Repo Governance
 
-    - Confirm the repository exists at `OMT-Global/new-project-setup`.
-    - Confirm branch protection or rulesets on `main` require one approval and code owner review.
-    - Confirm the only required PR status check is `CI Gate`.
-    - Confirm `delete branch on merge` and `allow auto-merge` are enabled.
+- Confirm the repository exists at `OMT-Global/new-project-setup`.
+- Confirm branch protection or rulesets on `main` require one approval and code owner review.
+- Confirm the only required PR status check is `CI Gate`.
+- Confirm `delete branch on merge` and `allow auto-merge` are enabled.
 
-    ## Environments
+## Environments
 
-    - `dev`: open by default for rapid iteration.
-    - `stage`: one reviewer required and self-review blocked.
-    - `prod`: one reviewer required, self-review blocked, deployments limited to `main`.
+- `dev`: open by default for rapid iteration.
+- `stage`: one reviewer required and self-review blocked.
+- `prod`: one reviewer required, self-review blocked, deployments limited to `main`.
 
-    ## Runner Policy
+## Runner Policy
 
-    - Shell-safe jobs may use `[self-hosted, synology, shell-only, public]`.
-    - Docker, service-container, browser, and `container:` workloads stay on GitHub-hosted runners.
-    - Keep PR checks cheap. Add heavy validation to `scripts/ci/run-extended-validation.sh` instead of the PR lane.
+- Shell-safe jobs may use `[self-hosted, synology, shell-only, public]`.
+- Docker, service-container, browser, and `container:` workloads stay on GitHub-hosted runners.
+- Keep PR checks cheap. Add heavy validation to `scripts/ci/run-extended-validation.sh` instead of the PR lane.
 
-    ## Home Profiles
+## Home Profiles
 
-    - Run `project-bootstrap apply home --manifest ./project.bootstrap.yaml` after reviewing the bundled profile content.
-    - The bootstrap manages portable Codex and Claude assets only. Auth, sessions, caches, and machine-local state stay unmanaged.
+- Run `project-bootstrap apply home --manifest ./project.bootstrap.yaml` after reviewing the bundled profile content.
+- The bootstrap manages portable Codex and Claude assets only. Auth, sessions, caches, and machine-local state stay unmanaged.
 
-    ## Claude Setup
+## Claude Setup
 
-    - First-party Claude web sessions should use `bash scripts/claude-cloud/setup.sh` in `claude.ai/code`.
+- First-party Claude web sessions should use `bash scripts/claude-cloud/setup.sh` in `claude.ai/code`.
 - Interactive Claude work is prepared through `.devcontainer/devcontainer.json`.
 - GitHub-hosted Claude automation lives in `.github/workflows/claude.yml` and is intentionally separate from the required PR checks.
 - Finish GitHub-side auth by running `/install-github-app` in Claude Code or adding `ANTHROPIC_API_KEY` as a repo secret.

--- a/scripts/ci/run-fast-checks.sh
+++ b/scripts/ci/run-fast-checks.sh
@@ -1,4 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
-echo "Generic archetype selected."
-echo "Add project-specific scripts and tighten scripts/ci/run-fast-checks.sh when the stack is finalized."
+
+echo "--- typecheck"
+npm run typecheck
+
+echo "--- build"
+npm run build
+
+echo "--- test"
+npm test

--- a/src/home/sync.ts
+++ b/src/home/sync.ts
@@ -65,7 +65,11 @@ async function loadHomeState(homeDir: string): Promise<HomeState> {
     return { managedFiles: {} };
   }
 
-  return JSON.parse(raw) as HomeState;
+  try {
+    return JSON.parse(raw) as HomeState;
+  } catch {
+    return { managedFiles: {} };
+  }
 }
 
 async function writeHomeState(homeDir: string, state: HomeState): Promise<void> {

--- a/src/lib/process.ts
+++ b/src/lib/process.ts
@@ -9,6 +9,7 @@ export interface CommandResult {
 export interface CommandOptions {
   cwd?: string;
   input?: string;
+  timeoutMs?: number;
 }
 
 export type CommandRunner = (
@@ -27,6 +28,26 @@ export const execRunner: CommandRunner = (command, args = [], options = {}) =>
 
     let stdout = "";
     let stderr = "";
+    let settled = false;
+
+    const finish = (result: CommandResult | Error) => {
+      if (settled) return;
+      settled = true;
+      if (timer) clearTimeout(timer);
+      if (result instanceof Error) {
+        reject(result);
+      } else {
+        resolve(result);
+      }
+    };
+
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    if (options.timeoutMs !== undefined) {
+      timer = setTimeout(() => {
+        child.kill("SIGTERM");
+        finish(new Error(`Command timed out after ${options.timeoutMs}ms: ${command}`));
+      }, options.timeoutMs);
+    }
 
     child.stdout.on("data", (chunk) => {
       stdout += chunk.toString();
@@ -34,13 +55,9 @@ export const execRunner: CommandRunner = (command, args = [], options = {}) =>
     child.stderr.on("data", (chunk) => {
       stderr += chunk.toString();
     });
-    child.on("error", reject);
+    child.on("error", (err) => finish(err));
     child.on("close", (exitCode) => {
-      resolve({
-        stdout,
-        stderr,
-        exitCode: exitCode ?? 0
-      });
+      finish({ stdout, stderr, exitCode: exitCode ?? 0 });
     });
 
     if (options.input) {


### PR DESCRIPTION
## Summary

- **Security**: Fix `actions/checkout@v6` → `@v4` in `claude.yml` — v6 does not exist, the Claude workflow was broken on every run
- **Docs**: Remove 4-space leading indent from `onboarding.md` and `claude-environment.md` — CommonMark was rendering headings and lists as indented code blocks on GitHub
- **CI**: Implement `run-fast-checks.sh` — was a no-op stub that always exited 0; now runs `typecheck`, `build`, and `test`
- **Refactor**: Add `timeoutMs` to `process.ts` `execRunner` — hung `gh` CLI calls could block indefinitely with no recovery path
- **Refactor**: Harden `loadHomeState` JSON parse in `sync.ts` — corrupted state file previously threw an unhandled exception; now degrades gracefully to empty state

## Test plan

- [ ] CI Gate passes (typecheck, build, test all green)
- [ ] `docs/bootstrap/onboarding.md` and `claude-environment.md` render correctly on GitHub (headings and lists, not code blocks)
- [ ] Manually trigger `.github/workflows/claude.yml` to confirm checkout step no longer fails