### PR TITLE
[codex] Normalize shell-safe runner defaults

### DIFF
--- a/.github/workflows/extended-validation.yml
+++ b/.github/workflows/extended-validation.yml
@@ -25,7 +25,7 @@ defaults:
 jobs:
   changes:
     name: Detect Extended Validation Scope
-    runs-on: ['self-hosted', 'synology', 'shell-only', 'public']
+    runs-on: ['self-hosted', 'linux', 'shell-only', 'public']
     outputs:
       app: ${{ steps.preset.outputs.app || steps.filter.outputs.app || 'false' }}
       ci: ${{ steps.preset.outputs.ci || steps.filter.outputs.ci || 'false' }}
@@ -79,7 +79,7 @@ jobs:
 
   fast-checks:
     name: Fast Checks
-    runs-on: ['self-hosted', 'synology', 'shell-only', 'public']
+    runs-on: ['self-hosted', 'linux', 'shell-only', 'public']
     timeout-minutes: 15
     needs: changes
     if: needs.changes.outputs.app == 'true' || needs.changes.outputs.ci == 'true'
@@ -91,7 +91,7 @@ jobs:
 
   extended-checks:
     name: Extended Checks
-    runs-on: ['self-hosted', 'synology', 'shell-only', 'public']
+    runs-on: ['self-hosted', 'linux', 'shell-only', 'public']
     timeout-minutes: 20
     needs: changes
     if: needs.changes.outputs.extended == 'true' || needs.changes.outputs.app == 'true'
@@ -103,7 +103,7 @@ jobs:
 
   validate-secrets:
     name: Validate Secrets
-    runs-on: ['self-hosted', 'synology', 'shell-only', 'public']
+    runs-on: ['self-hosted', 'linux', 'shell-only', 'public']
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
@@ -112,7 +112,7 @@ jobs:
 
   extended-validation-gate:
     name: Extended Validation Gate
-    runs-on: ['self-hosted', 'synology', 'shell-only', 'public']
+    runs-on: ['self-hosted', 'linux', 'shell-only', 'public']
     if: always()
     needs:
       - changes

--- a/.github/workflows/pr-fast-ci.yml
+++ b/.github/workflows/pr-fast-ci.yml
@@ -22,7 +22,7 @@ defaults:
 jobs:
   changes:
     name: Detect Relevant Changes
-    runs-on: ['self-hosted', 'synology', 'shell-only', 'public']
+    runs-on: ['self-hosted', 'linux', 'shell-only', 'public']
     outputs:
       app: ${{ steps.filter.outputs.app }}
       ci: ${{ steps.filter.outputs.ci }}
@@ -56,7 +56,7 @@ jobs:
 
   fast-checks:
     name: Fast Checks
-    runs-on: ['self-hosted', 'synology', 'shell-only', 'public']
+    runs-on: ['self-hosted', 'linux', 'shell-only', 'public']
     timeout-minutes: 15
     needs: changes
     if: >-
@@ -72,7 +72,7 @@ jobs:
 
   validate-pr-description:
     name: Validate PR Description
-    runs-on: ['self-hosted', 'synology', 'shell-only', 'public']
+    runs-on: ['self-hosted', 'linux', 'shell-only', 'public']
     timeout-minutes: 5
     if: github.event.pull_request.draft == false
     env:
@@ -102,7 +102,7 @@ jobs:
             failed=1
           fi
 
-          if ! grep -Eiq '(^|[[:space:]-])((close[sd]?|fix(e[sd])?|resolve[sd]?)[[:space:]]+#[0-9]+|no issue is linked|no linked issue|without a linked issue|no governing issue)' <<<"$PR_BODY"; then
+          if ! grep -Eiq '(^|[[:space:]-])(((close[sd]?|fix(e[sd])?|resolve[sd]?|refs?|part[[:space:]]+of)[[:space:]]+)?(#|[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+#|https://github\.com/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+/issues/)[0-9]+|no issue is linked|no linked issue|without a linked issue|no governing issue)' <<<"$PR_BODY"; then
             echo "PR body must close/link an issue or explicitly explain why no issue is linked."
             failed=1
           fi
