### PR TITLE
[codex] Validate managed path dependencies

### DIFF
--- a/src/render.ts
+++ b/src/render.ts
@@ -43,8 +43,52 @@ function selectManagedFiles(manifest: BootstrapManifest, files: RenderedFile[]):
     return files;
   }
 
-  return files.filter((file) =>
+  const selectedFiles = files.filter((file) =>
     manifest.repo.managedPaths.some((pattern) => matchesManagedPath(file.path, pattern))
+  );
+  validateManagedPathDependencies(selectedFiles);
+  return selectedFiles;
+}
+
+function validateManagedPathDependencies(files: RenderedFile[]): void {
+  const selectedPaths = new Set(files.map((file) => file.path));
+  const dependencies = [
+    {
+      path: "AGENTS.md",
+      requires: [
+        ".githooks/pre-commit",
+        ".github/PULL_REQUEST_TEMPLATE.md",
+        "docs/bootstrap/onboarding.md"
+      ]
+    },
+    {
+      path: "CONTRIBUTING.md",
+      requires: [".githooks/pre-commit", ".github/PULL_REQUEST_TEMPLATE.md"]
+    },
+    {
+      path: ".github/PULL_REQUEST_TEMPLATE.md",
+      requires: ["docs/bootstrap/onboarding.md"]
+    }
+  ];
+
+  const violations = dependencies.flatMap(({ path: managedPath, requires }) => {
+    if (!selectedPaths.has(managedPath)) {
+      return [];
+    }
+
+    const missing = requires.filter((requiredPath) => !selectedPaths.has(requiredPath));
+    return missing.length > 0 ? [{ path: managedPath, missing }] : [];
+  });
+
+  if (violations.length === 0) {
+    return;
+  }
+
+  const details = violations
+    .map(({ path: managedPath, missing }) => `${managedPath} requires ${missing.join(", ")}`)
+    .join("; ");
+  throw new Error(
+    `Invalid repo.managedPaths: selected bootstrap guidance excludes required companion files. ${details}.`
   );
 }
 

--- a/tests/smoke.test.ts
+++ b/tests/smoke.test.ts
@@ -66,6 +66,8 @@ describe("repo smoke", () => {
         managedPaths: [
           "project.bootstrap.yaml",
           "AGENTS.md",
+          ".githooks/pre-commit",
+          ".github/PULL_REQUEST_TEMPLATE.md",
           "scripts/codex-cloud/**",
           "docs/bootstrap/**"
         ]
@@ -89,9 +91,58 @@ describe("repo smoke", () => {
 
     const agents = await readFile(path.join(targetDir, "AGENTS.md"), "utf8");
     expect(agents).toContain("CI baseline");
+    await expect(access(path.join(targetDir, ".githooks/pre-commit"))).resolves.toBeUndefined();
+    await expect(access(path.join(targetDir, ".github/PULL_REQUEST_TEMPLATE.md"))).resolves.toBeUndefined();
 
     const secondPlan = await planRepo(manifest, targetDir);
     expect(secondPlan.changes.every((change) => change.type === "unchanged")).toBe(true);
+  });
+
+  it("rejects selected guidance when repo.managedPaths excludes referenced companion files", async () => {
+    const targetDir = await makeTempDir();
+    const manifest = normalizeManifest({
+      project: {
+        name: "cloudcurator",
+        displayName: "CloudCurator",
+        description:
+          "Native macOS menu bar organizer for keeping iCloud Drive files local, tagged, searchable, and reversible.",
+        visibility: "private",
+        owner: "OMT-Global"
+      },
+      repo: {
+        managedPaths: [
+          "AGENTS.md",
+          "CONTRIBUTING.md",
+          "CODEOWNERS",
+          ".github/PULL_REQUEST_TEMPLATE.md",
+          ".github/ISSUE_TEMPLATE/implementation.yml",
+          ".github/ISSUE_TEMPLATE/flow_blocker.yml"
+        ]
+      },
+      archetype: {
+        kind: "generic-empty",
+        packageManager: "npm",
+        moduleName: "CloudCurator"
+      },
+      github: {
+        reviewers: ["jmcte"],
+        flowGovernance: true,
+        requiredStatusChecks: ["CI Gate"]
+      },
+      release: {
+        enabled: false
+      },
+      agents: {
+        manageCodexHome: false,
+        sharedSkills: ["github", "build-macos-apps"]
+      }
+    });
+
+    await expect(planRepo(manifest, targetDir)).rejects.toThrow(
+      "Invalid repo.managedPaths: selected bootstrap guidance excludes required companion files."
+    );
+    await expect(planRepo(manifest, targetDir)).rejects.toThrow(".githooks/pre-commit");
+    await expect(planRepo(manifest, targetDir)).rejects.toThrow("docs/bootstrap/onboarding.md");
   });
 
   it("backs out previously managed Claude files from an already bootstrapped repo", async () => {


### PR DESCRIPTION
## Summary

- Reject `repo.managedPaths` selections that include generated guidance while excluding companion files those templates reference.
- Add a CloudCurator-shaped smoke regression for restricted managed paths.
- Update selected-file adoption coverage so `AGENTS.md` is only adopted with the required hook, PR template, and onboarding companions.

## Governing Issue

No governing issue is linked; this is cleanup from live bootstrap application failures found while reconciling downstream repos.

## Validation

- [x] Relevant local checks passed: `npm test` (10 files, 58 tests)
- [x] Required PR checks are expected to satisfy `CI Gate`
- [x] Skipped checks are explained below

No checks were intentionally skipped.

## Bootstrap Governance

- [x] Changes are scoped to the linked issue
- [x] Contributor or PR guidance changes are reflected in `CONTRIBUTING.md`, `.github/PULL_REQUEST_TEMPLATE.md`, and `docs/bootstrap/onboarding.md` when applicable
- [x] Auto-merge is enabled, or GitHub plan-limit evidence is recorded and the fallback merge-readiness policy applies
- [x] No real secrets, runtime auth, or machine-local env files are committed

No governing issue is linked; this change tightens bootstrap validation after downstream generated guidance exposed missing managed-path dependency checks. Auto-merge is not enabled from this local session; use the fallback merge-readiness policy after required checks and review pass.

## Merge Automation

- [x] Auto-merge is enabled, or the reason it is unavailable or unsafe is noted below

Auto-merge was not enabled because GitHub CLI authentication is unstable in this session. Fallback merge-readiness applies once review and required checks are green.

## Notes

- The validation is intentionally fail-fast before any files are written to a target repo.
- This should prevent partial bootstrap adoption that copies guidance without the referenced enforcement and onboarding files.
