### PR TITLE
Add flow governance templates

### DIFF
--- a/src/archetypes.ts
+++ b/src/archetypes.ts
@@ -377,6 +377,28 @@ function contributingDoc(manifest: BootstrapManifest): string {
   `;
 }
 
+function flowPullRequestSection(manifest: BootstrapManifest): string {
+  if (!manifest.github.flowGovernance) {
+    return "";
+  }
+
+  return dedent`
+    ## Flow Contract
+
+    - Owner lane:
+    - Repair owner:
+    - Autonomy class:
+    - Risk class:
+
+    ## Flow Merge Readiness
+
+    - [ ] Every blocker has a next actor and next action
+    - [ ] No active blocking requested changes remain
+    - [ ] Non-author approval is present when required
+    - [ ] Auto-merge is appropriate when gates pass
+  `;
+}
+
 function pullRequestTemplate(manifest: BootstrapManifest): string {
   return dedent`
     ## Summary
@@ -400,6 +422,8 @@ function pullRequestTemplate(manifest: BootstrapManifest): string {
     - [ ] Auto-merge is enabled, or GitHub plan-limit evidence is recorded and the fallback merge-readiness policy applies
     - [ ] No real secrets, runtime auth, or machine-local env files are committed
 
+${flowPullRequestSection(manifest)}
+
     ## Merge Automation
 
     - [ ] Auto-merge is enabled, or the reason it is unavailable or unsafe is noted below
@@ -407,6 +431,121 @@ function pullRequestTemplate(manifest: BootstrapManifest): string {
     ## Notes
 
     -
+  `;
+}
+
+function implementationIssueTemplate(): string {
+  return dedent`
+    name: Implementation work
+    description: Durable contract for autonomous or review-gated implementation work
+    title: ""
+    labels:
+      - state:intake
+    body:
+      - type: textarea
+        id: problem
+        attributes:
+          label: Problem / intent
+          description: What should change and why?
+        validations:
+          required: true
+      - type: textarea
+        id: acceptance
+        attributes:
+          label: Acceptance criteria
+          description: Concrete conditions that make this done.
+        validations:
+          required: true
+      - type: textarea
+        id: validation
+        attributes:
+          label: Validation commands
+          description: Commands or checks the worker should run.
+        validations:
+          required: true
+      - type: dropdown
+        id: autonomy
+        attributes:
+          label: Autonomy class
+          options:
+            - Class 0 - Observe only
+            - Class 1 - Safe autonomous
+            - Class 2 - Review-gated autonomous
+            - Class 3 - Human decision required
+            - Class 4 - Forbidden unattended
+        validations:
+          required: true
+      - type: dropdown
+        id: lane
+        attributes:
+          label: Recommended lane
+          options:
+            - Pheidon
+            - Apollo
+            - Ares
+            - Daedalus
+            - Hephaestus
+            - Hermes
+            - Human
+        validations:
+          required: true
+  `;
+}
+
+function flowBlockerIssueTemplate(): string {
+  return dedent`
+    name: Flow blocker
+    description: Record a blocked unit of work with a next actor and unblock target
+    title: "Flow blocker: "
+    labels:
+      - state:blocked-infra
+    body:
+      - type: textarea
+        id: blocked_item
+        attributes:
+          label: Blocked issue/PR
+          description: Link the blocked item.
+        validations:
+          required: true
+      - type: dropdown
+        id: blocked_type
+        attributes:
+          label: Blocker type
+          options:
+            - Human decision
+            - Infrastructure
+            - Scope
+            - Auth/credential
+            - External dependency
+        validations:
+          required: true
+      - type: textarea
+        id: evidence
+        attributes:
+          label: Evidence
+          description: Logs, checks, review comments, or command output proving the block.
+        validations:
+          required: true
+      - type: dropdown
+        id: next_actor
+        attributes:
+          label: Next actor
+          options:
+            - Pheidon
+            - Apollo
+            - Ares
+            - Daedalus
+            - Hephaestus
+            - Hermes
+            - Human
+        validations:
+          required: true
+      - type: textarea
+        id: unblock
+        attributes:
+          label: Required unblock action
+        validations:
+          required: true
   `;
 }
 
@@ -1528,6 +1667,20 @@ export function renderManagedFiles(manifest: BootstrapManifest): RenderedFile[] 
       reason: "Pull request guidance template",
       contents: `${pullRequestTemplate(manifest)}\n`
     },
+    ...(manifest.github.flowGovernance
+      ? [
+          {
+            path: ".github/ISSUE_TEMPLATE/implementation.yml",
+            reason: "Flow implementation issue template",
+            contents: `${implementationIssueTemplate()}\n`
+          },
+          {
+            path: ".github/ISSUE_TEMPLATE/flow_blocker.yml",
+            reason: "Flow blocker issue template",
+            contents: `${flowBlockerIssueTemplate()}\n`
+          }
+        ]
+      : []),
     {
       path: ".github/workflows/pr-fast-ci.yml",
       reason: "Fast pull request workflow",

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -44,6 +44,33 @@ export const DEFAULT_ISSUE_LABELS: IssueLabelConfig[] = [
   { name: "review:legal", color: "c2e0c6", description: "Needs legal review." },
   { name: "review:accessibility", color: "e99695", description: "Needs accessibility review." },
   { name: "review:release", color: "f9d0c4", description: "Needs release review." }
+ ];
+
+export const DEFAULT_FLOW_LABELS: IssueLabelConfig[] = [
+  { name: "lane:apollo", color: "8dd3c7", description: "Scope, backlog, synthesis, and issue-contract work." },
+  { name: "lane:ares", color: "fb8072", description: "Validation, adversarial review, and test-pressure work." },
+  { name: "lane:daedalus", color: "80b1d3", description: "Implementation and substantive code repair work." },
+  { name: "lane:hephaestus", color: "fdb462", description: "CI, build, lockfile, mergeability, and artifact work." },
+  { name: "lane:hermes", color: "bebada", description: "macOS/platform-native or special execution work." },
+  { name: "lane:pheidon", color: "b3de69", description: "Orchestration, gate, governance, and controller action." },
+  { name: "state:intake", color: "d9d9d9", description: "Captured but not yet planned." },
+  { name: "state:ready-for-planning", color: "ccebc5", description: "Ready for planning refinement." },
+  { name: "state:ready-for-implementation", color: "bc80bd", description: "Ready for assigned implementation." },
+  { name: "state:needs-review", color: "ffffb3", description: "Needs review before advancing." },
+  { name: "state:needs-repair", color: "fb8072", description: "Needs repair before advancing." },
+  { name: "state:repairing", color: "fdb462", description: "Repair is actively assigned." },
+  { name: "state:ready-for-approval", color: "b3de69", description: "Pheidon/gate approval is next." },
+  { name: "state:waiting-checks", color: "ffffb3", description: "Waiting on checks or merge queue." },
+  { name: "state:auto-merge-armed", color: "b3de69", description: "Auto-merge is enabled." },
+  { name: "state:blocked-human", color: "e41a1c", description: "Human decision required." },
+  { name: "state:blocked-infra", color: "984ea3", description: "Infrastructure/tooling/auth blocker." },
+  { name: "state:blocked-scope", color: "ff7f00", description: "Scope or acceptance criteria blocker." },
+  { name: "state:paused", color: "999999", description: "Intentionally paused." },
+  { name: "autonomy:observe", color: "d9d9d9", description: "Class 0; observe only." },
+  { name: "autonomy:safe", color: "b3de69", description: "Class 1; safe autonomous work allowed." },
+  { name: "autonomy:review-gated", color: "ffffb3", description: "Class 2; review-gated autonomous work." },
+  { name: "autonomy:human-required", color: "fb8072", description: "Class 3; human decision required." },
+  { name: "autonomy:forbidden-unattended", color: "000000", description: "Class 4; forbidden unattended." }
 ];
 
 const environmentSchema = z.object({
@@ -113,6 +140,7 @@ const manifestSchema = z.object({
       reviewers: z.array(z.string()).optional(),
       codeowners: z.array(codeownerSchema).optional(),
       issueLabels: z.array(issueLabelSchema).optional(),
+      flowGovernance: z.boolean().optional(),
       organization: organizationSchema.optional(),
       autoMerge: z.boolean().optional(),
       deleteBranchOnMerge: z.boolean().optional(),
@@ -245,13 +273,24 @@ function normalizeCodeowners(
 }
 
 function normalizeIssueLabels(
-  labels: z.input<typeof issueLabelSchema>[] | undefined
+  labels: z.input<typeof issueLabelSchema>[] | undefined,
+  flowGovernance: boolean
 ): IssueLabelConfig[] {
-  return (labels ?? DEFAULT_ISSUE_LABELS).map((label) => ({
-    name: label.name.trim(),
-    color: label.color.replace(/^#/, "").toLowerCase(),
-    description: label.description.trim()
-  }));
+  const base = labels ?? DEFAULT_ISSUE_LABELS;
+  const merged = flowGovernance ? [...base, ...DEFAULT_FLOW_LABELS] : base;
+  const seen = new Set<string>();
+  return merged
+    .filter((label) => {
+      const name = label.name.trim();
+      if (seen.has(name)) return false;
+      seen.add(name);
+      return true;
+    })
+    .map((label) => ({
+      name: label.name.trim(),
+      color: label.color.replace(/^#/, "").toLowerCase(),
+      description: label.description.trim()
+    }));
 }
 
 function normalizeOrganization(
@@ -304,6 +343,7 @@ export function normalizeManifest(raw: z.input<typeof manifestSchema>): Bootstra
   const github = parsed.github ?? {};
   const organization = normalizeOrganization(github.organization);
   const repoFeatures = github.repoFeatures ?? {};
+  const flowGovernance = github.flowGovernance ?? false;
   const environments = parsed.environments ?? {};
 
   const defaultEnvironment = (overrides?: z.input<typeof environmentSchema>): EnvironmentConfig => ({
@@ -337,7 +377,8 @@ export function normalizeManifest(raw: z.input<typeof manifestSchema>): Bootstra
       createRepo: github.createRepo ?? true,
       reviewers,
       codeowners: normalizeCodeowners(github.codeowners ?? [], reviewers),
-      issueLabels: normalizeIssueLabels(github.issueLabels),
+      issueLabels: normalizeIssueLabels(github.issueLabels, flowGovernance),
+      flowGovernance,
       ...(organization ? { organization } : {}),
       autoMerge: github.autoMerge ?? true,
       deleteBranchOnMerge: github.deleteBranchOnMerge ?? true,

--- a/src/types.ts
+++ b/src/types.ts
@@ -69,6 +69,7 @@ export interface BootstrapManifest {
     reviewers: string[];
     codeowners: CodeownerRule[];
     issueLabels: IssueLabelConfig[];
+    flowGovernance: boolean;
     organization?: OrganizationConfig;
     autoMerge: boolean;
     deleteBranchOnMerge: boolean;

--- a/tests/render.test.ts
+++ b/tests/render.test.ts
@@ -225,4 +225,34 @@ describe("renderManagedFiles", () => {
     expect(onboarding?.contents).toContain("Do not repurpose them as the required PR gate");
     expect(prWorkflow?.contents).toContain("name: CI Gate");
   });
+
+  it("renders flow governance labels and templates when enabled", () => {
+    const manifest = normalizeManifest({
+      project: {
+        name: "flow-enabled-repo",
+        owner: "acme"
+      },
+      archetype: {
+        kind: "generic-empty"
+      },
+      github: {
+        flowGovernance: true
+      }
+    });
+
+    const files = renderManagedFiles(manifest);
+    const prTemplate = files.find((file) => file.path === ".github/PULL_REQUEST_TEMPLATE.md");
+    const implementation = files.find((file) => file.path === ".github/ISSUE_TEMPLATE/implementation.yml");
+    const blocker = files.find((file) => file.path === ".github/ISSUE_TEMPLATE/flow_blocker.yml");
+
+    expect(manifest.github.issueLabels.some((label) => label.name === "state:needs-repair")).toBe(true);
+    expect(manifest.github.issueLabels.some((label) => label.name === "lane:daedalus")).toBe(true);
+    expect(prTemplate?.contents).toContain("\n## Flow Contract\n");
+    expect(prTemplate?.contents).toContain("\n- [ ] Auto-merge is appropriate when gates pass");
+    expect(prTemplate?.contents).not.toContain("    ## Flow Contract");
+    expect(implementation?.contents).toContain("Autonomy class");
+    expect(implementation?.contents).toContain("Recommended lane");
+    expect(blocker?.contents).toContain("Required unblock action");
+  });
+
 });


### PR DESCRIPTION
## Summary

- Add bootstrap support for OMT-Global flow governance surfaces.
- Add `github.flowGovernance` manifest support.
- When enabled, bootstrap renders flow issue templates, appends PR flow-contract sections, and includes canonical lane/state/autonomy labels.

## Governing Issue

No governing issue is linked; this is part of the approved autonomous flow platform rollout from JT.

## Validation

- [x] `npm run check`
- [x] `npm run build`
- [x] `npm run dev -- plan --manifest /home/pheidon/src/omt-global/flow/project.bootstrap.yaml --target /home/pheidon/src/omt-global/flow`

## Bootstrap Governance

- [x] Changes are scoped to the flow governance rollout.
- [x] Contributor/PR guidance changes are reflected through generated PR and issue-template surfaces.
- [x] No real secrets, runtime auth, or machine-local env files are committed.

## Merge Automation

- Auto-merge is blocked until checks pass and a valid non-author approval is present.

## Notes

- `OMT-Global/flow` now exists and uses `github.flowGovernance: true` in its manifest.
- Local Axiom pilot applied flow labels to PRs #531, #530, and #517.