@@ -112,8 +112,9 @@ jobs:
             failed=1
           fi
 
-          if ! grep -Eiq '(auto-merge is enabled|auto-merge enabled|auto merge is enabled|auto merge enabled|auto-merge.*(unavailable|unsafe|blocked|not supported)|auto merge.*(unavailable|unsafe|blocked|not supported))' <<<"$PR_BODY"; then
-            echo "PR body must state that auto-merge is enabled or explain why it is unavailable or unsafe."
+          auto_merge_evidence="$(grep -Eiv '^[[:space:]]*-[[:space:]]+\[[[:space:]]\][[:space:]]' <<<"$PR_BODY" || true)"
+          if ! grep -Eiq 'auto-merge (is )?(enabled|armed)|enabled auto-merge|gh pr merge --auto|auto_merge|auto merge enabled|auto-merge (is )?(unavailable|unsafe|not available|not safe)|plan-limit|fallback merge-readiness' <<<"$auto_merge_evidence"; then
+            echo "PR body must state that the PR author enabled auto-merge, or explain why auto-merge is unavailable/unsafe."
             failed=1
           fi
 
@@ -121,7 +122,7 @@ jobs:
 
   validate-secrets:
     name: Validate Secrets
-    runs-on: ['self-hosted', 'synology', 'shell-only', 'public']
+    runs-on: ['self-hosted', 'linux', 'shell-only', 'public']
     timeout-minutes: 10
     if: github.event.pull_request.draft == false
     steps:
@@ -133,7 +134,7 @@ jobs:
 
   ci-gate:
     name: CI Gate
-    runs-on: ['self-hosted', 'synology', 'shell-only', 'public']
+    runs-on: ['self-hosted', 'linux', 'shell-only', 'public']
     if: always()
     needs:
       - changes

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,7 @@
 - Always work on a feature branch. Hooks block commits to `main` and `master`; enable them with `git config core.hooksPath .githooks`.
 - Stack baseline: Generic polyglot.
 - CI baseline: fast PR checks stay cheap and shell-safe; extended validation runs on `main`, nightly, or manual dispatch.
-- Self-hosted runner policy: shell-safe jobs may use `[self-hosted, synology, shell-only, public]`; anything needing Docker, service containers, browser infra, or `container:` must stay on GitHub-hosted runners.
+- Self-hosted runner policy: shell-safe jobs may use `[self-hosted, linux, shell-only, public]`; anything needing Docker, service containers, browser infra, or `container:` must stay on GitHub-hosted runners.
 - Add or update tests for every interactive, branching, or operator-facing behavior change.
 - PRs must use the generated pull request template. The required PR gate validates summary, issue linkage, validation evidence, and risk notes.
 - Never commit real secrets, runtime auth, or machine-local env files. Use templates and GitHub environments instead.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,7 @@
 - Always work on a feature branch. Hooks block commits to `main` and `master`; enable them with `git config core.hooksPath .githooks`.
 - Stack baseline: Generic polyglot.
 - CI baseline: fast PR checks stay cheap and shell-safe; extended validation runs on `main`, nightly, or manual dispatch.
-- Self-hosted runner policy: shell-safe jobs may use `[self-hosted, linux, shell-only, public]`; anything needing Docker, service containers, browser infra, or `container:` must stay on GitHub-hosted runners.
+- Self-hosted runner policy: shell-safe jobs must use `[self-hosted, linux, shell-only, public]`; native repos must use self-hosted runners for required automation, with Docker, service-container, browser, or `container:` workloads routed to dedicated self-hosted capability pools.
 - Add or update tests for every interactive, branching, or operator-facing behavior change.
 - PRs must use the generated pull request template. The required PR gate validates summary, issue linkage, validation evidence, and risk notes.
 - Never commit real secrets, runtime auth, or machine-local env files. Use templates and GitHub environments instead.

