### PR TITLE
Rename project to bootstrap

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-  "name": "new-project-setup Claude Code",
+  "name": "bootstrap Claude Code",
   "image": "mcr.microsoft.com/devcontainers/base:ubuntu-24.04",
   "remoteUser": "vscode",
   "updateRemoteUserUID": true,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,21 +1,22 @@
-    # CLAUDE.md
+# CLAUDE.md
 
-    ## Project Map
+## Project Map
 
-    - `project.bootstrap.yaml`: source of truth for bootstrap policy
+- `project.bootstrap.yaml`: source of truth for bootstrap policy
 - `.github/workflows/`: generated fast and extended CI lanes
 - `scripts/claude-cloud/setup.sh`: first-party Claude Code on the web setup script
 - `.github/workflows/claude.yml`: opt-in Claude GitHub Action for manual or `@claude` review flows
 - `.devcontainer/devcontainer.json`: interactive Claude Code workspace baseline
-- `scripts/ci/`: generated check entrypoints used by the workflows
+- `.github/workflows/`: repo CI and review workflows
+- `scripts/ci/`: bootstrap CI entrypoints when this repo uses the generated workflow lane
 - `scripts/claude/setup-devcontainer.sh`: installs repo dependencies inside the devcontainer
-- `.githooks/pre-commit`: branch and env-file guardrail
+- `.githooks/pre-commit`: branch and env-file guardrail when local hooks are bootstrap-managed
 - `docs/bootstrap/onboarding.md`: operator checklist for repo/governance setup
 - `docs/bootstrap/claude-environment.md`: Claude setup guide for hosted, interactive, and GitHub-hosted use
 
-    ## Guardrails
+## Guardrails
 
-    - Keep `CI Gate` as the single required PR status check.
+- Keep `CI Gate` as the single required PR status check.
 - Use one approval plus code owners on `main` unless the manifest explicitly changes it.
 - `stage` and `prod` environments require reviewers and prevent self-review by default.
 - Home-level Codex and Claude profile sync is managed by the bootstrap tool, not by ad-hoc manual edits.

--- a/README.md
+++ b/README.md
@@ -1,26 +1,37 @@
-# new-project-setup
-Manifest-driven bootstrap CLI for repo governance, agent setup, and split CI.
+# Bootstrap
 
-This repository was bootstrapped with a manifest-driven baseline for:
+Manifest-first control plane for repo scaffolding, GitHub governance, and portable agent profiles.
+
+Use `project.bootstrap.yaml` as the control plane for repo-local scaffolding, GitHub governance, CI policy, and portable Codex/Claude profile sync. Plan first, then apply repo, GitHub, and home targets deliberately.
+
+## What The Bootstrap Owns
 
 - GitHub governance and environments
-- repo-local AGENTS and CLAUDE instructions
-- split fast and extended CI
-- Codex and Claude home profile sync
+- Repo-local `AGENTS.md` and `CLAUDE.md` guidance
+- Fast PR checks plus heavier extended validation lanes
+- Portable Codex and Claude home profile sync
+- Operator docs for onboarding, hosted agents, and follow-up setup
 
-## Bootstrap Metadata
+## Quickstart
 
-- Owner: `OMT-Global`
+```sh
+bootstrap plan --manifest ./project.bootstrap.yaml
+bootstrap apply repo --manifest ./project.bootstrap.yaml
+bootstrap apply github --manifest ./project.bootstrap.yaml
+bootstrap apply home --manifest ./project.bootstrap.yaml
+bootstrap doctor --manifest ./project.bootstrap.yaml
+```
+
+Confirm branch protection points at the `CI Gate` status.
+
+## Project Identity
+
+- Product name: `Bootstrap`
+- Repository: `OMT-Global/bootstrap`
+- Manifest: `project.bootstrap.yaml`
 - Visibility: `public`
 - Default branch: `main`
 - Archetype: `generic-empty`
-
-## First Pass
-
-1. Review `project.bootstrap.yaml`.
-2. Run `project-bootstrap plan --manifest ./project.bootstrap.yaml`.
-3. Apply repo, GitHub, and home setup in that order.
-4. Confirm branch protection points at the `CI Gate` status.
 
 ## Claude Code
 
@@ -34,4 +45,4 @@ The full checklist is in `docs/bootstrap/claude-environment.md`.
 
 ## Repository URL
 
-- https://github.com/OMT-Global/new-project-setup
+- https://github.com/OMT-Global/bootstrap

