### PR TITLE
chore: add Pheidon as code owner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @jmcte
+* @jmcte @pheidon


### PR DESCRIPTION
## Summary

- Add `@pheidon` alongside `@jmcte` in `CODEOWNERS` so Pheidon can satisfy code-owner review requirements where appropriate.

## Governing Issue

No governing issue is linked; this is a small operator-requested repository governance update.

## Validation

- [x] Inspected `CODEOWNERS` directly.
- [x] Verified GitHub reports no CODEOWNERS parsing errors.
- [x] Required PR checks are expected to satisfy `CI Gate` after this body correction.

## Bootstrap Governance

- [x] Changes are scoped to the requested code-owner update.
- [x] Contributor or PR guidance changes are not applicable; this only changes repository code-owner routing.
- [x] Auto-merge is enabled.
- [x] No real secrets, runtime auth, or machine-local env files are committed.

## Merge Automation

- [x] Auto-merge is enabled.

## Notes

- `@jmcte` remains a code owner.
- Because Pheidon authored/pushed this PR, John should approve this one under the independent/last-push approval rule.