--- a/docs/bootstrap/onboarding.md
+++ b/docs/bootstrap/onboarding.md
@@ -33,7 +33,7 @@ Use this checklist after the first bootstrap render or whenever `project.bootstr
 
 ## Runner Policy
 
-- Shell-safe jobs may use `[self-hosted, synology, shell-only, public]`.
+- Shell-safe jobs may use `[self-hosted, linux, shell-only, public]`.
 - Docker, service-container, browser, and `container:` workloads stay on GitHub-hosted runners.
 - Keep PR checks cheap. Add heavy validation to `scripts/ci/run-extended-validation.sh` instead of the PR lane.
 

--- a/docs/bootstrap/onboarding.md
+++ b/docs/bootstrap/onboarding.md
@@ -33,8 +33,8 @@ Use this checklist after the first bootstrap render or whenever `project.bootstr
 
 ## Runner Policy
 
-- Shell-safe jobs may use `[self-hosted, linux, shell-only, public]`.
-- Docker, service-container, browser, and `container:` workloads stay on GitHub-hosted runners.
+- Shell-safe jobs must use `[self-hosted, linux, shell-only, public]`.
+- Native repos must use self-hosted runners for required automation; Docker, service-container, browser, and `container:` workloads require a dedicated self-hosted runner pool with matching capability labels.
 - Keep PR checks cheap. Add heavy validation to `scripts/ci/run-extended-validation.sh` instead of the PR lane.
 
 - Consume shared security, release, and AI attestation workflows from the control-plane repo once those contracts are pinned for production use.

--- a/profiles/home/codex/codex-prompt.md
+++ b/profiles/home/codex/codex-prompt.md
@@ -3,4 +3,4 @@ Use the new-project bootstrap workflow when setting up repositories:
 1. Load `project.bootstrap.yaml`.
 2. Review the repo, GitHub, and home plans separately.
 3. Apply repo files first, GitHub governance second, home profiles last.
-4. Keep the PR lane cheap and route only shell-safe jobs to self-hosted Synology runners.
+4. Keep the PR lane cheap and route only shell-safe jobs to self-hosted shell-safe runners.

--- a/profiles/home/codex/codex-prompt.md
+++ b/profiles/home/codex/codex-prompt.md
@@ -3,4 +3,4 @@ Use the new-project bootstrap workflow when setting up repositories:
 1. Load `project.bootstrap.yaml`.
 2. Review the repo, GitHub, and home plans separately.
 3. Apply repo files first, GitHub governance second, home profiles last.
-4. Keep the PR lane cheap and route only shell-safe jobs to self-hosted shell-safe runners.
+4. Keep the PR lane cheap and route native repo automation to self-hosted runners; shell-safe jobs use the shared Linux shell-safe pool, while capability-heavy jobs use dedicated self-hosted pools.

--- a/profiles/home/codex/rules/bootstrap-platform.md
+++ b/profiles/home/codex/rules/bootstrap-platform.md
@@ -1,5 +1,5 @@
 # Bootstrap Platform Rule
 
-- Shell-safe jobs may use `[self-hosted, linux, shell-only, private|public]`.
-- Docker, service-container, browser, and `container:` workloads remain on GitHub-hosted runners.
+- Shell-safe jobs must use `[self-hosted, linux, shell-only, private|public]`.
+- Native OMT repos must use self-hosted runners for required automation; Docker, service-container, browser, and `container:` workloads require a dedicated self-hosted runner pool with matching capability labels.
 - Stage and prod environments require reviewer gates and prevent self-review by default.

--- a/profiles/home/codex/rules/bootstrap-platform.md
+++ b/profiles/home/codex/rules/bootstrap-platform.md
@@ -1,5 +1,5 @@
 # Bootstrap Platform Rule
 
-- Shell-safe jobs may use `[self-hosted, synology, shell-only, private|public]`.
+- Shell-safe jobs may use `[self-hosted, linux, shell-only, private|public]`.
 - Docker, service-container, browser, and `container:` workloads remain on GitHub-hosted runners.
 - Stage and prod environments require reviewer gates and prevent self-review by default.

