### PR TITLE
chore: assign CODEOWNERS to OMT-Codeowners team

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
-# Managed CODEOWNERS for OMT-Global native repos.
-* @pheidon @jmcte
+# OMT-Global code ownership
+* @OMT-Global/omt-codeowners


### PR DESCRIPTION
## Summary
Assigns repository CODEOWNERS to the org-visible @OMT-Global/omt-codeowners team so code-owner review can satisfy branch protection.

## Governing Issue
No governing issue is linked; this is a repo-ops follow-up for CODEOWNERS branch protection readiness.

## Validation
- [x] Verified via GitHub PR metadata that this PR changes only `CODEOWNERS`.
- [x] Confirmed the PR description now includes the required generated-template sections.
- [x] Confirmed the description states why no governing issue is linked and why auto-merge is currently unavailable.

## Bootstrap Governance
Team members now include pheidon, jmcte, and athena-omt; the team has write access to this repo so GitHub code-owner approval can satisfy branch protection and auto-merge gates.

## Merge Automation
Auto-merge is unavailable until GitHub reruns PR description validation and CI Gate after this body repair.

## Notes
No production app, API, SaaS, payment, admin, upload, auth, session, or database-backed surface is changed by this PR.