--- a/docs/bootstrap/claude-environment.md
+++ b/docs/bootstrap/claude-environment.md
@@ -1,15 +1,21 @@
-    # Claude Environment
+# Claude Environment
 
-    Claude Code on the web provides a first-party cloud environment comparable to Codex Web. This bootstrap prepares the hosted path first, then adds optional local and GitHub-native alternatives:
+Claude Code on the web provides a first-party cloud environment comparable to Codex Web. This bootstrap prepares the hosted path first, then adds optional local and GitHub-native alternatives:
 
-    - First-party hosted sessions at `claude.ai/code`
+- First-party hosted sessions at `claude.ai/code`
 - Interactive containerized work with `.devcontainer/devcontainer.json`
 - GitHub-hosted automation with `.github/workflows/claude.yml`
+
+## Project
+
+- Product name: `Bootstrap`
+- Repository: `OMT-Global/bootstrap`
+- Manifest: `project.bootstrap.yaml`
 
 ## Claude Code On The Web
 
 - Hosted entrypoint: `https://claude.ai/code`
-- Repo: `OMT-Global/new-project-setup`
+- Repo: `OMT-Global/bootstrap`
 - Setup script: `bash scripts/claude-cloud/setup.sh`
 - Network access: start with limited access; only expand it when a task truly needs more than registries and GitHub
 - Environment variables: configure them in the Claude environment UI as `.env`-style key-value pairs
@@ -42,15 +48,14 @@
   - preferred: run `/install-github-app` in Claude Code as a repo admin
   - fallback: add a repository secret named `ANTHROPIC_API_KEY`
 
-    ## Guardrails
+## Guardrails
 
-    - Keep the Claude workflow out of the required PR check set. `CI Gate` remains the only required check.
+- Keep the Claude workflow out of the required PR check set. The required checks are `CI Gate`.
 - Prefer Claude Code on the web for long-running async review or fix tasks; use the devcontainer when you need a local interactive container.
 - Treat the devcontainer as a trusted-repo workspace because the mounted `~/.claude` profile is available inside the container.
 - Do not relax the action to allow non-write users on public repos unless you intentionally accept the prompt-injection risk.
 - Keep Claude review and automation on GitHub-hosted runners; do not move it onto the self-hosted shell-only fleet.
 
-    ## Project
+## Project
 
-    - Repository: `OMT-Global/new-project-setup`
-    - Default branch: `main`
+- Default branch: `main`

--- a/docs/bootstrap/codex-cloud-environment.md
+++ b/docs/bootstrap/codex-cloud-environment.md
@@ -1,8 +1,15 @@
 # Codex Cloud Environment
 
-Configure the Codex Web environment in Codex settings for:
+Configure the Codex Web environment in Codex settings for this bootstrap-managed repository.
 
-- Repo: `OMT-Global/new-project-setup`
+## Project
+
+- Product name: `Bootstrap`
+- Repository: `OMT-Global/bootstrap`
+- Manifest: `project.bootstrap.yaml`
+
+## Environment Settings
+
 - Base image: `universal`
 - Setup mode: manual setup script
 - Setup script: `bash scripts/codex-cloud/setup.sh`
@@ -14,4 +21,4 @@ Configure the Codex Web environment in Codex settings for:
 
 - Codex cloud tasks automatically read `AGENTS.md` in this repo.
 - Setup scripts run in a separate shell session from the agent. Persistent env vars belong in Codex environment settings or `~/.bashrc`.
-- This repo uses `CI Gate` as the single required PR check, so cloud review tasks should preserve that contract.
+- This repo uses required PR checks `CI Gate`, so cloud review tasks should preserve that contract.

--- a/docs/bootstrap/next-steps.md
+++ b/docs/bootstrap/next-steps.md
@@ -1,5 +1,6 @@
 # Next Steps
 
 - Add the primary runtime and package manifest for this project.
-- Tighten `scripts/ci/run-fast-checks.sh` once the toolchain is known.
-- Review CODEOWNERS and environment reviewers before the first merge.
+- Tighten `scripts/ci/run-fast-checks.sh` and `scripts/ci/run-extended-validation.sh` once the toolchain is known.
+- Review CODEOWNERS, environment reviewers, and required PR checks before the first merge.
+- Re-run `bootstrap plan --manifest ./project.bootstrap.yaml` after major manifest changes to confirm intended drift.

--- a/docs/bootstrap/onboarding.md
+++ b/docs/bootstrap/onboarding.md
@@ -1,32 +1,39 @@
-    # Bootstrap Onboarding
+# Bootstrap Onboarding
 