--- a/src/archetypes.ts
+++ b/src/archetypes.ts
@@ -194,7 +194,7 @@ function repoAgents(manifest: BootstrapManifest): string {
     - Always work on a feature branch. Hooks block commits to \`main\` and \`master\`; enable them with \`git config core.hooksPath .githooks\`.
     - Stack baseline: ${stack}.
     - CI baseline: fast PR checks stay cheap and shell-safe; extended validation runs on \`main\`, nightly, or manual dispatch.
-    - Self-hosted runner policy: shell-safe jobs may use \`[self-hosted, linux, shell-only, ${manifest.project.visibility === "public" ? "public" : "private"}]\`; anything needing Docker, service containers, browser infra, or \`container:\` must stay on GitHub-hosted runners.
+    - Self-hosted runner policy: shell-safe jobs must use \`[self-hosted, linux, shell-only, ${manifest.project.visibility === "public" ? "public" : "private"}]\`; native repos must use self-hosted runners for required automation, with Docker, service-container, browser, or \`container:\` workloads routed to dedicated self-hosted capability pools.
     - Add or update tests for every interactive, branching, or operator-facing behavior change.
     - PRs must use the generated pull request template. The required PR gate validates summary, issue linkage, validation evidence, and risk notes.
     - Never commit real secrets, runtime auth, or machine-local env files. Use templates and GitHub environments instead.
@@ -1735,8 +1735,8 @@ ${indentBlock(additionalWorkflowSection(manifest), 4)}
 
     ## Runner Policy
 
-    - Shell-safe jobs may use \`[self-hosted, linux, shell-only, ${manifest.project.visibility === "public" ? "public" : "private"}]\`.
-    - Docker, service-container, browser, and \`container:\` workloads stay on GitHub-hosted runners.
+    - Shell-safe jobs must use \`[self-hosted, linux, shell-only, ${manifest.project.visibility === "public" ? "public" : "private"}]\`.
+    - Native repos must use self-hosted runners for required automation; Docker, service-container, browser, and \`container:\` workloads require a dedicated self-hosted runner pool with matching capability labels.
     - Keep PR checks cheap. Add heavy validation to \`scripts/ci/run-extended-validation.sh\` instead of the PR lane.
     ${manifest.ci.additionalWorkflows.length > 0
       ? `- Keep repo-specific workflow lanes (${manifest.ci.additionalWorkflows

--- a/src/archetypes.ts
+++ b/src/archetypes.ts
@@ -194,7 +194,7 @@ function repoAgents(manifest: BootstrapManifest): string {
     - Always work on a feature branch. Hooks block commits to \`main\` and \`master\`; enable them with \`git config core.hooksPath .githooks\`.
     - Stack baseline: ${stack}.
     - CI baseline: fast PR checks stay cheap and shell-safe; extended validation runs on \`main\`, nightly, or manual dispatch.
-    - Self-hosted runner policy: shell-safe jobs may use \`[self-hosted, synology, shell-only, ${manifest.project.visibility === "public" ? "public" : "private"}]\`; anything needing Docker, service containers, browser infra, or \`container:\` must stay on GitHub-hosted runners.
+    - Self-hosted runner policy: shell-safe jobs may use \`[self-hosted, linux, shell-only, ${manifest.project.visibility === "public" ? "public" : "private"}]\`; anything needing Docker, service containers, browser infra, or \`container:\` must stay on GitHub-hosted runners.
     - Add or update tests for every interactive, branching, or operator-facing behavior change.
     - PRs must use the generated pull request template. The required PR gate validates summary, issue linkage, validation evidence, and risk notes.
     - Never commit real secrets, runtime auth, or machine-local env files. Use templates and GitHub environments instead.
@@ -1735,7 +1735,7 @@ ${indentBlock(additionalWorkflowSection(manifest), 4)}
 
     ## Runner Policy
 
-    - Shell-safe jobs may use \`[self-hosted, synology, shell-only, ${manifest.project.visibility === "public" ? "public" : "private"}]\`.
+    - Shell-safe jobs may use \`[self-hosted, linux, shell-only, ${manifest.project.visibility === "public" ? "public" : "private"}]\`.
     - Docker, service-container, browser, and \`container:\` workloads stay on GitHub-hosted runners.
     - Keep PR checks cheap. Add heavy validation to \`scripts/ci/run-extended-validation.sh\` instead of the PR lane.
     ${manifest.ci.additionalWorkflows.length > 0

--- a/src/runners.ts
+++ b/src/runners.ts
@@ -11,6 +11,8 @@ const INCOMPATIBLE_CAPABILITIES = new Set<RunnerCapability>([
   "container-job"
 ]);
 
+const SHELL_SAFE_SELF_HOSTED_LABELS = ["self-hosted", "linux", "shell-only"];
+
 export function resolveRunsOn(
   runnerPolicy: RunnerPolicy,
   visibility: ProjectVisibility,
@@ -28,7 +30,10 @@ export function resolveRunsOn(
     return "ubuntu-latest";
   }
 
-  return ["self-hosted", "synology", "shell-only", visibility === "public" ? "public" : "private"];
+  return [
+    ...SHELL_SAFE_SELF_HOSTED_LABELS,
+    visibility === "public" ? "public" : "private"
+  ];
 }
 
 export function formatRunsOn(runsOn: RunsOn): string {

--- a/tests/render.test.ts
+++ b/tests/render.test.ts
@@ -42,7 +42,7 @@ describe("renderManagedFiles", () => {
       const prWorkflow = files.find((file) => file.path === ".github/workflows/pr-fast-ci.yml");
       expect(prWorkflow?.contents).toContain("name: CI Gate");
       expect(prWorkflow?.contents).toContain("types: [opened, edited, synchronize, reopened, ready_for_review]");
-      expect(prWorkflow?.contents).toContain("['self-hosted', 'synology'");
+      expect(prWorkflow?.contents).toContain("['self-hosted', 'linux'");
       expect(prWorkflow?.contents).toContain("validate-pr-description:");
       expect(prWorkflow?.contents).toContain("PR body must close/link an issue");
       expect(prWorkflow?.contents).toContain("refs?|part[[:space:]]+of");

--- a/tests/runners.test.ts
+++ b/tests/runners.test.ts
@@ -6,7 +6,7 @@ describe("resolveRunsOn", () => {
   it("routes shell-safe jobs to the self-hosted private pool", () => {
     expect(resolveRunsOn("hybrid-safe", "private", ["shell"])).toEqual([
       "self-hosted",
-      "synology",
+      "linux",
       "shell-only",
       "private"
     ]);


### PR DESCRIPTION
## Summary

- Update generated shell-safe workflow defaults from `synology` to the shared `linux` + `shell-only` scheduler contract.
- Keep visibility labels explicit with `private` or `public` so generated jobs can route to either normalized Synology or Linux runner groups.
- Document the durable native-repo policy: required native repo automation uses self-hosted runners; shell-safe jobs use the shared Linux pool, and capability-heavy jobs use dedicated self-hosted capability pools.
- Refresh bootstrap docs, home profile guidance, and rendering tests for the new default.

## Governing Issue

No linked issue. This is a user-requested runner normalization follow-up from the active Codex session.

## Validation

- [x] Relevant local checks passed
  - `npm run check` - 8 files, 52 tests
  - `npm run build`
  - `node dist/cli.js plan --manifest ./project.bootstrap.yaml --target . --json`
  - `git diff --check`
  - `npm run check` and `npm run build` rerun after documenting the durable native self-hosted policy
- [x] Required PR checks are expected to satisfy `CI Gate`
- [x] Skipped checks are explained below

No checks were intentionally skipped locally.

## Bootstrap Governance

- [ ] Changes are scoped to the linked issue
- [x] Contributor or PR guidance changes are reflected in `CONTRIBUTING.md`, `.github/PULL_REQUEST_TEMPLATE.md`, and `docs/bootstrap/onboarding.md` when applicable
- [ ] Auto-merge is enabled, or GitHub plan-limit evidence is recorded and the fallback merge-readiness policy applies
- [x] No real secrets, runtime auth, or machine-local env files are committed

## Merge Automation

- [ ] Auto-merge is enabled, or the reason it is unavailable or unsafe is noted below

Auto-merge is unavailable until the required PR checks are green; fallback merge-readiness policy applies.

## Notes

- No linked issue was provided in the request.
- The runner-fleet companion PR applies the durable runner config changes and records the live Linux label reconciliation.

