### PR TITLE
Add explicit MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 OMT Global
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## Summary

- Add an explicit MIT `LICENSE` file.
- Leave repository code unchanged.

## Governing Issue

No governing issue is linked; this is an organization metadata hygiene update across public repositories.

## Validation

- [x] License file was added through GitHub contents API on a dedicated branch.
- [x] Verified the PR branch contains `LICENSE`.

## Bootstrap Governance

This change only adds repository licensing metadata and does not alter bootstrap behavior, generated policy, secrets, workflows, or runtime configuration.

## Merge Automation

Auto-merge is blocked until required checks and review policy are satisfied.

## Notes

Direct default-branch updates are blocked by branch protection, so this change is submitted as a narrow PR.
