### PR TITLE
Render release version, artifact, and changelog automation

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,19 @@
+changelog:
+  categories:
+    - title: Features
+      labels:
+        - "type:feature"
+    - title: Fixes
+      labels:
+        - "type:bug"
+    - title: Operations
+      labels:
+        - "area:infra"
+        - "area:qa"
+    - title: Documentation
+      labels:
+        - "kind:docs"
+        - "documentation"
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -16,7 +16,11 @@ jobs:
     with:
       runs-on: '["ubuntu-latest"]'
       verify-script: scripts/ci/run-release-verification.sh
+      version-script: scripts/ci/run-release-version.sh
+      build-script: scripts/ci/run-release-build.sh
       publish-script: scripts/ci/run-release-publish.sh
+      release-notes-file: dist/release/RELEASE_NOTES.md
+      artifact-dir: dist/release
       create-github-release: true
       tag-prefix: 'v'
       update-major-tag: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,11 @@ on:
         required: false
         default: "dist/release/RELEASE_NOTES.md"
         type: string
+      artifact-dir:
+        description: Directory whose files are uploaded as GitHub Release assets
+        required: false
+        default: "dist/release"
+        type: string
       default-branch:
         description: Default release branch for new minor and major releases
         required: false
@@ -151,6 +156,28 @@ jobs:
             exit 1
           fi
           bash "${{ inputs.publish-script }}"
+      - name: Generate release notes
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ steps.release_meta.outputs.tag }}
+          PREVIOUS_TAG: ${{ steps.release_meta.outputs.previous_tag }}
+          NOTES_FILE: ${{ inputs.release-notes-file }}
+        run: |
+          set -euo pipefail
+
+          mkdir -p "$(dirname "${NOTES_FILE}")"
+
+          args=(--method POST "repos/${GITHUB_REPOSITORY}/releases/generate-notes" -f "tag_name=${RELEASE_TAG}")
+          if [[ -n "${PREVIOUS_TAG}" ]]; then
+            args+=(-f "previous_tag_name=${PREVIOUS_TAG}")
+          fi
+
+          if gh api "${args[@]}" --jq '.body' > "${NOTES_FILE}" && [[ -s "${NOTES_FILE}" ]]; then
+            echo "Wrote categorized release notes to ${NOTES_FILE}."
+          else
+            echo "Falling back to a minimal release notes file for ${RELEASE_TAG}." >&2
+            printf '# %s\n' "${RELEASE_TAG}" > "${NOTES_FILE}"
+          fi
       - name: Create GitHub release
         if: ${{ inputs.create-github-release }}
         env:
@@ -168,6 +195,19 @@ jobs:
           else
             gh release create "${tag}" --generate-notes ||
               gh release edit "${tag}" --latest
