### PR TITLE
Allow prerelease release tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,14 +91,21 @@ jobs:
           escaped_prefix="$(printf '%s' "${prefix}" | sed 's/[][(){}.^$*+?|\\-]/\\&/g')"
 
           semver_component='(0|[1-9][0-9]*)'
-          if [[ ! "${tag}" =~ ^${escaped_prefix}${semver_component}\.${semver_component}\.${semver_component}$ ]]; then
-            echo "Release tag '${tag}' does not match the required exact SemVer pattern '${prefix}X.Y.Z'." >&2
+          prerelease_identifier='(0|[1-9][0-9]*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*)'
+          prerelease_pattern="(-${prerelease_identifier}(\.${prerelease_identifier})*)?"
+          if [[ ! "${tag}" =~ ^${escaped_prefix}${semver_component}\.${semver_component}\.${semver_component}${prerelease_pattern}$ ]]; then
+            echo "Release tag '${tag}' does not match the required SemVer pattern '${prefix}X.Y.Z[-prerelease]'." >&2
             exit 1
           fi
 
           major="${BASH_REMATCH[1]}"
           minor="${BASH_REMATCH[2]}"
           patch="${BASH_REMATCH[3]}"
+          prerelease="${BASH_REMATCH[4]:-}"
+          is_prerelease=false
+          if [[ -n "${prerelease}" ]]; then
+            is_prerelease=true
+          fi
           commit="$(git rev-list -n 1 "${tag}")"
 
           git fetch origin "+refs/heads/*:refs/remotes/origin/*" --prune
@@ -125,6 +132,7 @@ jobs:
             echo "major=${major}"
             echo "minor=${minor}"
             echo "patch=${patch}"
+            echo "is_prerelease=${is_prerelease}"
             echo "commit=${commit}"
             echo "previous_tag=${previous_tag}"
           } >> "${GITHUB_OUTPUT}"
@@ -182,6 +190,7 @@ jobs:
         if: ${{ inputs.create-github-release }}
         env:
           GH_TOKEN: ${{ github.token }}
+          IS_PRERELEASE: ${{ steps.release_meta.outputs.is_prerelease }}
         run: |
           tag="${GITHUB_REF_NAME}"
           if [[ -z "${tag}" ]]; then
@@ -189,12 +198,21 @@ jobs:
             exit 1
           fi
 
-          if [[ -s "${{ inputs.release-notes-file }}" ]]; then
-            gh release create "${tag}" --notes-file "${{ inputs.release-notes-file }}" ||
-              gh release edit "${tag}" --notes-file "${{ inputs.release-notes-file }}" --latest
+          release_create_args=()
+          release_edit_args=()
+          if [[ "${IS_PRERELEASE}" == "true" ]]; then
+            release_create_args=(--prerelease --latest=false)
+            release_edit_args=(--prerelease)
           else
-            gh release create "${tag}" --generate-notes ||
-              gh release edit "${tag}" --latest
+            release_edit_args=(--latest)
+          fi
+
+          if [[ -s "${{ inputs.release-notes-file }}" ]]; then
+            gh release create "${tag}" --notes-file "${{ inputs.release-notes-file }}" "${release_create_args[@]}" ||
+              gh release edit "${tag}" --notes-file "${{ inputs.release-notes-file }}" "${release_edit_args[@]}"
+          else
+            gh release create "${tag}" --generate-notes "${release_create_args[@]}" ||
+              gh release edit "${tag}" "${release_edit_args[@]}"
           fi
 
           artifact_dir="${{ inputs.artifact-dir }}"
@@ -215,8 +233,14 @@ jobs:
           TAG_PREFIX: ${{ inputs.tag-prefix }}
           UPDATE_MAJOR_TAG: ${{ inputs.update-major-tag }}
           UPDATE_MINOR_TAG: ${{ inputs.update-minor-tag }}
+          IS_PRERELEASE: ${{ steps.release_meta.outputs.is_prerelease }}
         run: |
           set -euo pipefail
