### PR TITLE
Add org governance controls to bootstrap GitHub sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Use `project.bootstrap.yaml` as the control plane for repo-local scaffolding, Gi
 
 ## What The Bootstrap Owns
 
-- GitHub governance and environments
+- GitHub governance, environments, and optional org defaults
 - Repo-local `AGENTS.md` and `CLAUDE.md` guidance
 - Fast PR checks plus heavier extended validation lanes
 - Portable Codex and Claude home profile sync
@@ -21,6 +21,8 @@ bootstrap apply github --manifest ./project.bootstrap.yaml
 bootstrap apply home --manifest ./project.bootstrap.yaml
 bootstrap doctor --manifest ./project.bootstrap.yaml
 ```
+
+If `github.organization` is set and `OMT-Global` is an organization, `bootstrap apply github` also reconciles org defaults for new repos.
 
 Confirm branch protection points at the `CI Gate` status.
 

--- a/docs/bootstrap/onboarding.md
+++ b/docs/bootstrap/onboarding.md
@@ -14,6 +14,13 @@ Use this checklist after the first bootstrap render or whenever `project.bootstr
 - Confirm branch protection points at the `CI Gate` status.
 - Confirm `delete branch on merge` and `allow auto-merge` are enabled.
 
+## Org Governance
+
+- Confirm the org default repository permission is `read`.
+- Confirm member repository creation is disabled.
+- Confirm new-repo security defaults keep dependency graph, Dependabot alerts, Dependabot security updates, secret scanning, push protection enabled.
+- Treat upstream-aligned forks as explicit exceptions; keep them aligned with the source fork unless you intentionally manage their GitHub policy here.
+
 ## Environments
 
 - `dev`: open by default for rapid iteration.

--- a/project.bootstrap.yaml
+++ b/project.bootstrap.yaml
@@ -21,6 +21,17 @@ github:
     - pattern: "*"
       owners:
         - "@jmcte"
+  organization:
+    defaultRepositoryPermission: read
+    membersCanCreateRepositories: false
+    membersCanCreatePublicRepositories: false
+    membersCanCreatePrivateRepositories: false
+    newRepositorySecurity:
+      dependabotAlerts: true
+      dependabotSecurityUpdates: true
+      dependencyGraph: true
+      secretScanning: true
+      secretScanningPushProtection: true
   autoMerge: true
   deleteBranchOnMerge: true
   requiredApprovals: 1

--- a/src/archetypes.ts
+++ b/src/archetypes.ts
@@ -51,6 +51,67 @@ function requiredStatusCheckConfirmation(manifest: BootstrapManifest): string {
     : `Confirm branch protection points at the expected required status checks: ${requiredStatusChecksDisplay(manifest)}.`;
 }
 
