### PR TITLE
ci: run workflows on self-hosted runners

### DIFF
--- a/.github/workflows/ai-attestation-reusable.yml
+++ b/.github/workflows/ai-attestation-reusable.yml
@@ -42,6 +42,30 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Ensure envsubst is available
+        shell: bash
+        run: |
+          set -euo pipefail
+          if command -v envsubst >/dev/null 2>&1; then
+            exit 0
+          fi
+
+          if ! command -v apt-get >/dev/null 2>&1; then
+            echo "envsubst is required by cosign-installer, but apt-get is unavailable." >&2
+            exit 1
+          fi
+
+          if [[ "$(id -u)" == "0" ]]; then
+            apt-get update
+            apt-get install -y --no-install-recommends gettext-base
+          elif command -v sudo >/dev/null 2>&1; then
+            sudo apt-get update
+            sudo apt-get install -y --no-install-recommends gettext-base
+          else
+            echo "envsubst is missing and this runner cannot install gettext-base." >&2
+            exit 1
+          fi
+
       - name: Install cosign
         uses: sigstore/cosign-installer@v4.1.1
 
@@ -100,6 +124,30 @@ jobs:
       - public
     needs: attest
     steps:
+      - name: Ensure envsubst is available
+        shell: bash
+        run: |
+          set -euo pipefail
+          if command -v envsubst >/dev/null 2>&1; then
+            exit 0
+          fi
+
+          if ! command -v apt-get >/dev/null 2>&1; then
+            echo "envsubst is required by cosign-installer, but apt-get is unavailable." >&2
+            exit 1
+          fi
+
+          if [[ "$(id -u)" == "0" ]]; then
+            apt-get update
+            apt-get install -y --no-install-recommends gettext-base
+          elif command -v sudo >/dev/null 2>&1; then
+            sudo apt-get update
+            sudo apt-get install -y --no-install-recommends gettext-base
+          else
+            echo "envsubst is missing and this runner cannot install gettext-base." >&2
+            exit 1
+          fi
+
       - name: Install cosign
         uses: sigstore/cosign-installer@v4.1.1
 

--- a/.github/workflows/ai-attestation-reusable.yml
+++ b/.github/workflows/ai-attestation-reusable.yml
@@ -30,7 +30,11 @@ permissions:
 
 jobs:
   attest:
-    runs-on: ubuntu-latest
+    runs-on:
+      - self-hosted
+      - linux
+      - shell-only
+      - public
     outputs:
       sha: ${{ steps.meta.outputs.sha }}
     steps:
@@ -89,7 +93,11 @@ jobs:
           retention-days: ${{ inputs.retention_days }}
 
   verify:
-    runs-on: ubuntu-latest
+    runs-on:
+      - self-hosted
+      - linux
+      - shell-only
+      - public
     needs: attest
     steps:
       - name: Install cosign

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -14,7 +14,7 @@ jobs:
   release:
     uses: OMT-Global/bootstrap/.github/workflows/release.yml@refs/heads/main
     with:
-      runs-on: '["ubuntu-latest"]'
+      runs-on: '["self-hosted","linux","shell-only","public"]'
       verify-script: scripts/ci/run-release-verification.sh
       version-script: scripts/ci/run-release-version.sh
       build-script: scripts/ci/run-release-build.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
       runs-on:
         description: JSON array runner selector for the release job
         required: false
-        default: '["ubuntu-latest"]'
+        default: '["self-hosted","linux","shell-only","public"]'
         type: string
       verify-script:
         description: Release verification script path relative to the repository root

--- a/.github/workflows/security-pr.yml
+++ b/.github/workflows/security-pr.yml
@@ -34,7 +34,11 @@ jobs:
   dependency-review:
     name: dependency-review
     if: ${{ inputs.dependency-review }}
-    runs-on: ubuntu-latest
+    runs-on:
+      - self-hosted
+      - linux
+      - shell-only
+      - public
     permissions:
       contents: read
       pull-requests: read
@@ -47,7 +51,11 @@ jobs:
   codeql:
     name: codeql
     if: ${{ inputs.codeql-languages != '' }}
-    runs-on: ubuntu-latest
+    runs-on:
+      - self-hosted
+      - linux
+      - shell-only
+      - public
     permissions:
       actions: read
       contents: read
@@ -69,7 +77,11 @@ jobs:
   osv:
     name: osv
     if: ${{ inputs.run-osv }}
-    runs-on: ubuntu-latest
+    runs-on:
+      - self-hosted
+      - linux
+      - shell-only
+      - public
     permissions:
       contents: read
       security-events: write
@@ -87,7 +99,11 @@ jobs:
   semgrep:
     name: semgrep
     if: ${{ inputs.run-semgrep }}
-    runs-on: ubuntu-latest
+    runs-on:
+      - self-hosted
+      - linux
+      - shell-only
+      - public
     permissions:
       contents: read
       security-events: write

--- a/tests/reusable-workflows.test.ts
+++ b/tests/reusable-workflows.test.ts
@@ -9,6 +9,8 @@ function loadWorkflow(relativePath: string) {
 }
 
 describe("reusable workflows", () => {
+  const shellSafePublicRunner = '["self-hosted","linux","shell-only","public"]';
+
   it("defines the security PR reusable workflow contract", () => {
     const workflow = loadWorkflow(".github/workflows/security-pr.yml");
     expect(workflow.name).toBe("Security PR");
@@ -20,7 +22,7 @@ describe("reusable workflows", () => {
   it("defines the reusable release workflow contract", () => {
     const workflow = loadWorkflow(".github/workflows/release.yml");
     expect(workflow.name).toBe("Reusable Release");
-    expect((workflow.on as any).workflow_call.inputs["runs-on"].default).toBe('["ubuntu-latest"]');
+    expect((workflow.on as any).workflow_call.inputs["runs-on"].default).toBe(shellSafePublicRunner);
     expect((workflow.on as any).workflow_call.inputs["verify-script"].default).toContain("run-release-verification");
     expect((workflow.on as any).workflow_call.inputs["version-script"].default).toContain("run-release-version");
     expect((workflow.on as any).workflow_call.inputs["build-script"].default).toContain("run-release-build");


### PR DESCRIPTION
## Summary

- Move non-fallback workflow jobs off GitHub-hosted runner labels and onto OMT self-hosted runner labels.
- Keep explicit hosted fork/fallback paths unchanged where present.
- Align workflow contract tests where this repository has them.

## Governing Issue

No linked issue. This follows JT's direct policy request that CI jobs should not run on GitHub-hosted runners unless they are explicit fallbacks.

## Validation

- [x] `git diff --check`
- [x] Workflow YAML parsed successfully
- [x] Hosted-runner policy scan found no non-fallback direct `ubuntu-*`, `macos-*`, or `windows-*` `runs-on` jobs in this patched worktree
- `npm run check` (52 tests)

## Bootstrap Governance

- [x] Changes are scoped to the runner policy request
- [x] Contributor or PR guidance changes are not required
- [ ] Auto-merge is enabled, or GitHub plan-limit evidence is recorded and the fallback merge-readiness policy applies
- [x] No real secrets, runtime auth, or machine-local env files are committed

## Merge Automation

- [ ] Auto-merge is enabled, or the reason it is unavailable or unsafe is noted below

Auto-merge is intentionally not enabled yet. This is a cross-repository runner policy migration and should land after CI confirms each repo's self-hosted route.

## Notes

- Generated from `/home/pheidon/.openclaw/workspace/reports/github-hosted-runner-audit-2026-05-31.md`.
- Repositories with explicit fork fallback jobs keep those jobs on GitHub-hosted runners by design.