+
+          if [[ "${IS_PRERELEASE}" == "true" ]]; then
+            echo "Skipping floating SemVer tag promotion for prerelease ${RELEASE_TAG}."
+            exit 0
+          fi
 
           prefix="${TAG_PREFIX}"
           tag="${RELEASE_TAG}"

--- a/tests/reusable-workflows.test.ts
+++ b/tests/reusable-workflows.test.ts
@@ -44,11 +44,19 @@ describe("reusable workflows", () => {
       "Promote floating SemVer tags"
     ]);
     const deriveMetadata = releaseJob.steps.find((step: any) => step.name === "Derive release metadata");
+    const createRelease = releaseJob.steps.find((step: any) => step.name === "Create GitHub release");
     const promoteTags = releaseJob.steps.find((step: any) => step.name === "Promote floating SemVer tags");
     expect(deriveMetadata.run).toContain("semver_component='(0|[1-9][0-9]*)'");
+    expect(deriveMetadata.run).toContain("prerelease_identifier=");
+    expect(deriveMetadata.run).toContain("is_prerelease=${is_prerelease}");
+    expect(createRelease.run).toContain("release_create_args=(--prerelease --latest=false)");
+    expect(createRelease.run).toContain("release_edit_args=(--prerelease)");
+    expect(createRelease.env.IS_PRERELEASE).toBe("${{ steps.release_meta.outputs.is_prerelease }}");
+    expect(promoteTags.env.IS_PRERELEASE).toBe("${{ steps.release_meta.outputs.is_prerelease }}");
+    expect(promoteTags.run).toContain("Skipping floating SemVer tag promotion for prerelease");
     expect(promoteTags.run).toContain("semver_component='(0|[1-9][0-9]*)'");
     expect(deriveMetadata.run).toContain(
-      "^${escaped_prefix}${semver_component}\\.${semver_component}\\.${semver_component}$"
+      "^${escaped_prefix}${semver_component}\\.${semver_component}\\.${semver_component}${prerelease_pattern}$"
     );
     expect(promoteTags.run).toContain(
       "^${escaped_prefix}${semver_component}\\.${semver_component}\\.${semver_component}$"


### PR DESCRIPTION
## Summary

- Allow the reusable release workflow to derive metadata from SemVer prerelease tags such as `v1.0.0-beta1`.
- Mark generated prerelease GitHub releases as prerelease/not latest.
- Skip floating `vMAJOR` and `vMAJOR.MINOR` tag promotion for prerelease tags while preserving final-release behavior.

## Governing Issue

Closes #33

This also unblocks OMT-Global/dockyard#87, where the `v1.0.0-beta1` release run failed before Dockyard's publish script could run.

## Validation

- [x] Relevant local checks passed
- [x] Required PR checks are expected to satisfy `CI Gate`
- [x] Skipped checks are explained below

Commands run:

```sh
git diff --check
npm test -- tests/reusable-workflows.test.ts
npm run check
```

Results:

- `git diff --check`: passed.
- `npm test -- tests/reusable-workflows.test.ts`: passed, 3 tests.
- `npm run check`: passed, 52 tests.

## Bootstrap Governance

- [x] Changes are scoped to the linked issue
- [x] Contributor or PR guidance changes are not applicable
- [x] Auto-merge is enabled, or GitHub plan-limit evidence is recorded and the fallback merge-readiness policy applies
- [x] No real secrets, runtime auth, or machine-local env files are committed

## Merge Automation

- [x] Auto-merge is enabled, or the reason it is unavailable or unsafe is noted below

Auto-merge availability should be checked after PR checks complete. If unavailable, the fallback merge-readiness policy applies.

## Notes

- Dockyard release run `26172356319` failed with `Release tag 'v1.0.0-beta1' does not match the required exact SemVer pattern 'vX.Y.Z'.`
- Final releases like `v1.0.0` still promote floating tags when the existing `update-major-tag` / `update-minor-tag` inputs are true.
