### PR TITLE
docs: add pheidon governance contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,15 @@
 - Add or update tests for every interactive, branching, or operator-facing behavior change.
 - Never commit real secrets, runtime auth, or machine-local env files. Use templates and GitHub environments instead.
 
+## Kingdom Governance
+
+- Pheidon is the orchestrator and current gate for repo execution work.
+- GitHub issues are the source of record for agent execution work.
+- Worker agents should act from assigned or explicitly enabled issues, not free-roaming backlog grabs.
+- If an agent authors a PR, that same agent may not approve it. This is a hard rule.
+- Healthy PRs should converge toward auto-merge once required checks are green or intentionally skipped, approvals are satisfied, and no blocking review state remains.
+- PRs should link and close their governing issue where possible so issue state remains the durable work contract.
+
 ## Local Conventions
 
 - Keep scope tight and favor predictable templates over clever scaffolding.

--- a/README.md
+++ b/README.md
@@ -45,6 +45,50 @@ This bootstrap can prepare these Claude workflows:
 
 The full checklist is in `docs/bootstrap/claude-environment.md`.
 
+## Kingdom Governance Flow
+
+### Issue to merge flow
+
+```mermaid
+flowchart TD
+    J[John designs work] --> I[GitHub issue becomes source of record]
+    I --> P[Pheidon assigns or enables issue]
+    P --> W[Worker lane implements]
+    W --> PR[Worker opens PR linked to issue]
+    PR --> G{Pheidon gate checks readiness}
+    G -->|CI green or intentionally skipped\napprovals satisfied\nmergeable| A[Arm auto-merge]
+    A --> M[GitHub merges PR]
+    M --> C[Linked issue closes]
+    C --> N[Worker eligible for next issue]
+    G -->|CI failed\nbehind/conflicted\nrequested changes| R[Return PR to owning worker]
+    R --> W
+```
+
+### PR ownership and repair loop
+
+```mermaid
+flowchart TD
+    PR[Worker-owned PR] --> S{PR healthy?}
+    S -->|No| B{Blocker type}
+    B -->|CI failure| F[PR owner fixes CI]
+    B -->|Behind or conflicts| RB[PR owner rebases or refreshes branch]
+    B -->|Review changes requested| RC[PR owner updates implementation]
+    F --> PR
+    RB --> PR
+    RC --> PR
+    S -->|Yes| G[Pheidon gate confirms policy]
+    G --> AM[Auto-merge armed]
+```
+
+### Governance rules
+
+- GitHub issues are the source of record for agent execution work.
+- Pheidon is the orchestrator and current gate.
+- Workers should act from assigned or explicitly enabled issues.
+- PR authors may not approve their own PRs.
+- PR owners must repair their own PRs until merge-ready unless Pheidon explicitly reassigns ownership.
+- Healthy PRs should converge toward auto-merge.
+
 ## Repository URL
 
 - https://github.com/OMT-Global/bootstrap


### PR DESCRIPTION
## Summary
- add a kingdom governance section to the repo AGENTS contract
- document Pheidon as orchestrator and current gate for repo execution work
- document issue-driven work, no self-approval by PR authors, and auto-merge as the intended healthy end-state

## Why
This aligns the non-forked OMT-Global repos with the current Pheidon runtime and governance model.