+          fi
+
+          artifact_dir="${{ inputs.artifact-dir }}"
+          if [[ -d "${artifact_dir}" ]]; then
+            mapfile -t assets < <(find "${artifact_dir}" -maxdepth 1 -type f | sort)
+            if [[ ${#assets[@]} -gt 0 ]]; then
+              gh release upload "${tag}" "${assets[@]}" --clobber
+              echo "Uploaded ${#assets[@]} release asset(s) from ${artifact_dir}."
+            else
+              echo "No release assets found in ${artifact_dir}; skipping asset upload."
+            fi
+          else
+            echo "Artifact directory ${artifact_dir} does not exist; skipping asset upload."
           fi
       - name: Promote floating SemVer tags
         env:

--- a/docs/bootstrap/tier-a-ci-contract.md
+++ b/docs/bootstrap/tier-a-ci-contract.md
@@ -17,7 +17,10 @@ This document is the control-plane contract for Tier A `OMT-Global` repos.
   - Carries slower repo-specific validation
 - `release`
   - Reusable workflow
-  - Separates verification from publish
+  - Separates verification, version validation, build, and publish
+  - Validates repo version surfaces (`package.json`, `pyproject.toml`, container metadata) against the pushed tag before build
+  - Builds `dist/release/` artifacts, generates SHA256 checksums, and uploads them as release assets
+  - Generates categorized release notes from `.github/release.yml` and writes them to `dist/release/RELEASE_NOTES.md`
   - Promotes floating `vX.Y` and `vX` tags from immutable exact `vX.Y.Z` tags
   - Uses OIDC-capable permissions by default
 - `ai-attestation`
@@ -69,7 +72,11 @@ jobs:
     with:
       runs-on: '["ubuntu-latest"]'
       verify-script: scripts/ci/run-release-verification.sh
+      version-script: scripts/ci/run-release-version.sh
+      build-script: scripts/ci/run-release-build.sh
       publish-script: scripts/ci/run-release-publish.sh
+      release-notes-file: dist/release/RELEASE_NOTES.md
+      artifact-dir: dist/release
       create-github-release: true
       tag-prefix: v
       update-major-tag: true
@@ -81,6 +88,8 @@ Release policy:
 - create immutable exact tags such as `v1.2.3`
 - let automation advance `v1.2` and `v1` to that same commit
 - cut patch releases from `release/X.Y`, and cut new minor or major releases from `main`
+- land version bumps in a pull request before tagging; the release workflow validates, it does not create post-tag commits
+- configure version surfaces, artifact directory, checksums, and changelog categories under `release` in `project.bootstrap.yaml`
 
 Example AI attestation caller:
 

--- a/docs/bootstrap/versioning.md
+++ b/docs/bootstrap/versioning.md
@@ -20,5 +20,29 @@ Consumers should prefer `v1` for the default compatibility channel, `v1.2` when 
 
 - `.github/workflows/release-tag.yml` runs when an exact SemVer tag matching `v*.*.*` is pushed.
 - `scripts/ci/run-release-verification.sh` runs the repo release gate before publication.
+- `scripts/ci/run-release-version.sh` validates that the repo version surfaces match the pushed tag before build and publish.
+- `scripts/ci/run-release-build.sh` populates the release artifact directory and writes SHA256 checksums when enabled.
 - `scripts/ci/run-release-publish.sh` is the repo hook for artifact publication; the generated default is a no-op until the repo needs more than GitHub releases.
 - The shared reusable release workflow creates or updates the GitHub release and then advances the floating compatibility tags when enabled in `project.bootstrap.yaml`.
+
+## Version Validation
+
+- Version bumps land in a normal pull request before the release tag is pushed; the workflow never creates post-tag commits.
+- Configure version surfaces under `release.versions` in `project.bootstrap.yaml` with a `type` of `npm`, `python`, or `container` and the file `path`.
+- `scripts/ci/run-release-version.sh` fails the release when a configured `package.json` or `pyproject.toml` version does not equal the tag (with the `v` prefix stripped). Container surfaces are derived from the tag at publish time.
+- With no configured surfaces the hook prints an explicit no-op rather than silently passing.
+
+## Release Artifacts
+
+- The default release artifact directory is `dist/release/`.
+- `scripts/ci/run-release-build.sh` is where repo-specific build steps populate that directory; with no artifacts it prints an explicit no-op message instead of failing silently.
+- Checksum generation is `sha256`; when set to `sha256` a `SHA256SUMS` file is written alongside the artifacts.
+- The reusable workflow uploads every file in the artifact directory to the GitHub Release.
+- SBOM/provenance is `optional` and is designed into the manifest for repos that opt in.
+
+## Release Notes
+
+- Release notes are generated automatically for every exact tag from changes since the previous exact SemVer tag.
+- The default implementation uses GitHub generated notes; `.github/release.yml` maps bootstrap labels to categories.
+- Override categories under `release.changelog.categories` in `project.bootstrap.yaml`. The default categories are Features, Fixes, Operations, and Documentation, with everything else under Other Changes.
+- The reusable workflow writes the notes to `dist/release/RELEASE_NOTES.md` before creating the GitHub Release.

--- a/scripts/ci/run-release-build.sh
+++ b/scripts/ci/run-release-build.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+artifact_dir="dist/release"
+mkdir -p "${artifact_dir}"
+
+# Add repo-specific build steps above this line to populate ${artifact_dir}
+# with downloadable release assets before checksums are generated.
+
+mapfile -t artifacts < <(find "${artifact_dir}" -maxdepth 1 -type f ! -name SHA256SUMS | sort)
+if [[ ${#artifacts[@]} -eq 0 ]]; then
+  echo "No release artifacts were produced in ${artifact_dir}."
+  echo "This repo ships no downloadable assets; add build steps to scripts/ci/run-release-build.sh when it does."
+  exit 0
+fi
+(
+  cd "${artifact_dir}"
+  : > SHA256SUMS
+  for entry in "${artifacts[@]}"; do
+    sha256sum -- "${entry#"${artifact_dir}/"}" >> SHA256SUMS
+  done
+)
+echo "Wrote ${artifact_dir}/SHA256SUMS for ${#artifacts[@]} artifact(s)."

--- a/scripts/ci/run-release-version.sh
+++ b/scripts/ci/run-release-version.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+tag="${GITHUB_REF_NAME:-}"
+if [[ -z "${tag}" ]]; then
+  echo "GITHUB_REF_NAME is required to validate release versions." >&2
+  exit 1
+fi
+prefix="v"
+version="${tag#"${prefix}"}"
+
+echo "No release version surfaces are configured in project.bootstrap.yaml."
+echo "Skipping version validation for ${tag}; version bump pull requests must merge before the release tag is pushed."

--- a/src/archetypes.ts
+++ b/src/archetypes.ts
@@ -980,6 +980,128 @@ function releasePublishScript(manifest: BootstrapManifest): string {
   `}\n`;
 }
 
+function releaseVersionScript(manifest: BootstrapManifest): string {
+  const prefix = manifest.release.tagPrefix;
+  const versions = manifest.release.versions;
+
+  const header = dedent`
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    tag="\${GITHUB_REF_NAME:-}"
+    if [[ -z "\${tag}" ]]; then
+      echo "GITHUB_REF_NAME is required to validate release versions." >&2
+      exit 1
+    fi
+    prefix="${prefix}"
+    version="\${tag#"\${prefix}"}"
+  `;
+
+  if (versions.length === 0) {
+    return `${header}\n\n${dedent`
+      echo "No release version surfaces are configured in project.bootstrap.yaml."
+      echo "Skipping version validation for \${tag}; version bump pull requests must merge before the release tag is pushed."
+    `}\n`;
+  }
+
+  const blocks = versions.map((entry) => {
+    if (entry.type === "npm") {
+      return dedent`
+        npm_file="${entry.path}"
+        if [[ ! -f "\${npm_file}" ]]; then
+          echo "Expected npm version file \${npm_file} is missing." >&2
+          exit 1
+        fi
+        npm_version="$(grep -m1 -oE '"version"[[:space:]]*:[[:space:]]*"[^"]+"' "\${npm_file}" | sed -E 's/.*"([^"]+)"[[:space:]]*$/\\1/')"
+        if [[ "\${npm_version}" != "\${version}" ]]; then
+          echo "\${npm_file} version \${npm_version} does not match release tag \${tag} (expected \${version})." >&2
+          echo "Land the version bump in a pull request before pushing the release tag." >&2
+          exit 1
+        fi
+        echo "\${npm_file} matches \${tag}."
+      `;
+    }
+
+    if (entry.type === "python") {
+      return dedent`
+        py_file="${entry.path}"
+        if [[ ! -f "\${py_file}" ]]; then
+          echo "Expected Python version file \${py_file} is missing." >&2
+          exit 1
+        fi
+        py_version="$(grep -m1 -oE '^[[:space:]]*version[[:space:]]*=[[:space:]]*"[^"]+"' "\${py_file}" | sed -E 's/.*"([^"]+)".*/\\1/')"
+        if [[ "\${py_version}" != "\${version}" ]]; then
+          echo "\${py_file} version \${py_version} does not match release tag \${tag} (expected \${version})." >&2
+          echo "Land the version bump in a pull request before pushing the release tag." >&2
+          exit 1
+        fi
+        echo "\${py_file} matches \${tag}."
+      `;
+    }
+
+    return dedent`
+      echo "Container release version for ${entry.path} is derived from \${tag} at publish time; no in-repo file to validate."
+    `;
+  });
+
+  return `${header}\n\n${blocks.join("\n\n")}\n`;
+}
+
+function releaseBuildScript(manifest: BootstrapManifest): string {
+  const dir = manifest.release.artifacts.directory;
+  const checksumBlock =
+    manifest.release.artifacts.checksum === "sha256"
+      ? dedent`
+          (
+            cd "\${artifact_dir}"
+            : > SHA256SUMS
+            for entry in "\${artifacts[@]}"; do
+              sha256sum -- "\${entry#"\${artifact_dir}/"}" >> SHA256SUMS
+            done
+          )
+          echo "Wrote \${artifact_dir}/SHA256SUMS for \${#artifacts[@]} artifact(s)."
+        `
+      : dedent`
+          echo "Checksum generation is disabled in project.bootstrap.yaml; skipping SHA256SUMS."
+        `;
+
+  return `${dedent`
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    artifact_dir="${dir}"
+    mkdir -p "\${artifact_dir}"
+
+    # Add repo-specific build steps above this line to populate \${artifact_dir}
+    # with downloadable release assets before checksums are generated.
+
+    mapfile -t artifacts < <(find "\${artifact_dir}" -maxdepth 1 -type f ! -name SHA256SUMS | sort)
+    if [[ \${#artifacts[@]} -eq 0 ]]; then
+      echo "No release artifacts were produced in \${artifact_dir}."
+      echo "This repo ships no downloadable assets; add build steps to scripts/ci/run-release-build.sh when it does."
+      exit 0
+    fi
+  `}\n${checksumBlock}\n`;
+}
+
+function releaseChangelogConfig(manifest: BootstrapManifest): string {
+  const categories = [
+    ...manifest.release.changelog.categories,
+    { title: "Other Changes", labels: ["*"] }
+  ];
+
+  const body = categories
+    .map(
+      (category) =>
+        `    - title: ${category.title}\n      labels:\n${category.labels
+          .map((label) => `        - "${label}"`)
+          .join("\n")}`
+    )
+    .join("\n");
+
+  return `changelog:\n  categories:\n${body}\n`;
+}
+
 function nextJsStarter(): RenderedFile[] {
   return [
     {
@@ -1284,7 +1406,11 @@ function releaseCallerWorkflow(manifest: BootstrapManifest): string {
         with:
           runs-on: '["ubuntu-latest"]'
           verify-script: scripts/ci/run-release-verification.sh
+          version-script: scripts/ci/run-release-version.sh
+          build-script: scripts/ci/run-release-build.sh
           publish-script: scripts/ci/run-release-publish.sh
+          release-notes-file: ${manifest.release.artifacts.directory}/RELEASE_NOTES.md
+          artifact-dir: ${manifest.release.artifacts.directory}
           create-github-release: ${manifest.release.createGitHubRelease ? "true" : "false"}
           tag-prefix: '${manifest.release.tagPrefix}'
           update-major-tag: ${manifest.release.updateMajorTag ? "true" : "false"}
@@ -1694,8 +1820,32 @@ function releaseVersioningDoc(manifest: BootstrapManifest): string {
 
     - \`.github/workflows/release-tag.yml\` runs when an exact SemVer tag matching \`${manifest.release.tagPrefix}*.*.*\` is pushed.
     - \`scripts/ci/run-release-verification.sh\` runs the repo release gate before publication.
+    - \`scripts/ci/run-release-version.sh\` validates that the repo version surfaces match the pushed tag before build and publish.
+    - \`scripts/ci/run-release-build.sh\` populates the release artifact directory and writes SHA256 checksums when enabled.
     - \`scripts/ci/run-release-publish.sh\` is the repo hook for artifact publication; the generated default is a no-op until the repo needs more than GitHub releases.
     - The shared reusable release workflow creates or updates the GitHub release and then advances the floating compatibility tags when enabled in \`project.bootstrap.yaml\`.
+
+    ## Version Validation
+
+    - Version bumps land in a normal pull request before the release tag is pushed; the workflow never creates post-tag commits.
+    - Configure version surfaces under \`release.versions\` in \`project.bootstrap.yaml\` with a \`type\` of \`npm\`, \`python\`, or \`container\` and the file \`path\`.
+    - \`scripts/ci/run-release-version.sh\` fails the release when a configured \`package.json\` or \`pyproject.toml\` version does not equal the tag (with the \`${manifest.release.tagPrefix}\` prefix stripped). Container surfaces are derived from the tag at publish time.
+    - With no configured surfaces the hook prints an explicit no-op rather than silently passing.
+
+    ## Release Artifacts
+
+    - The default release artifact directory is \`${manifest.release.artifacts.directory}/\`.
+    - \`scripts/ci/run-release-build.sh\` is where repo-specific build steps populate that directory; with no artifacts it prints an explicit no-op message instead of failing silently.
+    - Checksum generation is \`${manifest.release.artifacts.checksum}\`; when set to \`sha256\` a \`SHA256SUMS\` file is written alongside the artifacts.
+    - The reusable workflow uploads every file in the artifact directory to the GitHub Release.
+    - SBOM/provenance is \`${manifest.release.artifacts.sbom}\` and is designed into the manifest for repos that opt in.
+
+    ## Release Notes
+
+    - Release notes are generated automatically for every exact tag from changes since the previous exact SemVer tag.
+    - The default implementation uses GitHub generated notes; \`.github/release.yml\` maps bootstrap labels to categories.
+    - Override categories under \`release.changelog.categories\` in \`project.bootstrap.yaml\`. The default categories are Features, Fixes, Operations, and Documentation, with everything else under Other Changes.
+    - The reusable workflow writes the notes to \`${manifest.release.artifacts.directory}/RELEASE_NOTES.md\` before creating the GitHub Release.
   `;
 }
 
@@ -1789,6 +1939,15 @@ export function renderManagedFiles(manifest: BootstrapManifest): RenderedFile[] 
           }
         ]
       : []),
+    ...(manifest.release.enabled && manifest.release.changelog.enabled
+      ? [
+          {
+            path: ".github/release.yml",
+            reason: "Categorized release notes configuration",
+            contents: releaseChangelogConfig(manifest)
+          }
+        ]
+      : []),
     ...(manifest.ci.aiAttestation.enabled
       ? [
           {
@@ -1822,6 +1981,18 @@ export function renderManagedFiles(manifest: BootstrapManifest): RenderedFile[] 
             path: "scripts/ci/run-release-verification.sh",
             reason: "Release verification entrypoint",
             contents: releaseVerificationScript(manifest),
+            executable: true
+          },
+          {
+            path: "scripts/ci/run-release-version.sh",
+            reason: "Release version validation entrypoint",
+            contents: releaseVersionScript(manifest),
+            executable: true
+          },
+          {
+            path: "scripts/ci/run-release-build.sh",
+            reason: "Release artifact build entrypoint",
+            contents: releaseBuildScript(manifest),
             executable: true
           },
           {

--- a/tests/__snapshots__/render.test.ts.snap
+++ b/tests/__snapshots__/render.test.ts.snap
@@ -55,6 +55,10 @@ exports[`renderManagedFiles > renders a stable managed file set for generic-empt
     "path": ".github/workflows/release-tag.yml",
   },
   {
+    "executable": false,
+    "path": ".github/release.yml",
+  },
+  {
     "executable": true,
     "path": "scripts/check-detect-secrets.sh",
   },
@@ -69,6 +73,14 @@ exports[`renderManagedFiles > renders a stable managed file set for generic-empt
   {
     "executable": true,
     "path": "scripts/ci/run-release-verification.sh",
+  },
+  {
+    "executable": true,
+    "path": "scripts/ci/run-release-version.sh",
+  },
+  {
+    "executable": true,
+    "path": "scripts/ci/run-release-build.sh",
   },
   {
     "executable": true,
@@ -156,6 +168,10 @@ exports[`renderManagedFiles > renders a stable managed file set for nextjs-web 1
     "path": ".github/workflows/release-tag.yml",
   },
   {
+    "executable": false,
+    "path": ".github/release.yml",
+  },
+  {
     "executable": true,
     "path": "scripts/check-detect-secrets.sh",
   },
@@ -170,6 +186,14 @@ exports[`renderManagedFiles > renders a stable managed file set for nextjs-web 1
   {
     "executable": true,
     "path": "scripts/ci/run-release-verification.sh",
+  },
+  {
+    "executable": true,
+    "path": "scripts/ci/run-release-version.sh",
+  },
+  {
+    "executable": true,
+    "path": "scripts/ci/run-release-build.sh",
   },
   {
     "executable": true,
@@ -265,6 +289,10 @@ exports[`renderManagedFiles > renders a stable managed file set for node-ts-serv
     "path": ".github/workflows/release-tag.yml",
   },
   {
+    "executable": false,
+    "path": ".github/release.yml",
+  },
+  {
     "executable": true,
     "path": "scripts/check-detect-secrets.sh",
   },
@@ -279,6 +307,14 @@ exports[`renderManagedFiles > renders a stable managed file set for node-ts-serv
   {
     "executable": true,
     "path": "scripts/ci/run-release-verification.sh",
+  },
+  {
+    "executable": true,
+    "path": "scripts/ci/run-release-version.sh",
+  },
+  {
+    "executable": true,
+    "path": "scripts/ci/run-release-build.sh",
   },
   {
     "executable": true,
@@ -366,6 +402,10 @@ exports[`renderManagedFiles > renders a stable managed file set for python-servi
     "path": ".github/workflows/release-tag.yml",
   },
   {
+    "executable": false,
+    "path": ".github/release.yml",
+  },
+  {
     "executable": true,
     "path": "scripts/check-detect-secrets.sh",
   },
@@ -380,6 +420,14 @@ exports[`renderManagedFiles > renders a stable managed file set for python-servi
   {
     "executable": true,
     "path": "scripts/ci/run-release-verification.sh",
+  },
+  {
+    "executable": true,
+    "path": "scripts/ci/run-release-version.sh",
+  },
+  {
+    "executable": true,
+    "path": "scripts/ci/run-release-build.sh",
   },
   {
     "executable": true,

--- a/tests/render.test.ts
+++ b/tests/render.test.ts
@@ -251,7 +251,10 @@ describe("renderManagedFiles", () => {
     const files = renderManagedFiles(manifest);
     const releaseWorkflow = files.find((file) => file.path === ".github/workflows/release-tag.yml");
     const verifyScript = files.find((file) => file.path === "scripts/ci/run-release-verification.sh");
+    const versionScript = files.find((file) => file.path === "scripts/ci/run-release-version.sh");
+    const buildScript = files.find((file) => file.path === "scripts/ci/run-release-build.sh");
     const publishScript = files.find((file) => file.path === "scripts/ci/run-release-publish.sh");
+    const changelogConfig = files.find((file) => file.path === ".github/release.yml");
     const versioningDoc = files.find((file) => file.path === "docs/bootstrap/versioning.md");
 
     expect(releaseWorkflow?.contents).toContain("name: Release");
@@ -259,10 +262,51 @@ describe("renderManagedFiles", () => {
       "uses: OMT-Global/bootstrap/.github/workflows/release.yml@refs/tags/v1"
     );
     expect(releaseWorkflow?.contents).toContain("tag-prefix: 'v'");
+    expect(releaseWorkflow?.contents).toContain("version-script: scripts/ci/run-release-version.sh");
+    expect(releaseWorkflow?.contents).toContain("build-script: scripts/ci/run-release-build.sh");
+    expect(releaseWorkflow?.contents).toContain("artifact-dir: dist/release");
     expect(verifyScript?.contents).toContain("bash scripts/ci/run-fast-checks.sh");
+    expect(versionScript?.contents).toContain("No release version surfaces are configured");
+    expect(versionScript?.contents).toContain('version="${tag#"${prefix}"}"');
+    expect(buildScript?.contents).toContain('artifact_dir="dist/release"');
+    expect(buildScript?.contents).toContain("SHA256SUMS");
+    expect(buildScript?.contents).toContain("No release artifacts were produced");
     expect(publishScript?.contents).toContain("Create exact release tags such as v1.2.3");
+    expect(changelogConfig?.contents).toContain("changelog:");
+    expect(changelogConfig?.contents).toContain("- title: Features");
+    expect(changelogConfig?.contents).toContain('- "*"');
     expect(versioningDoc?.contents).toContain("Semantic Versioning");
     expect(versioningDoc?.contents).toContain("release/X.Y");
+    expect(versioningDoc?.contents).toContain("Version Validation");
+    expect(versioningDoc?.contents).toContain("Release Artifacts");
+    expect(versioningDoc?.contents).toContain("Release Notes");
+  });
+
+  it("renders npm and python version validation in the release version hook", () => {
+    const manifest = normalizeManifest({
+      project: {
+        name: "versioned-repo",
+        owner: "acme"
+      },
+      archetype: {
+        kind: "node-ts-service"
+      },
+      release: {
+        enabled: true,
+        versions: [
+          { type: "npm", path: "package.json" },
+          { type: "python", path: "pyproject.toml" }
+        ]
+      }
+    });
+
+    const files = renderManagedFiles(manifest);
+    const versionScript = files.find((file) => file.path === "scripts/ci/run-release-version.sh");
+
+    expect(versionScript?.contents).toContain('npm_file="package.json"');
+    expect(versionScript?.contents).toContain('py_file="pyproject.toml"');
+    expect(versionScript?.contents).toContain("does not match release tag");
+    expect(versionScript?.contents).not.toContain("No release version surfaces are configured");
   });
 
   it("documents repo-specific workflow lanes without replacing the standard CI frame", () => {

--- a/tests/reusable-workflows.test.ts
+++ b/tests/reusable-workflows.test.ts
@@ -27,6 +27,7 @@ describe("reusable workflows", () => {
     expect((workflow.on as any).workflow_call.inputs["release-notes-file"].default).toBe(
       "dist/release/RELEASE_NOTES.md"
     );
+    expect((workflow.on as any).workflow_call.inputs["artifact-dir"].default).toBe("dist/release");
     expect((workflow.on as any).workflow_call.inputs["tag-prefix"].default).toBe("v");
     expect((workflow.on as any).workflow_call.inputs["update-major-tag"].default).toBe(true);
     const releaseJob = (workflow.jobs as any).release;
@@ -38,6 +39,7 @@ describe("reusable workflows", () => {
       "Run release version hook",
       "Build release artifacts",
       "Publish release artifacts",
+      "Generate release notes",
       "Create GitHub release",
       "Promote floating SemVer tags"
     ]);


### PR DESCRIPTION
## Summary

Builds on the release manifest schema (#29) and reusable workflow orchestration (#30) to render the remaining release automation into managed files.

- **#25** - generated `scripts/ci/run-release-version.sh`: validates `package.json` / `pyproject.toml` versions against the pushed tag; explicit no-op when no surfaces are configured; never creates post-tag commits.
- **#24** - generated `scripts/ci/run-release-build.sh`: `dist/release/` default directory, SHA256SUMS when enabled, explicit no-op message when no artifacts; reusable workflow uploads artifact-dir files as release assets.
- **#23** - generated `.github/release.yml` categorized changelog config from the manifest; reusable workflow adds a "Generate release notes" step writing `dist/release/RELEASE_NOTES.md` before the GitHub release.
- **#26** - wired the release caller workflow, expanded `docs/bootstrap/versioning.md` and `docs/bootstrap/tier-a-ci-contract.md`, updated render snapshots and tests.

## Governing Issue

Closes #23
Closes #24
Closes #25
Closes #26

## Validation

- [x] PR Fast CI Fast Checks passed on commit `58e1bda3ea836feb12b5c4e2b7591eec9136164c`.
- [x] AI Attestation passed on commit `58e1bda3ea836feb12b5c4e2b7591eec9136164c`.
- [x] Generated release scripts, changelog config, reusable workflow updates, docs, and snapshots are included in the PR diff.

## Bootstrap Governance

This PR keeps release automation generated from the bootstrap manifest path and documents the Tier-A CI/versioning contract. It does not add unmanaged post-tag mutation; release validation and artifact generation happen inside the generated workflow surfaces.

## Merge Automation

Auto-merge is currently blocked by the required PR description gate. Once this body update passes CI and branch protection remains satisfied, auto-merge can be enabled safely.

## Notes

https://claude.ai/code/session_0123FockikrY2yTgCvEjhPKZ

---
_Generated by [Claude Code](https://claude.ai/code/session_0123FockikrY2yTgCvEjhPKZ)_
