### PR TITLE
fix: accept version 2 bootstrap manifests

### DIFF
--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -197,7 +197,7 @@ const releasePublishSchema = z.object({
 });
 
 const manifestSchema = z.object({
-  version: z.literal(1).optional(),
+  version: z.union([z.literal(1), z.literal(2)]).optional(),
   project: z.object({
     name: z.string().min(1),
     displayName: z.string().min(1).optional(),

--- a/tests/manifest.test.ts
+++ b/tests/manifest.test.ts
@@ -3,6 +3,44 @@ import { describe, expect, it } from "vitest";
 import { DEFAULT_ISSUE_LABELS, normalizeManifest } from "../src/manifest.js";
 
 describe("normalizeManifest", () => {
+  it("accepts version 2 manifests as compatibility input", () => {
+    const manifest = normalizeManifest({
+      version: 2,
+      project: {
+        name: "apw-cli",
+        owner: "OMT-Global",
+        visibility: "public",
+        defaultBranch: "main"
+      },
+      repo: {
+        managedPaths: ["project.bootstrap.yaml", ".github/workflows/pr-fast-ci.yml"],
+        class: "library"
+      },
+      archetype: {
+        kind: "generic-empty",
+        packageManager: "npm",
+        moduleName: "apw"
+      },
+      github: {
+        createRepo: false,
+        reviewers: ["jmcte"],
+        requiredStatusChecks: ["CI Gate"],
+        security: { dependabot: false }
+      },
+      ci: {
+        policy: "standard-public",
+        runnerPolicy: "hybrid-safe",
+        workflows: { prFastCi: true }
+      }
+    } as never);
+
+    expect(manifest.version).toBe(1);
+    expect(manifest.project.name).toBe("apw-cli");
+    expect(manifest.repo.managedPaths).toContain(".github/workflows/pr-fast-ci.yml");
+    expect(manifest.ci.runnerPolicy).toBe("hybrid-safe");
+    expect(manifest.github.requiredStatusChecks).toEqual(["CI Gate"]);
+  });
+
   it("applies defaults and reviewer-derived governance", () => {
     const manifest = normalizeManifest({
       project: {


### PR DESCRIPTION
## Summary

- Accept existing `version: 2` bootstrap manifests as compatibility input.
- Keep the normalized internal manifest model at `version: 1`.
- Add a regression test with APW-style v2-only fields so future parser changes keep this path loadable.

## Governing Issue

No governing issue is linked. This was found while reconciling Workboard card `9625fd72-bb21-4be1-966e-546ad781309a` for bootstrap manifest and runner-policy drift.

## Validation

- [x] `npm test -- --run tests/manifest.test.ts`
- [x] `npm run typecheck`

## Bootstrap Governance

- [x] Manifest parser compatibility remains explicit: v2 is accepted as input, but normalized output stays on the current v1 model.
- [x] APW planning now reaches the managed-path dependency guard instead of failing at version parsing.
- [x] The larger APW managed-path/render rewrite is not included in this PR.

## Merge Automation

Auto-merge is not available through the current Hephaestus token path: the GraphQL edit/merge flow requires a scope query involving `read:org`. Fallback merge-readiness applies after CI and review.

## Notes

APW fleet planning still reports: `AGENTS.md requires .github/PULL_REQUEST_TEMPLATE.md`. Applying the current renderer to APW rewrites a broad repo surface, so that remains a separate compatibility decision.
