### PR TITLE
Support repo-specific workflow lanes in bootstrap manifests

### DIFF
--- a/src/archetypes.ts
+++ b/src/archetypes.ts
@@ -51,6 +51,26 @@ function requiredStatusCheckConfirmation(manifest: BootstrapManifest): string {
     : `Confirm branch protection points at the expected required status checks: ${requiredStatusChecksDisplay(manifest)}.`;
 }
 
+function additionalWorkflowLines(manifest: BootstrapManifest): string[] {
+  return manifest.ci.additionalWorkflows.map(
+    (workflow) => `- \`${workflow.path}\`: ${workflow.purpose}`
+  );
+}
+
+function additionalWorkflowSection(manifest: BootstrapManifest): string {
+  if (manifest.ci.additionalWorkflows.length === 0) {
+    return "";
+  }
+
+  return dedent`
+    ## Repo-Specific Workflow Lanes
+
+${indentBlock(additionalWorkflowLines(manifest).join("\n"), 4)}
+
+    These lanes are adjunct to the standard CI shape. Keep the required PR status checks aligned with ${requiredStatusChecksDisplay(manifest)}, and keep heavyweight or specialized logic out of the fast PR gate unless the manifest explicitly changes that contract.
+  `;
+}
+
 function organizationRepoCreationPolicy(manifest: BootstrapManifest): string {
   const organization = manifest.github.organization;
   if (!organization) {
@@ -178,6 +198,7 @@ function repoClaude(manifest: BootstrapManifest): string {
   const projectMapLines = [
     "- `project.bootstrap.yaml`: source of truth for bootstrap policy",
     "- `.github/workflows/`: generated fast and extended CI lanes",
+    ...additionalWorkflowLines(manifest),
     manifest.agents.enableClaudeWebEnvironment
       ? "- `scripts/claude-cloud/setup.sh`: first-party Claude Code on the web setup script"
       : null,
@@ -211,6 +232,9 @@ function repoClaude(manifest: BootstrapManifest): string {
       : null,
     manifest.agents.enableClaudeGitHubAction
       ? "- The generated Claude GitHub Action is a separate review lane. It must not become a required status check."
+      : null,
+    manifest.ci.additionalWorkflows.length > 0
+      ? `- Repo-specific workflow lanes (${manifest.ci.additionalWorkflows.map((workflow) => `\`${workflow.path}\``).join(", ")}) stay adjunct to the standard PR and extended validation lanes.`
       : null,
     manifest.agents.enableClaudeDevcontainer
       ? "- Treat the devcontainer as a trusted-repo workspace. Do not mount extra secrets beyond the persisted `~/.claude` profile unless you explicitly need them."
@@ -271,6 +295,9 @@ ${indentBlock(claudeBullets, 6)}
     ## What The Bootstrap Owns
 
     - GitHub governance, environments, and optional org defaults
+    ${manifest.ci.additionalWorkflows.length > 0
+      ? "- Optional repo-specific workflow lanes declared in the manifest without replacing the standard CI frame"
+      : ""}
     - Repo-local \`AGENTS.md\` and \`CLAUDE.md\` guidance
     - Fast PR checks plus heavier extended validation lanes
     - Portable Codex and Claude home profile sync
@@ -298,6 +325,7 @@ ${indentBlock(projectIdentityLines(manifest), 4)}
     - Visibility: \`${manifest.project.visibility}\`
     - Default branch: \`${manifest.project.defaultBranch}\`
     - Archetype: \`${manifest.archetype.kind}\`
+${indentBlock(additionalWorkflowSection(manifest), 4)}
 ${indentBlock(claudeSection, 4)}
 
     ## Repository URL
@@ -1526,6 +1554,7 @@ ${indentBlock(projectIdentityLines(manifest), 4)}
     - Confirm \`delete branch on merge\` and \`allow auto-merge\` are enabled.
 
 ${indentBlock(organizationGovernanceSection(manifest), 4)}
+${indentBlock(additionalWorkflowSection(manifest), 4)}
 
     ## Environments
 
@@ -1538,6 +1567,11 @@ ${indentBlock(organizationGovernanceSection(manifest), 4)}
     - Shell-safe jobs may use \`[self-hosted, synology, shell-only, ${manifest.project.visibility === "public" ? "public" : "private"}]\`.
     - Docker, service-container, browser, and \`container:\` workloads stay on GitHub-hosted runners.
     - Keep PR checks cheap. Add heavy validation to \`scripts/ci/run-extended-validation.sh\` instead of the PR lane.
+    ${manifest.ci.additionalWorkflows.length > 0
+      ? `- Keep repo-specific workflow lanes (${manifest.ci.additionalWorkflows
+          .map((workflow) => `\`${workflow.path}\``)
+          .join(", ")}) as adjuncts to the standard CI frame. Do not repurpose them as the required PR gate unless the manifest's required status checks change deliberately.`
+      : ""}
 
     ## Home Profiles
 

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -15,6 +15,10 @@ function requiredStatusChecksLabel(manifest: BootstrapManifest): string {
   return manifest.github.requiredStatusChecks.join(", ");
 }
 
+function additionalWorkflowsLabel(manifest: BootstrapManifest): string {
+  return manifest.ci.additionalWorkflows.map((workflow) => workflow.path).join(", ");
+}
+
 async function commandExists(runner: CommandRunner, command: string): Promise<boolean> {
   const result = await runner(command, ["--version"]);
   return result.exitCode === 0;
@@ -123,6 +127,15 @@ export async function runDoctor(
       typeof runnerLabels === "string"
         ? `Shell-safe jobs resolve to ${runnerLabels}.`
         : `Shell-safe jobs resolve to [${runnerLabels.join(", ")}].`
+  });
+
+  checks.push({
+    name: "CI shape",
+    status: "ok",
+    detail:
+      manifest.ci.additionalWorkflows.length === 0
+        ? `Standard CI shape uses ${requiredStatusChecksLabel(manifest)} for PR gating plus extended validation on ${manifest.project.defaultBranch}, nightly, and manual dispatch.`
+        : `Standard CI shape uses ${requiredStatusChecksLabel(manifest)} for PR gating plus adjunct repo-specific workflow lanes: ${additionalWorkflowsLabel(manifest)}.`
   });
 
   for (const environmentName of ["stage", "prod"] as const) {

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 
 import { readTextIfExists } from "./lib/fs.js";
 import type {
+  AdditionalWorkflowConfig,
   BootstrapManifest,
   CodeownerRule,
   DefaultRepositoryPermission,
@@ -39,6 +40,11 @@ const organizationSchema = z.object({
   membersCanCreateInternalRepositories: z.boolean().optional(),
   webCommitSignoffRequired: z.boolean().optional(),
   newRepositorySecurity: organizationSecuritySchema.optional()
+});
+
+const additionalWorkflowSchema = z.object({
+  path: z.string().min(1),
+  purpose: z.string().min(1)
 });
 
 const manifestSchema = z.object({
@@ -95,7 +101,8 @@ const manifestSchema = z.object({
       pythonVersion: z.string().optional(),
       fastChecks: z.array(z.string()).optional(),
       extendedChecks: z.array(z.string()).optional(),
-      nightlyCron: z.string().optional()
+      nightlyCron: z.string().optional(),
+      additionalWorkflows: z.array(additionalWorkflowSchema).optional()
     })
     .optional(),
   agents: z
@@ -211,6 +218,15 @@ function normalizeOrganization(
   };
 }
 
+function normalizeAdditionalWorkflows(
+  workflows: z.input<typeof additionalWorkflowSchema>[] | undefined
+): AdditionalWorkflowConfig[] {
+  return (workflows ?? []).map((workflow) => ({
+    path: workflow.path.replace(/\\/g, "/"),
+    purpose: workflow.purpose.trim()
+  }));
+}
+
 export function normalizeManifest(raw: z.input<typeof manifestSchema>): BootstrapManifest {
   const parsed = manifestSchema.parse(raw);
   const reviewers = (parsed.github?.reviewers ?? []).map((reviewer) => reviewer.replace(/^@/, ""));
@@ -277,7 +293,8 @@ export function normalizeManifest(raw: z.input<typeof manifestSchema>): Bootstra
       pythonVersion: parsed.ci?.pythonVersion ?? "3.12",
       fastChecks: parsed.ci?.fastChecks ?? ["lint", "typecheck", "unit", "build", "secrets"],
       extendedChecks: parsed.ci?.extendedChecks ?? ["integration", "release-readiness"],
-      nightlyCron: parsed.ci?.nightlyCron ?? "0 7 * * *"
+      nightlyCron: parsed.ci?.nightlyCron ?? "0 7 * * *",
+      additionalWorkflows: normalizeAdditionalWorkflows(parsed.ci?.additionalWorkflows)
     },
     agents: {
       manageCodexHome: parsed.agents?.manageCodexHome ?? true,

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,6 +19,11 @@ export interface RepoConfig {
   managedPaths: string[];
 }
 
+export interface AdditionalWorkflowConfig {
+  path: string;
+  purpose: string;
+}
+
 export interface OrganizationSecurityDefaults {
   dependabotAlerts: boolean;
   dependabotSecurityUpdates: boolean;
@@ -83,6 +88,7 @@ export interface BootstrapManifest {
     fastChecks: string[];
     extendedChecks: string[];
     nightlyCron: string;
+    additionalWorkflows: AdditionalWorkflowConfig[];
   };
   agents: {
     manageCodexHome: boolean;

--- a/tests/manifest.test.ts
+++ b/tests/manifest.test.ts
@@ -84,6 +84,33 @@ describe("normalizeManifest", () => {
     expect(manifest.github.requiredStatusChecks).toEqual(["test"]);
   });
 
+  it("normalizes declared repo-specific workflow lanes", () => {
+    const manifest = normalizeManifest({
+      project: {
+        name: "ops-repo",
+        owner: "acme"
+      },
+      archetype: {
+        kind: "generic-empty"
+      },
+      ci: {
+        additionalWorkflows: [
+          {
+            path: ".github\\workflows\\deploy.yml",
+            purpose: "Runs deploy orchestration after the standard CI lanes pass."
+          }
+        ]
+      }
+    });
+
+    expect(manifest.ci.additionalWorkflows).toEqual([
+      {
+        path: ".github/workflows/deploy.yml",
+        purpose: "Runs deploy orchestration after the standard CI lanes pass."
+      }
+    ]);
+  });
+
   it("preserves an explicit docs-facing display name", () => {
     const manifest = normalizeManifest({
       project: {

--- a/tests/render.test.ts
+++ b/tests/render.test.ts
@@ -85,4 +85,36 @@ describe("renderManagedFiles", () => {
     expect(onboarding?.contents).toContain("- Product name: `Bootstrap`");
     expect(onboarding?.contents).toContain("- Repository: `acme/bootstrap`");
   });
+
+  it("documents repo-specific workflow lanes without replacing the standard CI frame", () => {
+    const manifest = normalizeManifest({
+      project: {
+        name: "ops-repo",
+        owner: "acme"
+      },
+      archetype: {
+        kind: "generic-empty"
+      },
+      ci: {
+        additionalWorkflows: [
+          {
+            path: ".github/workflows/deploy.yml",
+            purpose: "Runs deploy orchestration after the standard CI lanes pass."
+          }
+        ]
+      }
+    });
+
+    const files = renderManagedFiles(manifest);
+    const readme = files.find((file) => file.path === "README.md");
+    const claude = files.find((file) => file.path === "CLAUDE.md");
+    const onboarding = files.find((file) => file.path === "docs/bootstrap/onboarding.md");
+    const prWorkflow = files.find((file) => file.path === ".github/workflows/pr-fast-ci.yml");
+
+    expect(readme?.contents).toContain("Repo-Specific Workflow Lanes");
+    expect(readme?.contents).toContain("`.github/workflows/deploy.yml`");
+    expect(claude?.contents).toContain("stay adjunct to the standard PR and extended validation lanes");
+    expect(onboarding?.contents).toContain("Do not repurpose them as the required PR gate");
+    expect(prWorkflow?.contents).toContain("name: CI Gate");
+  });
 });


### PR DESCRIPTION
## Summary
- add `ci.additionalWorkflows` to the bootstrap manifest schema and normalized types
- surface repo-specific workflow lanes in generated docs and doctor output without changing the required PR gate
- add regression coverage for workflow-lane normalization and rendered documentation

## Verification
- PATH=/opt/homebrew/bin:$PATH /opt/homebrew/bin/npm run typecheck
- PATH=/opt/homebrew/bin:$PATH /opt/homebrew/bin/npm test
- PATH=/opt/homebrew/bin:$PATH /opt/homebrew/bin/npm run build