+function organizationRepoCreationPolicy(manifest: BootstrapManifest): string {
+  const organization = manifest.github.organization;
+  if (!organization) {
+    return "";
+  }
+
+  const disabledScopes = [
+    !organization.membersCanCreatePublicRepositories ? "public" : null,
+    !organization.membersCanCreatePrivateRepositories ? "private" : null,
+    organization.membersCanCreateInternalRepositories === false ? "internal" : null
+  ].filter((scope): scope is string => Boolean(scope));
+
+  if (
+    !organization.membersCanCreateRepositories &&
+    !organization.membersCanCreatePublicRepositories &&
+    !organization.membersCanCreatePrivateRepositories &&
+    organization.membersCanCreateInternalRepositories !== true
+  ) {
+    return "member repository creation is disabled.";
+  }
+
+  if (disabledScopes.length === 0) {
+    return "member repository creation matches the explicit manifest overrides.";
+  }
+
+  return `member repository creation is disabled for ${disabledScopes.join("/")}.`;
+}
+
+function organizationSecurityDefaultsLabel(manifest: BootstrapManifest): string {
+  const organization = manifest.github.organization;
+  if (!organization) {
+    return "";
+  }
+
+  const enabledDefaults = [
+    organization.newRepositorySecurity.dependencyGraph ? "dependency graph" : null,
+    organization.newRepositorySecurity.dependabotAlerts ? "Dependabot alerts" : null,
+    organization.newRepositorySecurity.dependabotSecurityUpdates ? "Dependabot security updates" : null,
+    organization.newRepositorySecurity.secretScanning ? "secret scanning" : null,
+    organization.newRepositorySecurity.secretScanningPushProtection ? "push protection" : null
+  ].filter((value): value is string => Boolean(value));
+
+  return enabledDefaults.join(", ");
+}
+
+function organizationGovernanceSection(manifest: BootstrapManifest): string {
+  const organization = manifest.github.organization;
+  if (!organization) {
+    return "";
+  }
+
+  return dedent`
+    ## Org Governance
+
+    - Confirm the org default repository permission is \`${organization.defaultRepositoryPermission}\`.
+    - Confirm ${organizationRepoCreationPolicy(manifest)}
+    - Confirm new-repo security defaults keep ${organizationSecurityDefaultsLabel(manifest)} enabled.
+    - Treat upstream-aligned forks as explicit exceptions; keep them aligned with the source fork unless you intentionally manage their GitHub policy here.
+  `;
+}
+
 function codeowners(manifest: BootstrapManifest): string {
   if (manifest.github.codeowners.length === 0) {
     return "# Add CODEOWNERS entries when reviewer mapping is ready.\n";
@@ -209,7 +270,7 @@ ${indentBlock(claudeBullets, 6)}
 
     ## What The Bootstrap Owns
 
-    - GitHub governance and environments
+    - GitHub governance, environments, and optional org defaults
     - Repo-local \`AGENTS.md\` and \`CLAUDE.md\` guidance
     - Fast PR checks plus heavier extended validation lanes
     - Portable Codex and Claude home profile sync
@@ -224,6 +285,10 @@ ${indentBlock(claudeBullets, 6)}
     bootstrap apply home --manifest ./project.bootstrap.yaml
     bootstrap doctor --manifest ./project.bootstrap.yaml
     \`\`\`
+
+    ${manifest.github.organization
+      ? `If \`github.organization\` is set and \`${manifest.project.owner}\` is an organization, \`bootstrap apply github\` also reconciles org defaults for new repos.`
+      : ""}
 
     ${requiredStatusCheckConfirmation(manifest)}
 
@@ -1459,6 +1524,8 @@ ${indentBlock(projectIdentityLines(manifest), 4)}
     - Confirm branch protection or rulesets on \`${manifest.project.defaultBranch}\` require one approval and code owner review.
     - ${requiredStatusCheckConfirmation(manifest)}
     - Confirm \`delete branch on merge\` and \`allow auto-merge\` are enabled.
+
+${indentBlock(organizationGovernanceSection(manifest), 4)}
 
     ## Environments
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -138,7 +138,7 @@ async function main(): Promise<void> {
 
   apply
     .command("github")
-    .description("Create or update GitHub repo settings, branch protection, and environments.")
+    .description("Create or update GitHub org defaults, repo settings, branch protection, and environments.")
     .option("--manifest <path>", "Path to manifest")
     .action(async (options) => {
       const manifest = await loadManifest(resolveManifestPath(options.manifest));

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -52,6 +52,14 @@ export async function runDoctor(
     });
   }
 
+  if (manifest.github.organization) {
+    checks.push({
+      name: "GitHub org policy",
+      status: "ok",
+      detail: `apply github will also reconcile org defaults for ${manifest.project.owner}.`
+    });
+  }
+
   if (manifest.agents.manageCodexHome) {
     const codexAvailable = await commandExists(runner, "codex");
     checks.push({

--- a/src/github/provision.ts
+++ b/src/github/provision.ts
@@ -13,6 +13,20 @@ interface GitHubOwner {
   type: "User" | "Organization";
 }
 
+interface GitHubOrganizationSettings {
+  default_repository_permission: string;
+  members_can_create_repositories: boolean;
+  members_can_create_public_repositories: boolean;
+  members_can_create_private_repositories: boolean;
+  members_can_create_internal_repositories?: boolean;
+  web_commit_signoff_required?: boolean;
+  dependabot_alerts_enabled_for_new_repositories: boolean;
+  dependabot_security_updates_enabled_for_new_repositories: boolean;
+  dependency_graph_enabled_for_new_repositories: boolean;
+  secret_scanning_enabled_for_new_repositories: boolean;
+  secret_scanning_push_protection_enabled_for_new_repositories: boolean;
+}
+
 interface ReviewerIdentity {
   type: "User" | "Team";
   id: number;
@@ -20,6 +34,53 @@ interface ReviewerIdentity {
 
 function requiredStatusChecksLabel(manifest: BootstrapManifest): string {
   return manifest.github.requiredStatusChecks.join(", ");
+}
+
+function hasOrganizationPolicy(manifest: BootstrapManifest): boolean {
+  return manifest.github.organization !== undefined;
+}
+
+function organizationPayload(manifest: BootstrapManifest): Record<string, boolean | string> | undefined {
+  const organization = manifest.github.organization;
+  if (!organization) {
+    return undefined;
+  }
+
+  return {
+    default_repository_permission: organization.defaultRepositoryPermission,
+    members_can_create_repositories: organization.membersCanCreateRepositories,
+    members_can_create_public_repositories: organization.membersCanCreatePublicRepositories,
+    members_can_create_private_repositories: organization.membersCanCreatePrivateRepositories,
+    ...(organization.membersCanCreateInternalRepositories !== undefined
+      ? {
+          members_can_create_internal_repositories: organization.membersCanCreateInternalRepositories
+        }
+      : {}),
+    ...(organization.webCommitSignoffRequired !== undefined
+      ? {
+          web_commit_signoff_required: organization.webCommitSignoffRequired
+        }
+      : {}),
+    dependabot_alerts_enabled_for_new_repositories: organization.newRepositorySecurity.dependabotAlerts,
+    dependabot_security_updates_enabled_for_new_repositories:
+      organization.newRepositorySecurity.dependabotSecurityUpdates,
+    dependency_graph_enabled_for_new_repositories: organization.newRepositorySecurity.dependencyGraph,
+    secret_scanning_enabled_for_new_repositories: organization.newRepositorySecurity.secretScanning,
+    secret_scanning_push_protection_enabled_for_new_repositories:
+      organization.newRepositorySecurity.secretScanningPushProtection
+  };
+}
+
+function organizationNeedsUpdate(
+  manifest: BootstrapManifest,
+  organization: GitHubOrganizationSettings
+): boolean {
+  const desired = organizationPayload(manifest);
+  if (!desired) {
+    return false;
+  }
+
+  return Object.entries(desired).some(([key, value]) => organization[key as keyof GitHubOrganizationSettings] !== value);
 }
 
 function isEnvironmentProtectionPlanLimit(error: unknown): boolean {
@@ -113,6 +174,13 @@ async function getOwner(client: GitHubClient, owner: string): Promise<GitHubOwne
   return client.api<GitHubOwner>("GET", `/users/${owner}`);
 }
 
+async function getOrganizationSettings(
+  client: GitHubClient,
+  owner: string
+): Promise<GitHubOrganizationSettings> {
+  return client.api<GitHubOrganizationSettings>("GET", `/orgs/${owner}`);
+}
+
 async function getRepo(
   client: GitHubClient,
   owner: string,
@@ -139,6 +207,15 @@ export async function planGitHub(
         id: "repo",
         description: `Create or update ${manifest.project.owner}/${manifest.project.name} with repo settings, auto-merge, and branch cleanup.`
       },
+      ...(hasOrganizationPolicy(manifest)
+        ? [
+            {
+              id: "organization",
+              description:
+                "Update organization defaults for repository permission, member repo creation, and new-repo security settings."
+            }
+          ]
+        : []),
       {
         id: "branch-protection",
         description: `Protect ${manifest.project.defaultBranch} with 1 approval, stale-review dismissal, code owner review, linear history, and required status checks ${requiredStatusChecksLabel(manifest)}.`
@@ -152,6 +229,23 @@ export async function planGitHub(
   }
 
   const repo = await getRepo(client, manifest.project.owner, manifest.project.name);
+  const owner = await getOwner(client, manifest.project.owner);
+
+  if (owner.type === "Organization" && hasOrganizationPolicy(manifest)) {
+    const organization = await getOrganizationSettings(client, manifest.project.owner);
+    actions.push({
+      id: organizationNeedsUpdate(manifest, organization) ? "organization" : "organization-sync",
+      description: organizationNeedsUpdate(manifest, organization)
+        ? `Update organization defaults for ${manifest.project.owner}.`
+        : `Organization defaults for ${manifest.project.owner} already match the manifest.`
+    });
+  } else if (owner.type !== "Organization" && hasOrganizationPolicy(manifest)) {
+    actions.push({
+      id: "organization-skip",
+      description: `Skip organization defaults because ${manifest.project.owner} is not an organization owner.`
+    });
+  }
+
   actions.push({
     id: "repo",
     description: repo
@@ -184,6 +278,22 @@ export async function applyGitHub(
   const repo = await getRepo(client, manifest.project.owner, manifest.project.name);
   const owner = await getOwner(client, manifest.project.owner);
   const actions: PlannedGitHubAction[] = [];
+
+  if (owner.type === "Organization" && hasOrganizationPolicy(manifest)) {
+    const payload = organizationPayload(manifest);
+    if (payload) {
+      await client.api("PATCH", `/orgs/${manifest.project.owner}`, payload);
+      actions.push({
+        id: "organization-update",
+        description: `Updated organization defaults for ${manifest.project.owner}.`
+      });
+    }
+  } else if (owner.type !== "Organization" && hasOrganizationPolicy(manifest)) {
+    actions.push({
+      id: "organization-skip",
+      description: `Skipped organization defaults because ${manifest.project.owner} is not an organization owner.`
+    });
+  }
 
   const visibility: BootstrapManifest["project"]["visibility"] | "private" =
     owner.type === "User" && manifest.project.visibility === "internal"

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -3,7 +3,13 @@ import YAML from "yaml";
 import { z } from "zod";
 
 import { readTextIfExists } from "./lib/fs.js";
-import type { BootstrapManifest, CodeownerRule, EnvironmentConfig } from "./types.js";
+import type {
+  BootstrapManifest,
+  CodeownerRule,
+  DefaultRepositoryPermission,
+  EnvironmentConfig,
+  OrganizationConfig
+} from "./types.js";
 
 const environmentSchema = z.object({
   reviewers: z.array(z.string()).optional(),
@@ -15,6 +21,24 @@ const environmentSchema = z.object({
 const codeownerSchema = z.object({
   pattern: z.string().min(1),
   owners: z.array(z.string().min(1)).min(1)
+});
+
+const organizationSecuritySchema = z.object({
+  dependabotAlerts: z.boolean().optional(),
+  dependabotSecurityUpdates: z.boolean().optional(),
+  dependencyGraph: z.boolean().optional(),
+  secretScanning: z.boolean().optional(),
+  secretScanningPushProtection: z.boolean().optional()
+});
+
+const organizationSchema = z.object({
+  defaultRepositoryPermission: z.enum(["read", "write", "admin", "none"]).optional(),
+  membersCanCreateRepositories: z.boolean().optional(),
+  membersCanCreatePublicRepositories: z.boolean().optional(),
+  membersCanCreatePrivateRepositories: z.boolean().optional(),
+  membersCanCreateInternalRepositories: z.boolean().optional(),
+  webCommitSignoffRequired: z.boolean().optional(),
+  newRepositorySecurity: organizationSecuritySchema.optional()
 });
 
 const manifestSchema = z.object({
@@ -42,6 +66,7 @@ const manifestSchema = z.object({
       createRepo: z.boolean().optional(),
       reviewers: z.array(z.string()).optional(),
       codeowners: z.array(codeownerSchema).optional(),
+      organization: organizationSchema.optional(),
       autoMerge: z.boolean().optional(),
       deleteBranchOnMerge: z.boolean().optional(),
       requiredApprovals: z.number().int().min(1).max(6).optional(),
@@ -153,12 +178,46 @@ function normalizeCodeowners(
   ];
 }
 
+function normalizeOrganization(
+  organization: z.input<typeof organizationSchema> | undefined
+): OrganizationConfig | undefined {
+  if (!organization) {
+    return undefined;
+  }
+
+  return {
+    defaultRepositoryPermission:
+      (organization.defaultRepositoryPermission as DefaultRepositoryPermission | undefined) ?? "read",
+    membersCanCreateRepositories: organization.membersCanCreateRepositories ?? false,
+    membersCanCreatePublicRepositories: organization.membersCanCreatePublicRepositories ?? false,
+    membersCanCreatePrivateRepositories: organization.membersCanCreatePrivateRepositories ?? false,
+    ...(organization.membersCanCreateInternalRepositories !== undefined
+      ? {
+          membersCanCreateInternalRepositories: organization.membersCanCreateInternalRepositories
+        }
+      : {}),
+    ...(organization.webCommitSignoffRequired !== undefined
+      ? {
+          webCommitSignoffRequired: organization.webCommitSignoffRequired
+        }
+      : {}),
+    newRepositorySecurity: {
+      dependabotAlerts: organization.newRepositorySecurity?.dependabotAlerts ?? true,
+      dependabotSecurityUpdates: organization.newRepositorySecurity?.dependabotSecurityUpdates ?? true,
+      dependencyGraph: organization.newRepositorySecurity?.dependencyGraph ?? true,
+      secretScanning: organization.newRepositorySecurity?.secretScanning ?? true,
+      secretScanningPushProtection: organization.newRepositorySecurity?.secretScanningPushProtection ?? true
+    }
+  };
+}
+
 export function normalizeManifest(raw: z.input<typeof manifestSchema>): BootstrapManifest {
   const parsed = manifestSchema.parse(raw);
   const reviewers = (parsed.github?.reviewers ?? []).map((reviewer) => reviewer.replace(/^@/, ""));
   const defaultBranch = parsed.project.defaultBranch ?? "main";
   const moduleName = parsed.archetype.moduleName ?? moduleNameForProject(parsed.project.name);
   const github = parsed.github ?? {};
+  const organization = normalizeOrganization(github.organization);
   const repoFeatures = github.repoFeatures ?? {};
   const environments = parsed.environments ?? {};
 
@@ -193,6 +252,7 @@ export function normalizeManifest(raw: z.input<typeof manifestSchema>): Bootstra
       createRepo: github.createRepo ?? true,
       reviewers,
       codeowners: normalizeCodeowners(github.codeowners ?? [], reviewers),
+      ...(organization ? { organization } : {}),
       autoMerge: github.autoMerge ?? true,
       deleteBranchOnMerge: github.deleteBranchOnMerge ?? true,
       requiredApprovals: github.requiredApprovals ?? 1,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,7 @@
 export type ProjectVisibility = "private" | "public" | "internal";
 export type ArchetypeKind = "nextjs-web" | "node-ts-service" | "python-service" | "generic-empty";
 export type RunnerPolicy = "hybrid-safe" | "self-hosted-first" | "github-hosted-first";
+export type DefaultRepositoryPermission = "read" | "write" | "admin" | "none";
 
 export interface CodeownerRule {
   pattern: string;
@@ -16,6 +17,24 @@ export interface EnvironmentConfig {
 
 export interface RepoConfig {
   managedPaths: string[];
+}
+
+export interface OrganizationSecurityDefaults {
+  dependabotAlerts: boolean;
+  dependabotSecurityUpdates: boolean;
+  dependencyGraph: boolean;
+  secretScanning: boolean;
+  secretScanningPushProtection: boolean;
+}
+
+export interface OrganizationConfig {
+  defaultRepositoryPermission: DefaultRepositoryPermission;
+  membersCanCreateRepositories: boolean;
+  membersCanCreatePublicRepositories: boolean;
+  membersCanCreatePrivateRepositories: boolean;
+  membersCanCreateInternalRepositories?: boolean;
+  webCommitSignoffRequired?: boolean;
+  newRepositorySecurity: OrganizationSecurityDefaults;
 }
 
 export interface BootstrapManifest {
@@ -38,6 +57,7 @@ export interface BootstrapManifest {
     createRepo: boolean;
     reviewers: string[];
     codeowners: CodeownerRule[];
+    organization?: OrganizationConfig;
     autoMerge: boolean;
     deleteBranchOnMerge: boolean;
     requiredApprovals: number;

--- a/tests/github-provision.test.ts
+++ b/tests/github-provision.test.ts
@@ -38,7 +38,20 @@ describe("GitHub provisioning", () => {
       },
       github: {
         reviewers: ["alice"],
-        requiredStatusChecks: ["test", "lint"]
+        requiredStatusChecks: ["test", "lint"],
+        organization: {
+          defaultRepositoryPermission: "read",
+          membersCanCreateRepositories: false,
+          membersCanCreatePublicRepositories: false,
+          membersCanCreatePrivateRepositories: false,
+          newRepositorySecurity: {
+            dependencyGraph: true,
+            dependabotAlerts: true,
+            dependabotSecurityUpdates: true,
+            secretScanning: true,
+            secretScanningPushProtection: true
+          }
+        }
       }
     });
 
@@ -66,7 +79,9 @@ describe("GitHub provisioning", () => {
     };
 
     const actions = await applyGitHub(manifest, client as never);
+    expect(actions.map((action) => action.id)).toContain("organization-update");
     expect(actions.map((action) => action.id)).toContain("repo-create");
+    expect(calls.some((call) => call.endpoint === "/orgs/acme" && call.method === "PATCH")).toBe(true);
     expect(calls.some((call) => call.endpoint === "/orgs/acme/repos" && call.method === "POST")).toBe(true);
     expect(
       calls.some(
@@ -88,6 +103,70 @@ describe("GitHub provisioning", () => {
         (call) => call.endpoint === "/repos/acme/example/environments/prod" && call.method === "PUT"
       )
     ).toBe(true);
+  });
+
+  it("reports org-policy drift in the GitHub plan when organization defaults differ", async () => {
+    const manifest = normalizeManifest({
+      project: {
+        name: "example",
+        owner: "acme"
+      },
+      archetype: {
+        kind: "generic-empty"
+      },
+      github: {
+        organization: {
+          defaultRepositoryPermission: "read",
+          membersCanCreateRepositories: false,
+          membersCanCreatePublicRepositories: false,
+          membersCanCreatePrivateRepositories: false,
+          newRepositorySecurity: {
+            dependencyGraph: true,
+            dependabotAlerts: true,
+            dependabotSecurityUpdates: true,
+            secretScanning: true,
+            secretScanningPushProtection: true
+          }
+        }
+      }
+    });
+
+    const actions = await planGitHub(
+      manifest,
+      {
+        isAvailable: async () => true,
+        isAuthenticated: async () => true,
+        tryApi: async (method: string, endpoint: string) => {
+          if (endpoint === "/repos/acme/example") {
+            return undefined;
+          }
+          return undefined;
+        },
+        api: async (method: string, endpoint: string) => {
+          if (endpoint === "/users/acme") {
+            return { login: "acme", type: "Organization" };
+          }
+          if (endpoint === "/orgs/acme") {
+            return {
+              default_repository_permission: "write",
+              members_can_create_repositories: true,
+              members_can_create_public_repositories: true,
+              members_can_create_private_repositories: true,
+              dependabot_alerts_enabled_for_new_repositories: false,
+              dependabot_security_updates_enabled_for_new_repositories: false,
+              dependency_graph_enabled_for_new_repositories: false,
+              secret_scanning_enabled_for_new_repositories: false,
+              secret_scanning_push_protection_enabled_for_new_repositories: false
+            };
+          }
+          return {};
+        }
+      } as never
+    );
+
+    expect(actions.find((action) => action.id === "organization")?.description).toContain(
+      "Update organization defaults for acme."
+    );
   });
 
   it("falls back to bare environments when private-repo protection rules are unsupported", async () => {

--- a/tests/manifest.test.ts
+++ b/tests/manifest.test.ts
@@ -99,4 +99,45 @@ describe("normalizeManifest", () => {
     expect(manifest.project.name).toBe("bootstrap");
     expect(manifest.project.displayName).toBe("Bootstrap");
   });
+
+  it("normalizes optional organization governance settings", () => {
+    const manifest = normalizeManifest({
+      project: {
+        name: "bootstrap",
+        owner: "acme"
+      },
+      archetype: {
+        kind: "generic-empty"
+      },
+      github: {
+        organization: {
+          defaultRepositoryPermission: "read",
+          membersCanCreateRepositories: false,
+          membersCanCreatePublicRepositories: false,
+          membersCanCreatePrivateRepositories: false,
+          newRepositorySecurity: {
+            dependencyGraph: true,
+            dependabotAlerts: true,
+            dependabotSecurityUpdates: true,
+            secretScanning: true,
+            secretScanningPushProtection: true
+          }
+        }
+      }
+    });
+
+    expect(manifest.github.organization).toEqual({
+      defaultRepositoryPermission: "read",
+      membersCanCreateRepositories: false,
+      membersCanCreatePublicRepositories: false,
+      membersCanCreatePrivateRepositories: false,
+      newRepositorySecurity: {
+        dependencyGraph: true,
+        dependabotAlerts: true,
+        dependabotSecurityUpdates: true,
+        secretScanning: true,
+        secretScanningPushProtection: true
+      }
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- add optional org-level GitHub governance settings to the bootstrap manifest and provisioner
- encode the OMT-Global defaults in this repo and surface them in README/onboarding/doctor output
- document upstream-aligned forks as explicit exceptions for GitHub policy management

## Verification
- npm run typecheck
- npm test
- npm run build
- node dist/cli.js doctor --manifest ./project.bootstrap.yaml
- node dist/cli.js plan --manifest ./project.bootstrap.yaml