-    ## Repo Governance
+Use this checklist after the first bootstrap render or whenever `project.bootstrap.yaml` changes in a way that affects GitHub policy, environments, or home-profile sync.
 
-    - Confirm the repository exists at `OMT-Global/new-project-setup`.
-    - Confirm branch protection or rulesets on `main` require one approval and code owner review.
-    - Confirm the only required PR status check is `CI Gate`.
-    - Confirm `delete branch on merge` and `allow auto-merge` are enabled.
+## Project
 
-    ## Environments
+- Product name: `Bootstrap`
+- Repository: `OMT-Global/bootstrap`
+- Manifest: `project.bootstrap.yaml`
 
-    - `dev`: open by default for rapid iteration.
-    - `stage`: one reviewer required and self-review blocked.
-    - `prod`: one reviewer required, self-review blocked, deployments limited to `main`.
+## Repo Governance
 
-    ## Runner Policy
+- Confirm branch protection or rulesets on `main` require one approval and code owner review.
+- Confirm branch protection points at the `CI Gate` status.
+- Confirm `delete branch on merge` and `allow auto-merge` are enabled.
 
-    - Shell-safe jobs may use `[self-hosted, synology, shell-only, public]`.
-    - Docker, service-container, browser, and `container:` workloads stay on GitHub-hosted runners.
-    - Keep PR checks cheap. Add heavy validation to `scripts/ci/run-extended-validation.sh` instead of the PR lane.
+## Environments
 
-    ## Home Profiles
+- `dev`: open by default for rapid iteration.
+- `stage`: one reviewer required and self-review blocked.
+- `prod`: one reviewer required, self-review blocked, deployments limited to `main`.
 
-    - Run `project-bootstrap apply home --manifest ./project.bootstrap.yaml` after reviewing the bundled profile content.
-    - The bootstrap manages portable Codex and Claude assets only. Auth, sessions, caches, and machine-local state stay unmanaged.
+## Runner Policy
 
-    ## Claude Setup
+- Shell-safe jobs may use `[self-hosted, synology, shell-only, public]`.
+- Docker, service-container, browser, and `container:` workloads stay on GitHub-hosted runners.
+- Keep PR checks cheap. Add heavy validation to `scripts/ci/run-extended-validation.sh` instead of the PR lane.
 
-    - First-party Claude web sessions should use `bash scripts/claude-cloud/setup.sh` in `claude.ai/code`.
+## Home Profiles
+
+- Run `bootstrap apply home --manifest ./project.bootstrap.yaml` after reviewing the bundled profile content.
+- The bootstrap manages portable Codex and Claude assets only. Auth, sessions, caches, and machine-local state stay unmanaged.
+
+## Claude Setup
+
+- First-party Claude web sessions should use `bash scripts/claude-cloud/setup.sh` in `claude.ai/code`.
 - Interactive Claude work is prepared through `.devcontainer/devcontainer.json`.
 - GitHub-hosted Claude automation lives in `.github/workflows/claude.yml` and is intentionally separate from the required PR checks.
 - Finish GitHub-side auth by running `/install-github-app` in Claude Code or adding `ANTHROPIC_API_KEY` as a repo secret.

