### PR TITLE
Normalize CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,2 @@
-* @jmcte @pheidon
+# Managed CODEOWNERS for OMT-Global native repos.
+* @pheidon @jmcte


### PR DESCRIPTION
## Summary

- Normalizes root CODEOWNERS ordering to list Pheidon before JMCTE for the managed native repo ownership policy.
- Adds an explicit managed-file comment so future updates keep CODEOWNERS aligned with bootstrap governance.

## Governing Issue

No governing issue is linked; this is a narrow ownership metadata normalization for an already-open governance PR.

## Validation

- [x] PR Fast CI already passed Fast Checks on commit `21103e27bee465e961146c42cf14560fd55a69a1`.
- [x] PR Fast CI already passed Validate Secrets on commit `21103e27bee465e961146c42cf14560fd55a69a1`.
- [x] This PR body update is expected to satisfy Validate PR Description and unblock CI Gate.

## Bootstrap Governance

- [x] Changes are scoped to CODEOWNERS governance metadata.
- [x] Contributor or PR guidance changes are not applicable.
- [ ] Auto-merge is enabled, or GitHub plan-limit evidence is recorded and the fallback merge-readiness policy applies.
- [x] No real secrets, runtime auth, or machine-local env files are committed.

## Merge Automation

- Auto-merge is currently blocked until Validate PR Description and CI Gate rerun successfully.

## Notes

- PR is approved and GitHub reports the branch as mergeable; the remaining blocker is the PR description gate.