--- a/package.json
+++ b/package.json
@@ -1,10 +1,11 @@
 {
-  "name": "new-project-setup",
+  "name": "bootstrap",
   "version": "0.1.0",
   "private": true,
-  "description": "Manifest-driven bootstrap CLI for repository setup, GitHub governance, home agent profiles, and CI baselines.",
+  "description": "Manifest-first control plane for repo scaffolding, GitHub governance, and portable agent profiles.",
   "type": "module",
   "bin": {
+    "bootstrap": "dist/cli.js",
     "project-bootstrap": "dist/cli.js"
   },
   "engines": {

--- a/project.bootstrap.yaml
+++ b/project.bootstrap.yaml
@@ -1,14 +1,18 @@
 version: 1
 project:
-  name: new-project-setup
-  description: Manifest-driven bootstrap CLI for repo governance, agent setup, and split CI.
+  name: bootstrap
+  displayName: Bootstrap
+  description: Manifest-first control plane for repo scaffolding, GitHub governance, and portable
+    agent profiles.
   visibility: public
   owner: OMT-Global
   defaultBranch: main
+repo:
+  managedPaths: []
 archetype:
   kind: generic-empty
   packageManager: npm
-  moduleName: new_project_setup
+  moduleName: bootstrap
 github:
   createRepo: true
   reviewers:
@@ -20,6 +24,8 @@ github:
   autoMerge: true
   deleteBranchOnMerge: true
   requiredApprovals: 1
+  requiredStatusChecks:
+    - CI Gate
   dismissStaleReviews: true
   requireCodeOwnerReviews: true
   requireLastPushApproval: false

--- a/scripts/check-detect-secrets.sh
+++ b/scripts/check-detect-secrets.sh
@@ -5,11 +5,12 @@
     ignore_globs=("scripts/check-detect-secrets.sh")
     if [[ -f .detect-secrets-ignore ]]; then
       while IFS= read -r ignore_glob; do
-        case "$ignore_glob" in
-          ""|\#*)
-            continue
-            ;;
-        esac
+        if [[ -z "$ignore_glob" ]]; then
+          continue
+        fi
+        if [[ "${ignore_glob:0:1}" == "#" ]]; then
+          continue
+        fi
         ignore_globs+=("$ignore_glob")
       done < .detect-secrets-ignore
     fi

--- a/src/archetypes.ts
+++ b/src/archetypes.ts
@@ -9,6 +9,24 @@ function repoUrl(manifest: BootstrapManifest): string {
   return `https://github.com/${manifest.project.owner}/${manifest.project.name}`;
 }
 
+function projectDisplayName(manifest: BootstrapManifest): string {
+  return manifest.project.displayName?.trim() || manifest.project.name;
+}
+
+function projectIdentityLines(manifest: BootstrapManifest): string {
+  const lines = [];
+  const displayName = projectDisplayName(manifest);
+
+  if (displayName !== manifest.project.name) {
+    lines.push(`- Product name: \`${displayName}\``);
+  }
+
+  lines.push(`- Repository: \`${manifest.project.owner}/${manifest.project.name}\``);
+  lines.push("- Manifest: `project.bootstrap.yaml`");
+
+  return lines.join("\n");
+}
+
 function requiredStatusChecksDisplay(manifest: BootstrapManifest): string {
   return manifest.github.requiredStatusChecks.map((check) => `\`${check}\``).join(", ");
 }
@@ -145,15 +163,16 @@ function repoClaude(manifest: BootstrapManifest): string {
 
     ## Project Map
 
-    ${projectMapLines}
+${indentBlock(projectMapLines, 4)}
 
     ## Guardrails
 
-    ${guardrailLines}
+${indentBlock(guardrailLines, 4)}
   `;
 }
 
 function repoReadme(manifest: BootstrapManifest): string {
+  const displayName = projectDisplayName(manifest);
   const claudeBullets = [
     manifest.agents.enableClaudeWebEnvironment
       ? "- First-party Claude Code on the web via `claude.ai/code` and `bash scripts/claude-cloud/setup.sh`"
@@ -175,38 +194,46 @@ function repoReadme(manifest: BootstrapManifest): string {
 
       This bootstrap can prepare these Claude workflows:
 
-      ${claudeBullets}
+${indentBlock(claudeBullets, 6)}
 
       The full checklist is in \`docs/bootstrap/claude-environment.md\`.
     `
     : "";
 
   return dedent`
-    # ${manifest.project.name}
+    # ${displayName}
 
     ${manifest.project.description}
 
-    This repository was bootstrapped with a manifest-driven baseline for:
+    Use \`project.bootstrap.yaml\` as the control plane for repo-local scaffolding, GitHub governance, CI policy, and portable Codex/Claude profile sync. Plan first, then apply repo, GitHub, and home targets deliberately.
+
+    ## What The Bootstrap Owns
 
     - GitHub governance and environments
-    - repo-local AGENTS and CLAUDE instructions
-    - optional split fast and extended CI
-    - Codex and Claude home profile sync
+    - Repo-local \`AGENTS.md\` and \`CLAUDE.md\` guidance
+    - Fast PR checks plus heavier extended validation lanes
+    - Portable Codex and Claude home profile sync
+    - Operator docs for onboarding, hosted agents, and follow-up setup
 
-    ## Bootstrap Metadata
+    ## Quickstart
 
-    - Owner: \`${manifest.project.owner}\`
+    \`\`\`sh
+    bootstrap plan --manifest ./project.bootstrap.yaml
+    bootstrap apply repo --manifest ./project.bootstrap.yaml
+    bootstrap apply github --manifest ./project.bootstrap.yaml
+    bootstrap apply home --manifest ./project.bootstrap.yaml
+    bootstrap doctor --manifest ./project.bootstrap.yaml
+    \`\`\`
+
+    ${requiredStatusCheckConfirmation(manifest)}
+
+    ## Project Identity
+
+${indentBlock(projectIdentityLines(manifest), 4)}
     - Visibility: \`${manifest.project.visibility}\`
     - Default branch: \`${manifest.project.defaultBranch}\`
     - Archetype: \`${manifest.archetype.kind}\`
-
-    ## First Pass
-
-    1. Review \`project.bootstrap.yaml\`.
-    2. Run \`project-bootstrap plan --manifest ./project.bootstrap.yaml\`.
-    3. Apply repo, GitHub, and home setup in that order.
-    4. ${requiredStatusCheckConfirmation(manifest)}
-${claudeSection}
+${indentBlock(claudeSection, 4)}
 
     ## Repository URL
 
@@ -547,9 +574,14 @@ function codexCloudDoc(manifest: BootstrapManifest): string {
   return dedent`
     # Codex Cloud Environment
 
-    Configure the Codex Web environment in Codex settings for:
+    Configure the Codex Web environment in Codex settings for this bootstrap-managed repository.
 
-    - Repo: \`${manifest.project.owner}/${manifest.project.name}\`
+    ## Project
+
+${indentBlock(projectIdentityLines(manifest), 4)}
+
+    ## Environment Settings
+
     - Base image: \`universal\`
     - Setup mode: manual setup script
     - Setup script: \`bash scripts/codex-cloud/setup.sh\`
@@ -776,7 +808,6 @@ function claudeWorkflow(manifest: BootstrapManifest): string {
 
     permissions:
       contents: read
-      pull-requests: read
 
     jobs:
       claude:
@@ -820,7 +851,11 @@ function claudeWorkflow(manifest: BootstrapManifest): string {
                 DEFAULT BRANCH: ${manifest.project.defaultBranch}
 
                 Use CLAUDE.md and docs/bootstrap/onboarding.md as repo policy context.
-                Keep required PR status checks aligned with ${requiredStatusChecksPlain(manifest)}.
+                ${
+                  manifest.github.requiredStatusChecks.length === 1
+                    ? `Keep ${primaryRequiredStatusCheck(manifest)} as the single required PR status check.`
+                    : `Keep required PR status checks aligned with ${requiredStatusChecksPlain(manifest)}.`
+                }
                 Preserve the split fast and extended validation model.
                 Shell-safe jobs may use \`[self-hosted, synology, shell-only, ${manifest.project.visibility === "public" ? "public" : "private"}]\`.
                 Docker, service-container, browser, and \`container:\` jobs stay on GitHub-hosted runners.
@@ -920,18 +955,21 @@ function claudeEnvironmentDoc(manifest: BootstrapManifest): string {
 
     Claude Code on the web provides a first-party cloud environment comparable to Codex Web. This bootstrap prepares the hosted path first, then adds optional local and GitHub-native alternatives:
 
-    ${featureList}
-${webSection}
-${devcontainerSection}
-${actionSection}
-
-    ## Guardrails
-
-    ${guardrailLines}
+${indentBlock(featureList, 4)}
 
     ## Project
 
-    - Repository: \`${manifest.project.owner}/${manifest.project.name}\`
+${indentBlock(projectIdentityLines(manifest), 4)}
+${indentBlock(webSection, 4)}
+${indentBlock(devcontainerSection, 4)}
+${indentBlock(actionSection, 4)}
+
+    ## Guardrails
+
+${indentBlock(guardrailLines, 4)}
+
+    ## Project
+
     - Default branch: \`${manifest.project.defaultBranch}\`
   `;
 }
@@ -991,7 +1029,7 @@ function nextJsStarter(): RenderedFile[] {
         export default function HomePage() {
           return (
             <main>
-              <h1>New Project Bootstrap</h1>
+              <h1>Bootstrap</h1>
               <p>Replace this starter page with the real application entrypoint.</p>
             </main>
           );
@@ -1025,7 +1063,7 @@ function nodeStarter(): RenderedFile[] {
       reason: "Minimal Node.js entrypoint",
       contents: dedent`
         export function main(): string {
-          return "new-project-bootstrap";
+          return "bootstrap";
         }
 
         if (import.meta.url === \`file://\${process.argv[1]}\`) {
@@ -1048,7 +1086,7 @@ function pythonStarter(moduleName: string): RenderedFile[] {
       reason: "Minimal Python entrypoint",
       contents: dedent`
         def main() -> str:
-            return "new-project-bootstrap"
+            return "bootstrap"
 
 
         if __name__ == "__main__":
@@ -1063,7 +1101,7 @@ function pythonStarter(moduleName: string): RenderedFile[] {
 
 
         def test_main() -> None:
-            assert main() == "new-project-bootstrap"
+            assert main() == "bootstrap"
       `
     }
   ];
@@ -1078,8 +1116,9 @@ function genericStarter(): RenderedFile[] {
         # Next Steps
 
         - Add the primary runtime and package manifest for this project.
-        - Tighten \`scripts/ci/run-fast-checks.sh\` once the toolchain is known.
-        - Review CODEOWNERS and environment reviewers before the first merge.
+        - Tighten \`scripts/ci/run-fast-checks.sh\` and \`scripts/ci/run-extended-validation.sh\` once the toolchain is known.
+        - Review CODEOWNERS, environment reviewers, and required PR checks before the first merge.
+        - Re-run \`bootstrap plan --manifest ./project.bootstrap.yaml\` after major manifest changes to confirm intended drift.
       `
     }
   ];
@@ -1172,7 +1211,6 @@ function prWorkflow(manifest: BootstrapManifest): string {
 
     permissions:
       contents: read
-      pull-requests: read
 
     env:
       NODE_VERSION: '${manifest.ci.nodeVersion}'
@@ -1410,9 +1448,14 @@ function onboardingDoc(manifest: BootstrapManifest): string {
   return dedent`
     # Bootstrap Onboarding
 
+    Use this checklist after the first bootstrap render or whenever \`project.bootstrap.yaml\` changes in a way that affects GitHub policy, environments, or home-profile sync.
+
+    ## Project
+
+${indentBlock(projectIdentityLines(manifest), 4)}
+
     ## Repo Governance
 
-    - Confirm the repository exists at \`${manifest.project.owner}/${manifest.project.name}\`.
     - Confirm branch protection or rulesets on \`${manifest.project.defaultBranch}\` require one approval and code owner review.
     - ${requiredStatusCheckConfirmation(manifest)}
     - Confirm \`delete branch on merge\` and \`allow auto-merge\` are enabled.
@@ -1431,12 +1474,12 @@ function onboardingDoc(manifest: BootstrapManifest): string {
 
     ## Home Profiles
 
-    - Run \`project-bootstrap apply home --manifest ./project.bootstrap.yaml\` after reviewing the bundled profile content.
+    - Run \`bootstrap apply home --manifest ./project.bootstrap.yaml\` after reviewing the bundled profile content.
     - The bootstrap manages portable Codex and Claude assets only. Auth, sessions, caches, and machine-local state stay unmanaged.
 
     ## Claude Setup
 
-    ${claudeSetupLines}
+${indentBlock(claudeSetupLines, 4)}
   `;
 }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -45,7 +45,9 @@ function formatHomeActions(actions: Awaited<ReturnType<typeof planHome>>["action
 
 async function main(): Promise<void> {
   const program = new Command();
-  program.name("project-bootstrap").description("Manifest-driven repo, GitHub, and home bootstrap CLI.");
+  program
+    .name("bootstrap")
+    .description("Manifest-first control plane for repo scaffolding, GitHub governance, and portable agent profiles.");
 
   program
     .command("init-manifest")
@@ -63,7 +65,8 @@ async function main(): Promise<void> {
         project: {
           name: options.name,
           owner: options.owner,
-          description: "New project bootstrapped with repo governance, agent setup, and split CI.",
+          description:
+            "Manifest-first control plane for repo scaffolding, GitHub governance, and portable agent profiles.",
           visibility: "private",
           defaultBranch: "main"
         },

--- a/src/home/sync.ts
+++ b/src/home/sync.ts
@@ -5,7 +5,7 @@ import { fileURLToPath } from "node:url";
 
 import { readTextIfExists, removeFileIfExists, writeTextFile } from "../lib/fs.js";
 import { sha256 } from "../lib/hash.js";
-import { HOME_STATE_PATH } from "../state.js";
+import { HOME_STATE_PATH, LEGACY_HOME_STATE_PATH } from "../state.js";
 import type {
   BootstrapManifest,
   ChangeType,
@@ -60,7 +60,9 @@ async function loadProfileFiles(sourceDir: string, targetRoot: string): Promise<
 }
 
 async function loadHomeState(homeDir: string): Promise<HomeState> {
-  const raw = await readTextIfExists(path.join(homeDir, HOME_STATE_PATH));
+  const raw =
+    (await readTextIfExists(path.join(homeDir, HOME_STATE_PATH))) ??
+    (await readTextIfExists(path.join(homeDir, LEGACY_HOME_STATE_PATH)));
   if (!raw) {
     return { managedFiles: {} };
   }

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -21,6 +21,7 @@ const manifestSchema = z.object({
   version: z.literal(1).optional(),
   project: z.object({
     name: z.string().min(1),
+    displayName: z.string().min(1).optional(),
     description: z.string().optional(),
     visibility: z.enum(["private", "public", "internal"]).optional(),
     owner: z.string().min(1),
@@ -172,8 +173,10 @@ export function normalizeManifest(raw: z.input<typeof manifestSchema>): Bootstra
     version: 1,
     project: {
       name: parsed.project.name,
+      ...(parsed.project.displayName ? { displayName: parsed.project.displayName } : {}),
       description:
-        parsed.project.description ?? "New project bootstrapped with the platform baseline.",
+        parsed.project.description ??
+        "Manifest-first control plane for repo scaffolding, GitHub governance, and portable agent profiles.",
       visibility: parsed.project.visibility ?? "private",
       owner: parsed.project.owner,
       defaultBranch
@@ -277,9 +280,10 @@ export function createSampleManifest(overrides?: ManifestOverrides): string {
     version: 1,
     project: {
       name: overrides?.project?.name ?? "example-project",
+      ...(overrides?.project?.displayName ? { displayName: overrides.project.displayName } : {}),
       description:
         overrides?.project?.description ??
-        "New project bootstrapped with repo governance, agent setup, and split CI.",
+        "Manifest-first control plane for repo scaffolding, GitHub governance, and portable agent profiles.",
       visibility: overrides?.project?.visibility ?? "private",
       owner: overrides?.project?.owner ?? "your-org",
       defaultBranch: overrides?.project?.defaultBranch ?? "main"

--- a/src/state.ts
+++ b/src/state.ts
@@ -7,7 +7,10 @@ import type { BootstrapManifest, RenderedFile, RepoState } from "./types.js";
 
 export const TEMPLATE_VERSION = "2026.03.28.2";
 export const FALLBACK_REPO_STATE_PATH = ".bootstrap/bootstrap-state.json";
-export const HOME_STATE_PATH = ".new-project-bootstrap/home-state.json";
+export const HOME_STATE_PATH = ".bootstrap/home-state.json";
+export const LEGACY_HOME_STATE_PATH = ".new-project-bootstrap/home-state.json";
+export const REPO_STATE_FILENAME = "bootstrap-state.json";
+export const LEGACY_REPO_STATE_FILENAME = "new-project-bootstrap-state.json";
 
 async function resolveGitDir(targetDir: string): Promise<string | undefined> {
   const gitPath = path.join(targetDir, ".git");
@@ -39,12 +42,21 @@ async function resolveGitDir(targetDir: string): Promise<string | undefined> {
 async function resolveRepoStatePath(targetDir: string): Promise<string> {
   const gitDir = await resolveGitDir(targetDir);
   return gitDir
-    ? path.join(gitDir, "info", "new-project-bootstrap-state.json")
+    ? path.join(gitDir, "info", REPO_STATE_FILENAME)
     : path.join(targetDir, FALLBACK_REPO_STATE_PATH);
 }
 
+async function resolveLegacyRepoStatePath(targetDir: string): Promise<string | undefined> {
+  const gitDir = await resolveGitDir(targetDir);
+  return gitDir ? path.join(gitDir, "info", LEGACY_REPO_STATE_FILENAME) : undefined;
+}
+
 export async function loadRepoState(targetDir: string): Promise<RepoState | undefined> {
-  const raw = await readTextIfExists(await resolveRepoStatePath(targetDir));
+  const nextPath = await resolveRepoStatePath(targetDir);
+  const legacyPath = await resolveLegacyRepoStatePath(targetDir);
+  const raw =
+    (await readTextIfExists(nextPath)) ??
+    (legacyPath ? await readTextIfExists(legacyPath) : undefined);
   if (!raw) {
     return undefined;
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,6 +22,7 @@ export interface BootstrapManifest {
   version: 1;
   project: {
     name: string;
+    displayName?: string;
     description: string;
     visibility: ProjectVisibility;
     owner: string;

--- a/tests/home-sync.test.ts
+++ b/tests/home-sync.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { access, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 
@@ -41,8 +41,34 @@ describe("home sync", () => {
 
     const codexAgents = await readFile(path.join(homeDir, ".codex/AGENTS.md"), "utf8");
     expect(codexAgents).toContain("Codex Home Profile");
+    await expect(access(path.join(homeDir, ".bootstrap/home-state.json"))).resolves.toBeUndefined();
 
     const secondPlan = await planHome(manifest, homeDir);
     expect(secondPlan.actions.every((action) => action.type === "unchanged")).toBe(true);
+  });
+
+  it("loads legacy home state from the old path", async () => {
+    const homeDir = await makeTempDir();
+    await mkdir(path.join(homeDir, ".new-project-bootstrap"), { recursive: true });
+    await writeFile(
+      path.join(homeDir, ".new-project-bootstrap/home-state.json"),
+      `${JSON.stringify({ managedFiles: { ".old-profile/file.txt": "abc123" } }, null, 2)}\n`,
+      "utf8"
+    );
+
+    const manifest = normalizeManifest({
+      project: {
+        name: "bootstrap",
+        owner: "acme"
+      },
+      archetype: {
+        kind: "generic-empty"
+      }
+    });
+
+    const plan = await planHome(manifest, homeDir);
+    expect(plan.actions.some((action) => action.path === ".old-profile/file.txt" && action.type === "delete")).toBe(
+      true
+    );
   });
 });

--- a/tests/manifest.test.ts
+++ b/tests/manifest.test.ts
@@ -18,6 +18,7 @@ describe("normalizeManifest", () => {
     });
 
     expect(manifest.project.defaultBranch).toBe("main");
+    expect(manifest.project.displayName).toBeUndefined();
     expect(manifest.repo.managedPaths).toEqual([]);
     expect(manifest.github.codeowners).toEqual([
       {
@@ -81,5 +82,21 @@ describe("normalizeManifest", () => {
 
     expect(manifest.repo.managedPaths).toEqual(["project.bootstrap.yaml", "docs/bootstrap/**"]);
     expect(manifest.github.requiredStatusChecks).toEqual(["test"]);
+  });
+
+  it("preserves an explicit docs-facing display name", () => {
+    const manifest = normalizeManifest({
+      project: {
+        name: "bootstrap",
+        displayName: "Bootstrap",
+        owner: "acme"
+      },
+      archetype: {
+        kind: "generic-empty"
+      }
+    });
+
+    expect(manifest.project.name).toBe("bootstrap");
+    expect(manifest.project.displayName).toBe("Bootstrap");
   });
 });

--- a/tests/render.test.ts
+++ b/tests/render.test.ts
@@ -63,4 +63,26 @@ describe("renderManagedFiles", () => {
     expect(prWorkflow?.contents).toContain("name: test");
     expect(prWorkflow?.contents).not.toContain("name: CI Gate");
   });
+
+  it("uses the display name in docs while keeping the repository slug visible", () => {
+    const manifest = normalizeManifest({
+      project: {
+        name: "bootstrap",
+        displayName: "Bootstrap",
+        owner: "acme"
+      },
+      archetype: {
+        kind: "generic-empty"
+      }
+    });
+
+    const files = renderManagedFiles(manifest);
+    const readme = files.find((file) => file.path === "README.md");
+    const onboarding = files.find((file) => file.path === "docs/bootstrap/onboarding.md");
+
+    expect(readme?.contents).toContain("# Bootstrap");
+    expect(readme?.contents).toContain("- Repository: `acme/bootstrap`");
+    expect(onboarding?.contents).toContain("- Product name: `Bootstrap`");
+    expect(onboarding?.contents).toContain("- Repository: `acme/bootstrap`");
+  });
 });

--- a/tests/smoke.test.ts
+++ b/tests/smoke.test.ts
@@ -121,7 +121,7 @@ describe("repo smoke", () => {
     await applyRepo(manifest, targetDir);
 
     await expect(
-      access(path.join(targetDir, ".git/info/new-project-bootstrap-state.json"))
+      access(path.join(targetDir, ".git/info/bootstrap-state.json"))
     ).resolves.toBeUndefined();
     await expect(access(path.join(targetDir, ".bootstrap/bootstrap-state.json"))).rejects.toThrow();
   });


### PR DESCRIPTION
## Summary
- rename the project slug and product name to bootstrap across manifest, package metadata, generated docs, and starter templates
- switch the CLI default command name to `bootstrap` while keeping `project-bootstrap` as a compatibility alias
- migrate bootstrap state writes to `.bootstrap` and keep legacy state-path reads covered by tests

## Verification
- npm test
- npm run typecheck
- npm run build