### PR TITLE
Support project.bootstrap.yaml version 2

### DIFF
--- a/src/archetypes.ts
+++ b/src/archetypes.ts
@@ -2673,6 +2673,289 @@ function releaseVersioningDoc(manifest: BootstrapManifest): string {
   `;
 }
 
+
+function repoDocEnabled(
+  manifest: BootstrapManifest,
+  key: "readme" | "contributing" | "security",
+  fallback: boolean
+): boolean {
+  return manifest.repo.docs?.[key] ?? fallback;
+}
+
+function envExampleEnabled(manifest: BootstrapManifest): boolean {
+  return manifest.repo.env?.exampleFile ?? true;
+}
+
+function pullRequestTemplateEnabled(manifest: BootstrapManifest): boolean {
+  return manifest.repo.templates?.pullRequest !== "none";
+}
+
+function issueTemplateEnabled(manifest: BootstrapManifest, template: "bug" | "feature"): boolean {
+  return manifest.repo.templates?.issueTemplates.includes(template) ?? false;
+}
+
+function preCommitHookEnabled(manifest: BootstrapManifest): boolean {
+  return manifest.repo.hooks?.preCommit !== "none";
+}
+
+function prePushHookEnabled(manifest: BootstrapManifest): boolean {
+  return manifest.repo.hooks?.prePush === "standard";
+}
+
+function workflowEnabled(
+  manifest: BootstrapManifest,
+  workflow: "prFastCi" | "extendedValidation" | "claude" | "pagesDeploy" | "ci",
+  fallback: boolean
+): boolean {
+  return manifest.ci.workflows?.[workflow] ?? fallback;
+}
+
+function claudeEnabled(manifest: BootstrapManifest): boolean {
+  return Boolean(
+    manifest.agents.manageClaudeHome ||
+      manifest.agents.enableClaudeWebEnvironment ||
+      manifest.agents.enableClaudeDevcontainer ||
+      manifest.agents.enableClaudeGitHubAction ||
+      workflowEnabled(manifest, "claude", false)
+  );
+}
+
+function securityDoc(manifest: BootstrapManifest): string {
+  const dependabot = manifest.github.security?.dependabot ?? manifest.ci.dependabot.enabled;
+  const secretHints = manifest.github.security?.secretScanningHints ?? true;
+
+  return dedent`
+    # Security Policy
+
+    ## Supported Surface
+
+    This repository follows the bootstrap-managed security baseline for ${manifest.project.owner}/${manifest.project.name}.
+
+    ## Reporting
+
+    Open a private security advisory or contact the repository maintainers before disclosing a vulnerability publicly.
+
+    ## Baseline
+
+    - Dependabot policy: ${dependabot ? "enabled" : "disabled by manifest"}
+    - Secret scanning hints: ${secretHints ? "enabled" : "disabled by manifest"}
+    - Generated hooks and CI helpers must not require committed secrets or machine-local environment files.
+  `;
+}
+
+function bugIssueTemplate(): string {
+  return dedent`
+    name: Bug Report
+    description: Report a reproducible defect.
+    title: "[Bug]: "
+    labels: ["type:bug", "status:needs-spec"]
+    body:
+      - type: textarea
+        id: summary
+        attributes:
+          label: Summary
+        validations:
+          required: true
+      - type: textarea
+        id: reproduction
+        attributes:
+          label: Reproduction
+        validations:
+          required: true
+      - type: textarea
+        id: validation
+        attributes:
+          label: Expected Validation
+        validations:
+          required: true
+  `;
+}
+
+function featureIssueTemplate(): string {
+  return dedent`
+    name: Feature Request
+    description: Propose a scoped feature or improvement.
+    title: "[Feature]: "
+    labels: ["type:feature", "status:needs-spec"]
+    body:
+      - type: textarea
+        id: outcome
+        attributes:
+          label: Desired Outcome
+        validations:
+          required: true
+      - type: textarea
+        id: scope
+        attributes:
+          label: Scope
+        validations:
+          required: true
+      - type: textarea
+        id: validation
+        attributes:
+          label: Validation
+        validations:
+          required: true
+  `;
+}
+
+function prePushHook(): string {
+  return dedent`
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    if [[ -x scripts/ci/run-fast-checks.sh ]]; then
+      bash scripts/ci/run-fast-checks.sh
+    fi
+  `;
+}
+
+function repoClaude(manifest: BootstrapManifest): string {
+  return dedent`
+    # CLAUDE.md
+
+    ## Project Context
+
+    - Repository: ${manifest.project.owner}/${manifest.project.name}
+    - Default branch: ${manifest.project.defaultBranch}
+    - Required PR checks: ${requiredStatusChecksPlain(manifest)}
+
+    ## Guardrails
+
+    - Use AGENTS.md and docs/bootstrap/onboarding.md as the governing repo policy.
+    - Keep Claude automation separate from required PR status checks unless the manifest explicitly changes that contract.
+    - Do not commit secrets or machine-local environment files.
+  `;
+}
+
+function claudeCloudSetupScript(manifest: BootstrapManifest): string {
+  return `${dedent`
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    bash scripts/codex-cloud/setup.sh
+    echo "Claude cloud setup complete for ${manifest.project.owner}/${manifest.project.name}."
+  `}\n`;
+}
+
+function claudeDevcontainer(manifest: BootstrapManifest): string {
+  return `${JSON.stringify(
+    {
+      name: `${manifest.project.name} Claude Code`,
+      image: "mcr.microsoft.com/devcontainers/base:ubuntu-24.04",
+      remoteUser: "vscode",
+      updateRemoteUserUID: true,
+      features: {
+        "ghcr.io/anthropics/devcontainer-features/claude-code:1": {},
+        "ghcr.io/devcontainers/features/github-cli:1": {},
+        "ghcr.io/devcontainers/features/node:1": { version: manifest.ci.nodeVersion },
+        "ghcr.io/devcontainers/features/python:1": { version: manifest.ci.pythonVersion }
+      },
+      mounts: ["source=${localEnv:HOME}/.claude,target=/home/vscode/.claude,type=bind"],
+      postCreateCommand: "bash scripts/claude/setup-devcontainer.sh"
+    },
+    null,
+    2
+  )}\n`;
+}
+
+function claudeDevcontainerSetupScript(): string {
+  return `${dedent`
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    bash scripts/codex-cloud/setup.sh
+  `}\n`;
+}
+
+function claudeWorkflow(manifest: BootstrapManifest): string {
+  return dedent`
+    name: Claude Code
+
+    on:
+      workflow_dispatch:
+        inputs:
+          prompt:
+            description: Optional manual task prompt
+            required: false
+            type: string
+      issue_comment:
+        types: [created]
+      pull_request_review_comment:
+        types: [created]
+      pull_request_review:
+        types: [submitted]
+
+    concurrency:
+      group: claude-\${{ github.event.pull_request.number || github.event.issue.number || github.run_id }}
+      cancel-in-progress: false
+
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+
+    jobs:
+      claude:
+        if: |
+          github.event_name == 'workflow_dispatch' ||
+          (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+          (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+          (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude'))
+        runs-on: ubuntu-latest
+        timeout-minutes: 30
+        steps:
+          - uses: actions/checkout@v4
+          - name: Run Claude Code
+            uses: anthropics/claude-code-action@v1
+            with:
+              anthropic_api_key: \${{ secrets.ANTHROPIC_API_KEY }}
+              prompt: |
+                REPO: \${{ github.repository }}
+                DEFAULT BRANCH: ${manifest.project.defaultBranch}
+                REQUIRED CHECKS: ${requiredStatusChecksPlain(manifest)}
+                Use CLAUDE.md, AGENTS.md, and docs/bootstrap/onboarding.md as policy context.
+                MANUAL TASK: \${{ github.event.inputs.prompt }}
+  `;
+}
+
+function claudeEnvironmentDoc(manifest: BootstrapManifest): string {
+  return dedent`
+    # Claude Environment
+
+    ## Project
+
+${indentBlock(projectIdentityLines(manifest), 4)}
+
+    ## Enabled Surfaces
+
+    ${manifest.agents.enableClaudeWebEnvironment ? "- Claude Code on the web with `bash scripts/claude-cloud/setup.sh`" : "- Claude Code on the web is not enabled by this manifest."}
+    ${manifest.agents.enableClaudeDevcontainer ? "- Interactive devcontainer through `.devcontainer/devcontainer.json`" : "- Claude devcontainer is not enabled by this manifest."}
+    ${manifest.agents.enableClaudeGitHubAction || workflowEnabled(manifest, "claude", false) ? "- GitHub-hosted Claude workflow at `.github/workflows/claude.yml`" : "- Claude GitHub Action is not enabled by this manifest."}
+
+    ## Guardrails
+
+    - Keep Claude automation out of the required PR check set unless the manifest explicitly changes branch protection.
+    - Prefer repo-scoped secrets and avoid mounting additional host credentials into the devcontainer.
+  `;
+}
+
+
+function filterRenderedFiles(manifest: BootstrapManifest, files: RenderedFile[]): RenderedFile[] {
+  return files.filter((file) => {
+    if (file.path === "README.md") return repoDocEnabled(manifest, "readme", true);
+    if (file.path === "CONTRIBUTING.md") return repoDocEnabled(manifest, "contributing", true);
+    if (file.path === ".env.example") return envExampleEnabled(manifest);
+    if (file.path === ".githooks/pre-commit") return preCommitHookEnabled(manifest);
+    if (file.path === ".github/PULL_REQUEST_TEMPLATE.md") return pullRequestTemplateEnabled(manifest);
+    if (file.path === ".github/workflows/pr-fast-ci.yml") return workflowEnabled(manifest, "prFastCi", true);
+    if (file.path === ".github/workflows/extended-validation.yml") {
+      return workflowEnabled(manifest, "extendedValidation", true);
+    }
+    return true;
+  });
+}
+
 export function renderManagedFiles(manifest: BootstrapManifest): RenderedFile[] {
   const releaseIsGoverned = manifest.release.maturity === "governed" || manifest.release.maturity === "regulated";
   const files: RenderedFile[] = [
@@ -2696,6 +2979,24 @@ export function renderManagedFiles(manifest: BootstrapManifest): RenderedFile[] 
       reason: "Contributor workflow guidance",
       contents: `${contributingDoc(manifest)}\n`
     },
+    ...(repoDocEnabled(manifest, "security", false)
+      ? [
+          {
+            path: "SECURITY.md",
+            reason: "Security reporting policy",
+            contents: `${securityDoc(manifest)}\n`
+          }
+        ]
+      : []),
+    ...(claudeEnabled(manifest)
+      ? [
+          {
+            path: "CLAUDE.md",
+            reason: "Repo-local Claude instructions",
+            contents: `${repoClaude(manifest)}\n`
+          }
+        ]
+      : []),
     {
       path: ".env.example",
       reason: "Safe environment template",
@@ -2712,6 +3013,16 @@ export function renderManagedFiles(manifest: BootstrapManifest): RenderedFile[] 
       contents: `${preCommitHook()}\n`,
       executable: true
     },
+    ...(prePushHookEnabled(manifest)
+      ? [
+          {
+            path: ".githooks/pre-push",
+            reason: "Push validation hook",
+            contents: `${prePushHook()}\n`,
+            executable: true
+          }
+        ]
+      : []),
     {
       path: "CODEOWNERS",
       reason: "Code owner mapping",
@@ -2722,6 +3033,24 @@ export function renderManagedFiles(manifest: BootstrapManifest): RenderedFile[] 
       reason: "Pull request guidance template",
       contents: `${pullRequestTemplate(manifest)}\n`
     },
+    ...(issueTemplateEnabled(manifest, "bug")
+      ? [
+          {
+            path: ".github/ISSUE_TEMPLATE/bug.yml",
+            reason: "Bug issue template",
+            contents: `${bugIssueTemplate()}\n`
+          }
+        ]
+      : []),
+    ...(issueTemplateEnabled(manifest, "feature")
+      ? [
+          {
+            path: ".github/ISSUE_TEMPLATE/feature.yml",
+            reason: "Feature issue template",
+            contents: `${featureIssueTemplate()}\n`
+          }
+        ]
+      : []),
     ...(manifest.github.flowGovernance
       ? [
           {
@@ -2826,6 +3155,15 @@ export function renderManagedFiles(manifest: BootstrapManifest): RenderedFile[] 
           }
         ]
       : []),
+    ...(workflowEnabled(manifest, "claude", Boolean(manifest.agents.enableClaudeGitHubAction))
+      ? [
+          {
+            path: ".github/workflows/claude.yml",
+            reason: "Claude GitHub automation workflow",
+            contents: `${claudeWorkflow(manifest)}\n`
+          }
+        ]
+      : []),
     ...(manifest.ci.aiAttestation.enabled
       ? [
           {
@@ -2894,6 +3232,31 @@ export function renderManagedFiles(manifest: BootstrapManifest): RenderedFile[] 
       contents: codexCloudMaintenanceScript(manifest),
       executable: true
     },
+    ...(manifest.agents.enableClaudeWebEnvironment
+      ? [
+          {
+            path: "scripts/claude-cloud/setup.sh",
+            reason: "Claude cloud setup script",
+            contents: claudeCloudSetupScript(manifest),
+            executable: true
+          }
+        ]
+      : []),
+    ...(manifest.agents.enableClaudeDevcontainer
+      ? [
+          {
+            path: ".devcontainer/devcontainer.json",
+            reason: "Claude interactive devcontainer",
+            contents: claudeDevcontainer(manifest)
+          },
+          {
+            path: "scripts/claude/setup-devcontainer.sh",
+            reason: "Claude devcontainer dependency bootstrap",
+            contents: claudeDevcontainerSetupScript(),
+            executable: true
+          }
+        ]
+      : []),
     {
       path: "docs/bootstrap/onboarding.md",
       reason: "Operator onboarding checklist",
@@ -2904,6 +3267,15 @@ export function renderManagedFiles(manifest: BootstrapManifest): RenderedFile[] 
       reason: "Codex web environment setup guide",
       contents: `${codexCloudDoc(manifest)}\n`
     },
+    ...(claudeEnabled(manifest)
+      ? [
+          {
+            path: "docs/bootstrap/claude-environment.md",
+            reason: "Claude environment setup guide",
+            contents: `${claudeEnvironmentDoc(manifest)}\n`
+          }
+        ]
+      : []),
     ...(manifest.release.enabled
       ? [
           {
@@ -2936,12 +3308,12 @@ export function renderManagedFiles(manifest: BootstrapManifest): RenderedFile[] 
 
   switch (manifest.archetype.kind) {
     case "nextjs-web":
-      return [...files, ...nextJsStarter()];
+      return filterRenderedFiles(manifest, [...files, ...nextJsStarter()]);
     case "node-ts-service":
-      return [...files, ...nodeStarter()];
+      return filterRenderedFiles(manifest, [...files, ...nodeStarter()]);
     case "python-service":
-      return [...files, ...pythonStarter(manifest.archetype.moduleName)];
+      return filterRenderedFiles(manifest, [...files, ...pythonStarter(manifest.archetype.moduleName)]);
     case "generic-empty":
-      return [...files, ...genericStarter(manifest)];
+      return filterRenderedFiles(manifest, [...files, ...genericStarter(manifest)]);
   }
 }

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -126,6 +126,67 @@ const additionalWorkflowSchema = z.object({
   purpose: z.string().min(1)
 });
 
+const repoDocsSchema = z.object({
+  readme: z.boolean().optional(),
+  contributing: z.boolean().optional(),
+  security: z.boolean().optional()
+});
+
+const repoTemplatesSchema = z.object({
+  pullRequest: z.enum(["standard", "none"]).optional(),
+  issueTemplates: z.array(z.string().min(1)).optional()
+});
+
+const repoEnvSchema = z.object({
+  exampleFile: z.boolean().optional(),
+  strategy: z.enum(["required", "optional", "none"]).optional()
+});
+
+const repoHooksSchema = z.object({
+  preCommit: z.enum(["standard", "none"]).optional(),
+  prePush: z.enum(["standard", "none"]).optional()
+});
+
+const githubSecuritySchema = z.object({
+  dependabot: z.boolean().optional(),
+  secretScanningHints: z.boolean().optional()
+});
+
+const ciWorkflowsSchema = z.object({
+  prFastCi: z.boolean().optional(),
+  extendedValidation: z.boolean().optional(),
+  claude: z.boolean().optional(),
+  pagesDeploy: z.boolean().optional(),
+  ci: z.boolean().optional(),
+  extras: z.array(additionalWorkflowSchema).optional()
+});
+
+const capabilitiesSchema = z.object({
+  pages: z
+    .object({
+      enabled: z.boolean().optional(),
+      provider: z.string().min(1).optional(),
+      outputDir: z.string().min(1).optional()
+    })
+    .optional(),
+  release: z
+    .object({
+      enabled: z.boolean().optional(),
+      kind: z.string().min(1).optional()
+    })
+    .optional(),
+  docsPublish: z
+    .object({
+      enabled: z.boolean().optional()
+    })
+    .optional(),
+  containers: z
+    .object({
+      enabled: z.boolean().optional()
+    })
+    .optional()
+});
+
 const dependabotEcosystemSchema = z.object({
   packageEcosystem: z.enum(["npm", "github-actions", "docker"]),
   directory: z.string().min(1).optional(),
@@ -208,12 +269,17 @@ const manifestSchema = z.object({
   }),
   repo: z
     .object({
-      managedPaths: z.array(z.string().min(1)).optional()
+      class: z.enum(["application", "library", "service", "tooling", "documentation"]).optional(),
+      managedPaths: z.array(z.string().min(1)).optional(),
+      docs: repoDocsSchema.optional(),
+      templates: repoTemplatesSchema.optional(),
+      env: repoEnvSchema.optional(),
+      hooks: repoHooksSchema.optional()
     })
     .optional(),
   archetype: z.object({
     kind: z.enum(["nextjs-web", "node-ts-service", "python-service", "generic-empty"]),
-    packageManager: z.enum(["npm", "pnpm", "yarn"]).optional(),
+    packageManager: z.enum(["npm", "pnpm", "yarn", "python"]).optional(),
     moduleName: z.string().optional()
   }),
   github: z
@@ -242,17 +308,20 @@ const manifestSchema = z.object({
           hasWiki: z.boolean().optional(),
           hasDiscussions: z.boolean().optional()
         })
-        .optional()
+        .optional(),
+      security: githubSecuritySchema.optional()
     })
     .optional(),
   ci: z
     .object({
+      policy: z.enum(["standard", "standard-public", "experimental", "strict"]).optional(),
       runnerPolicy: z.enum(["hybrid-safe", "self-hosted-first", "github-hosted-first"]).optional(),
       nodeVersion: z.string().optional(),
       pythonVersion: z.string().optional(),
       fastChecks: z.array(z.string()).optional(),
       extendedChecks: z.array(z.string()).optional(),
       nightlyCron: z.string().optional(),
+      workflows: ciWorkflowsSchema.optional(),
       additionalWorkflows: z.array(additionalWorkflowSchema).optional(),
       appPaths: z.array(z.string().min(1)).optional(),
       ciPaths: z.array(z.string().min(1)).optional(),
@@ -293,10 +362,16 @@ const manifestSchema = z.object({
   agents: z
     .object({
       manageCodexHome: z.boolean().optional(),
+      manageClaudeHome: z.boolean().optional(),
       codexProfile: z.string().optional(),
+      claudeProfile: z.string().optional(),
+      enableClaudeWebEnvironment: z.boolean().optional(),
+      enableClaudeDevcontainer: z.boolean().optional(),
+      enableClaudeGitHubAction: z.boolean().optional(),
       sharedSkills: z.array(z.string()).optional()
     })
     .optional(),
+  capabilities: capabilitiesSchema.optional(),
   environments: z
     .object({
       dev: environmentSchema.optional(),
@@ -428,6 +503,117 @@ function normalizeAdditionalWorkflows(
   }));
 }
 
+function mergeAdditionalWorkflows(
+  additionalWorkflows: AdditionalWorkflowConfig[],
+  extras: AdditionalWorkflowConfig[]
+): AdditionalWorkflowConfig[] {
+  const seen = new Set<string>();
+  return [...additionalWorkflows, ...extras].filter((workflow) => {
+    if (seen.has(workflow.path)) return false;
+    seen.add(workflow.path);
+    return true;
+  });
+}
+
+function normalizeRepo(repo: z.input<typeof manifestSchema>["repo"]): BootstrapManifest["repo"] {
+  return {
+    ...(repo?.class ? { class: repo.class } : {}),
+    managedPaths: repo?.managedPaths ?? [],
+    ...(repo?.docs
+      ? {
+          docs: {
+            readme: repo.docs.readme ?? true,
+            contributing: repo.docs.contributing ?? true,
+            security: repo.docs.security ?? false
+          }
+        }
+      : {}),
+    ...(repo?.templates
+      ? {
+          templates: {
+            pullRequest: repo.templates.pullRequest ?? "standard",
+            issueTemplates: repo.templates.issueTemplates ?? []
+          }
+        }
+      : {}),
+    ...(repo?.env
+      ? {
+          env: {
+            exampleFile: repo.env.exampleFile ?? true,
+            strategy: repo.env.strategy ?? "optional"
+          }
+        }
+      : {}),
+    ...(repo?.hooks
+      ? {
+          hooks: {
+            preCommit: repo.hooks.preCommit ?? "standard",
+            prePush: repo.hooks.prePush ?? "none"
+          }
+        }
+      : {})
+  };
+}
+
+function normalizeCiWorkflows(
+  workflows: z.input<typeof ciWorkflowsSchema> | undefined
+): BootstrapManifest["ci"]["workflows"] | undefined {
+  if (!workflows) {
+    return undefined;
+  }
+
+  return {
+    prFastCi: workflows.prFastCi ?? true,
+    extendedValidation: workflows.extendedValidation ?? true,
+    claude: workflows.claude ?? false,
+    pagesDeploy: workflows.pagesDeploy ?? false,
+    ci: workflows.ci ?? false,
+    extras: normalizeAdditionalWorkflows(workflows.extras)
+  };
+}
+
+function normalizeCapabilities(
+  capabilities: z.input<typeof capabilitiesSchema> | undefined
+): BootstrapManifest["capabilities"] | undefined {
+  if (!capabilities) {
+    return undefined;
+  }
+
+  return {
+    ...(capabilities.pages
+      ? {
+          pages: {
+            enabled: capabilities.pages.enabled ?? false,
+            provider: capabilities.pages.provider ?? "cloudflare-pages",
+            outputDir: capabilities.pages.outputDir ?? "dist"
+          }
+        }
+      : {}),
+    ...(capabilities.release
+      ? {
+          release: {
+            enabled: capabilities.release.enabled ?? true,
+            kind: capabilities.release.kind ?? "github-release"
+          }
+        }
+      : {}),
+    ...(capabilities.docsPublish
+      ? {
+          docsPublish: {
+            enabled: capabilities.docsPublish.enabled ?? false
+          }
+        }
+      : {}),
+    ...(capabilities.containers
+      ? {
+          containers: {
+            enabled: capabilities.containers.enabled ?? false
+          }
+        }
+      : {})
+  };
+}
+
 function normalizeDependabot(
   dependabot: z.input<typeof dependabotSchema> | undefined
 ): DependabotConfig {
@@ -477,6 +663,7 @@ function normalizeCustomScripts(
 
 export function normalizeManifest(raw: z.input<typeof manifestSchema>): BootstrapManifest {
   const parsed = manifestSchema.parse(raw);
+  const version = parsed.version ?? 1;
   const reviewers = (parsed.github?.reviewers ?? []).map((reviewer) => reviewer.replace(/^@/, ""));
   const defaultBranch = parsed.project.defaultBranch ?? "main";
   const moduleName = parsed.archetype.moduleName ?? moduleNameForProject(parsed.project.name);
@@ -485,7 +672,13 @@ export function normalizeManifest(raw: z.input<typeof manifestSchema>): Bootstra
   const repoFeatures = github.repoFeatures ?? {};
   const flowGovernance = github.flowGovernance ?? false;
   const environments = parsed.environments ?? {};
-  const releaseEnabled = parsed.release?.enabled ?? true;
+  const capabilities = normalizeCapabilities(parsed.capabilities);
+  const workflows = normalizeCiWorkflows(parsed.ci?.workflows);
+  const additionalWorkflows = mergeAdditionalWorkflows(
+    normalizeAdditionalWorkflows(parsed.ci?.additionalWorkflows),
+    workflows?.extras ?? []
+  );
+  const releaseEnabled = parsed.release?.enabled ?? capabilities?.release?.enabled ?? true;
 
   const defaultEnvironment = (overrides?: z.input<typeof environmentSchema>): EnvironmentConfig => ({
     reviewers: overrides?.reviewers ?? [],
@@ -495,7 +688,7 @@ export function normalizeManifest(raw: z.input<typeof manifestSchema>): Bootstra
   });
 
   return {
-    version: 1,
+    version,
     project: {
       name: parsed.project.name,
       ...(parsed.project.displayName ? { displayName: parsed.project.displayName } : {}),
@@ -506,9 +699,7 @@ export function normalizeManifest(raw: z.input<typeof manifestSchema>): Bootstra
       owner: parsed.project.owner,
       defaultBranch
     },
-    repo: {
-      managedPaths: parsed.repo?.managedPaths ?? []
-    },
+    repo: normalizeRepo(parsed.repo),
     archetype: {
       kind: parsed.archetype.kind,
       packageManager: parsed.archetype.packageManager ?? "npm",
@@ -537,16 +728,26 @@ export function normalizeManifest(raw: z.input<typeof manifestSchema>): Bootstra
         hasProjects: repoFeatures.hasProjects ?? false,
         hasWiki: repoFeatures.hasWiki ?? false,
         hasDiscussions: repoFeatures.hasDiscussions ?? false
-      }
+      },
+      ...(github.security
+        ? {
+            security: {
+              dependabot: github.security.dependabot ?? true,
+              secretScanningHints: github.security.secretScanningHints ?? true
+            }
+          }
+        : {})
     },
     ci: {
+      ...(parsed.ci?.policy ? { policy: parsed.ci.policy } : {}),
       runnerPolicy: parsed.ci?.runnerPolicy ?? "hybrid-safe",
       nodeVersion: parsed.ci?.nodeVersion ?? "20",
       pythonVersion: parsed.ci?.pythonVersion ?? "3.12",
       fastChecks: parsed.ci?.fastChecks ?? ["lint", "typecheck", "unit", "build", "secrets"],
       extendedChecks: parsed.ci?.extendedChecks ?? ["integration", "release-readiness"],
       nightlyCron: parsed.ci?.nightlyCron ?? "0 7 * * *",
-      additionalWorkflows: normalizeAdditionalWorkflows(parsed.ci?.additionalWorkflows),
+      additionalWorkflows,
+      ...(workflows ? { workflows } : {}),
       appPaths: normalizePaths(parsed.ci?.appPaths),
       ciPaths: normalizePaths(parsed.ci?.ciPaths),
       extendedPaths: normalizePaths(parsed.ci?.extendedPaths),
@@ -599,9 +800,19 @@ export function normalizeManifest(raw: z.input<typeof manifestSchema>): Bootstra
     },
     agents: {
       manageCodexHome: parsed.agents?.manageCodexHome ?? true,
+      ...(version === 2
+        ? {
+            manageClaudeHome: parsed.agents?.manageClaudeHome ?? false,
+            claudeProfile: parsed.agents?.claudeProfile ?? "default",
+            enableClaudeWebEnvironment: parsed.agents?.enableClaudeWebEnvironment ?? false,
+            enableClaudeDevcontainer: parsed.agents?.enableClaudeDevcontainer ?? false,
+            enableClaudeGitHubAction: parsed.agents?.enableClaudeGitHubAction ?? workflows?.claude ?? false
+          }
+        : {}),
       codexProfile: parsed.agents?.codexProfile ?? "default",
       sharedSkills: parsed.agents?.sharedSkills ?? []
     },
+    ...(capabilities ? { capabilities } : {}),
     environments: {
       dev: applyEnvironmentDefaults(defaultEnvironment(environments.dev), reviewers, defaultBranch, "dev"),
       stage: applyEnvironmentDefaults(
@@ -679,8 +890,17 @@ export function createSampleManifest(overrides?: ManifestOverrides): string {
   });
 }
 
+function serializableManifest(manifest: BootstrapManifest): BootstrapManifest | Record<string, unknown> {
+  if (manifest.version !== 2 || !manifest.capabilities?.release) {
+    return manifest;
+  }
+
+  const { release: _release, ...withoutRelease } = manifest;
+  return withoutRelease;
+}
+
 export function stringifyManifest(manifest: BootstrapManifest): string {
-  return YAML.stringify(manifest, {
+  return YAML.stringify(serializableManifest(manifest), {
     lineWidth: 100
   });
 }

--- a/src/render.ts
+++ b/src/render.ts
@@ -38,38 +38,67 @@ function matchesManagedPath(filePath: string, pattern: string): boolean {
   return globToRegExp(pattern).test(filePath.replace(/\\/g, "/"));
 }
 
+const managedPathDependencies = [
+  {
+    path: "AGENTS.md",
+    requires: [
+      ".githooks/pre-commit",
+      ".github/PULL_REQUEST_TEMPLATE.md",
+      "docs/bootstrap/onboarding.md"
+    ]
+  },
+  {
+    path: "CONTRIBUTING.md",
+    requires: [".githooks/pre-commit", ".github/PULL_REQUEST_TEMPLATE.md"]
+  },
+  {
+    path: ".github/PULL_REQUEST_TEMPLATE.md",
+    requires: ["docs/bootstrap/onboarding.md"]
+  }
+];
+
+function expandManagedPathDependencies(files: RenderedFile[], selectedFiles: RenderedFile[]): RenderedFile[] {
+  const availablePaths = new Set(files.map((file) => file.path));
+  const selectedPaths = new Set(selectedFiles.map((file) => file.path));
+  let changed = true;
+
+  while (changed) {
+    changed = false;
+    for (const { path: managedPath, requires } of managedPathDependencies) {
+      if (!selectedPaths.has(managedPath)) {
+        continue;
+      }
+
+      for (const requiredPath of requires) {
+        if (!selectedPaths.has(requiredPath) && availablePaths.has(requiredPath)) {
+          selectedPaths.add(requiredPath);
+          changed = true;
+        }
+      }
+    }
+  }
+
+  return files.filter((file) => selectedPaths.has(file.path));
+}
+
 function selectManagedFiles(manifest: BootstrapManifest, files: RenderedFile[]): RenderedFile[] {
   if (manifest.repo.managedPaths.length === 0) {
     return files;
   }
 
-  const selectedFiles = files.filter((file) =>
+  let selectedFiles = files.filter((file) =>
     manifest.repo.managedPaths.some((pattern) => matchesManagedPath(file.path, pattern))
   );
+  if (manifest.version === 2) {
+    selectedFiles = expandManagedPathDependencies(files, selectedFiles);
+  }
   validateManagedPathDependencies(selectedFiles);
   return selectedFiles;
 }
 
 function validateManagedPathDependencies(files: RenderedFile[]): void {
   const selectedPaths = new Set(files.map((file) => file.path));
-  const dependencies = [
-    {
-      path: "AGENTS.md",
-      requires: [
-        ".githooks/pre-commit",
-        ".github/PULL_REQUEST_TEMPLATE.md",
-        "docs/bootstrap/onboarding.md"
-      ]
-    },
-    {
-      path: "CONTRIBUTING.md",
-      requires: [".githooks/pre-commit", ".github/PULL_REQUEST_TEMPLATE.md"]
-    },
-    {
-      path: ".github/PULL_REQUEST_TEMPLATE.md",
-      requires: ["docs/bootstrap/onboarding.md"]
-    }
-  ];
+  const dependencies = managedPathDependencies;
 
   const violations = dependencies.flatMap(({ path: managedPath, requires }) => {
     if (!selectedPaths.has(managedPath)) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,10 @@
 export type ProjectVisibility = "private" | "public" | "internal";
 export type ArchetypeKind = "nextjs-web" | "node-ts-service" | "python-service" | "generic-empty";
+export type PackageManager = "npm" | "pnpm" | "yarn" | "python";
 export type RunnerPolicy = "hybrid-safe" | "self-hosted-first" | "github-hosted-first";
 export type DefaultRepositoryPermission = "read" | "write" | "admin" | "none";
+export type RepoClass = "application" | "library" | "service" | "tooling" | "documentation";
+export type CiPolicy = "standard" | "standard-public" | "experimental" | "strict";
 
 export interface CodeownerRule {
   pattern: string;
@@ -22,7 +25,25 @@ export interface EnvironmentConfig {
 }
 
 export interface RepoConfig {
+  class?: RepoClass;
   managedPaths: string[];
+  docs?: {
+    readme: boolean;
+    contributing: boolean;
+    security: boolean;
+  };
+  templates?: {
+    pullRequest: "standard" | "none";
+    issueTemplates: string[];
+  };
+  env?: {
+    exampleFile: boolean;
+    strategy: "required" | "optional" | "none";
+  };
+  hooks?: {
+    preCommit: "standard" | "none";
+    prePush: "standard" | "none";
+  };
 }
 
 export interface AdditionalWorkflowConfig {
@@ -118,7 +139,7 @@ export interface OrganizationConfig {
 }
 
 export interface BootstrapManifest {
-  version: 1;
+  version: 1 | 2;
   project: {
     name: string;
     displayName?: string;
@@ -130,7 +151,7 @@ export interface BootstrapManifest {
   repo: RepoConfig;
   archetype: {
     kind: ArchetypeKind;
-    packageManager: "npm" | "pnpm" | "yarn";
+    packageManager: PackageManager;
     moduleName: string;
   };
   github: {
@@ -157,8 +178,13 @@ export interface BootstrapManifest {
       hasWiki: boolean;
       hasDiscussions: boolean;
     };
+    security?: {
+      dependabot: boolean;
+      secretScanningHints: boolean;
+    };
   };
   ci: {
+    policy?: CiPolicy;
     runnerPolicy: RunnerPolicy;
     nodeVersion: string;
     pythonVersion: string;
@@ -166,6 +192,14 @@ export interface BootstrapManifest {
     extendedChecks: string[];
     nightlyCron: string;
     additionalWorkflows: AdditionalWorkflowConfig[];
+    workflows?: {
+      prFastCi: boolean;
+      extendedValidation: boolean;
+      claude: boolean;
+      pagesDeploy: boolean;
+      ci: boolean;
+      extras: AdditionalWorkflowConfig[];
+    };
     appPaths: string[];
     ciPaths: string[];
     extendedPaths: string[];
@@ -199,8 +233,30 @@ export interface BootstrapManifest {
   };
   agents: {
     manageCodexHome: boolean;
+    manageClaudeHome?: boolean;
     codexProfile: string;
+    claudeProfile?: string;
+    enableClaudeWebEnvironment?: boolean;
+    enableClaudeDevcontainer?: boolean;
+    enableClaudeGitHubAction?: boolean;
     sharedSkills: string[];
+  };
+  capabilities?: {
+    pages?: {
+      enabled: boolean;
+      provider: string;
+      outputDir: string;
+    };
+    release?: {
+      enabled: boolean;
+      kind: string;
+    };
+    docsPublish?: {
+      enabled: boolean;
+    };
+    containers?: {
+      enabled: boolean;
+    };
   };
   environments: {
     dev: EnvironmentConfig;

--- a/tests/manifest.test.ts
+++ b/tests/manifest.test.ts
@@ -34,7 +34,7 @@ describe("normalizeManifest", () => {
       }
     } as never);
 
-    expect(manifest.version).toBe(1);
+    expect(manifest.version).toBe(2);
     expect(manifest.project.name).toBe("apw-cli");
     expect(manifest.repo.managedPaths).toContain(".github/workflows/pr-fast-ci.yml");
     expect(manifest.ci.runnerPolicy).toBe("hybrid-safe");
@@ -404,6 +404,136 @@ describe("normalizeManifest", () => {
       codexProfile: "default",
       sharedSkills: []
     });
+  });
+
+
+  it("normalizes representative version 2 manifests with rich repo, CI, agent, and capability fields", () => {
+    const manifest = normalizeManifest({
+      version: 2,
+      project: {
+        name: "mailplus-intelligence",
+        displayName: "MailPlus Intelligence",
+        description: "Intelligence and automation workspace for MailPlus-related tooling.",
+        visibility: "public",
+        owner: "OMT-Global",
+        defaultBranch: "main"
+      },
+      repo: {
+        class: "library",
+        managedPaths: ["project.bootstrap.yaml", ".github/workflows/claude.yml"],
+        docs: {
+          readme: true,
+          contributing: true,
+          security: true
+        },
+        templates: {
+          pullRequest: "standard",
+          issueTemplates: ["bug", "feature"]
+        },
+        env: {
+          exampleFile: false,
+          strategy: "optional"
+        },
+        hooks: {
+          preCommit: "standard",
+          prePush: "none"
+        }
+      },
+      archetype: {
+        kind: "generic-empty",
+        packageManager: "python",
+        moduleName: "mailplus_intelligence"
+      },
+      github: {
+        createRepo: false,
+        reviewers: ["jmcte"],
+        codeowners: [{ pattern: "*", owners: ["@jmcte"] }],
+        allowRebaseMerge: true,
+        security: {
+          dependabot: false,
+          secretScanningHints: true
+        }
+      },
+      ci: {
+        policy: "experimental",
+        fastChecks: ["secrets", "unit-tests"],
+        extendedChecks: ["template-review", "fixture-regression"],
+        workflows: {
+          prFastCi: true,
+          extendedValidation: true,
+          claude: true,
+          pagesDeploy: false,
+          ci: false,
+          extras: [
+            {
+              path: ".github\\workflows\\deploy.yml",
+              purpose: "Deploys documentation after CI passes."
+            }
+          ]
+        },
+        additionalWorkflows: []
+      },
+      agents: {
+        manageCodexHome: true,
+        manageClaudeHome: true,
+        codexProfile: "default",
+        claudeProfile: "default",
+        enableClaudeWebEnvironment: true,
+        enableClaudeDevcontainer: true,
+        enableClaudeGitHubAction: true,
+        sharedSkills: []
+      },
+      capabilities: {
+        pages: {
+          enabled: false,
+          provider: "cloudflare-pages",
+          outputDir: "dist"
+        },
+        release: {
+          enabled: true,
+          kind: "github-release"
+        },
+        docsPublish: {
+          enabled: false
+        },
+        containers: {
+          enabled: false
+        }
+      }
+    });
+
+    expect(manifest.version).toBe(2);
+    expect(manifest.repo).toMatchObject({
+      class: "library",
+      docs: { readme: true, contributing: true, security: true },
+      env: { exampleFile: false, strategy: "optional" },
+      hooks: { preCommit: "standard", prePush: "none" }
+    });
+    expect(manifest.archetype.packageManager).toBe("python");
+    expect(manifest.github.security).toEqual({ dependabot: false, secretScanningHints: true });
+    expect(manifest.ci.policy).toBe("experimental");
+    expect(manifest.ci.workflows).toMatchObject({
+      prFastCi: true,
+      extendedValidation: true,
+      claude: true,
+      pagesDeploy: false,
+      ci: false
+    });
+    expect(manifest.ci.additionalWorkflows).toEqual([
+      {
+        path: ".github/workflows/deploy.yml",
+        purpose: "Deploys documentation after CI passes."
+      }
+    ]);
+    expect(manifest.agents).toMatchObject({
+      manageClaudeHome: true,
+      claudeProfile: "default",
+      enableClaudeWebEnvironment: true,
+      enableClaudeDevcontainer: true,
+      enableClaudeGitHubAction: true
+    });
+    expect(manifest.capabilities?.release).toEqual({ enabled: true, kind: "github-release" });
+    expect(manifest.release.enabled).toBe(true);
   });
 
   it("normalizes optional organization governance settings", () => {

--- a/tests/render.test.ts
+++ b/tests/render.test.ts
@@ -175,6 +175,96 @@ describe("renderManagedFiles", () => {
     expect(onboarding?.contents).toContain("Fallback merge readiness requires");
   });
 
+
+  it("renders version 2 docs, templates, environment, and workflow switches", () => {
+    const manifest = normalizeManifest({
+      version: 2,
+      project: {
+        name: "mailplus-intelligence",
+        displayName: "MailPlus Intelligence",
+        description: "Intelligence and automation workspace for MailPlus-related tooling.",
+        visibility: "public",
+        owner: "OMT-Global"
+      },
+      repo: {
+        class: "library",
+        docs: {
+          readme: true,
+          contributing: true,
+          security: true
+        },
+        templates: {
+          pullRequest: "standard",
+          issueTemplates: ["bug", "feature"]
+        },
+        env: {
+          exampleFile: false,
+          strategy: "optional"
+        },
+        hooks: {
+          preCommit: "standard",
+          prePush: "none"
+        }
+      },
+      archetype: {
+        kind: "generic-empty",
+        packageManager: "python",
+        moduleName: "mailplus_intelligence"
+      },
+      github: {
+        security: {
+          dependabot: false,
+          secretScanningHints: true
+        }
+      },
+      ci: {
+        policy: "experimental",
+        workflows: {
+          prFastCi: true,
+          extendedValidation: false,
+          claude: true,
+          pagesDeploy: false,
+          ci: false,
+          extras: []
+        }
+      },
+      agents: {
+        manageClaudeHome: true,
+        enableClaudeWebEnvironment: true,
+        enableClaudeDevcontainer: true,
+        enableClaudeGitHubAction: true
+      },
+      capabilities: {
+        release: {
+          enabled: true,
+          kind: "github-release"
+        }
+      }
+    });
+
+    const files = renderManagedFiles(manifest);
+    const paths = files.map((file) => file.path);
+    const renderedManifest = files.find((file) => file.path === "project.bootstrap.yaml");
+    const claudeWorkflow = files.find((file) => file.path === ".github/workflows/claude.yml");
+
+    expect(paths).toContain("SECURITY.md");
+    expect(paths).toContain("CLAUDE.md");
+    expect(paths).toContain(".github/ISSUE_TEMPLATE/bug.yml");
+    expect(paths).toContain(".github/ISSUE_TEMPLATE/feature.yml");
+    expect(paths).toContain(".github/workflows/pr-fast-ci.yml");
+    expect(paths).toContain(".github/workflows/claude.yml");
+    expect(paths).toContain(".devcontainer/devcontainer.json");
+    expect(paths).toContain("scripts/claude-cloud/setup.sh");
+    expect(paths).toContain("docs/bootstrap/claude-environment.md");
+    expect(paths).not.toContain(".env.example");
+    expect(paths).not.toContain(".github/workflows/extended-validation.yml");
+    expect(renderedManifest?.contents).toContain("version: 2");
+    expect(renderedManifest?.contents).toContain("capabilities:");
+    expect(renderedManifest?.contents).not.toContain("\nrelease:\n");
+    expect(claudeWorkflow?.contents).toContain("name: Claude Code");
+    expect(claudeWorkflow?.contents).toContain("anthropics/claude-code-action@v1");
+  });
+
   it("documents required PR template enforcement in generated agent instructions", () => {
     const manifest = normalizeManifest({
       project: {

--- a/tests/smoke.test.ts
+++ b/tests/smoke.test.ts
@@ -98,6 +98,169 @@ describe("repo smoke", () => {
     expect(secondPlan.changes.every((change) => change.type === "unchanged")).toBe(true);
   });
 
+  it("plans version 2 guidance companions for canonical restricted managed paths", async () => {
+    const targetDir = await makeTempDir();
+    const manifest = normalizeManifest({
+      version: 2,
+      project: {
+        name: "mailplus-intelligence",
+        displayName: "MailPlus Intelligence",
+        description: "Intelligence and automation workspace for MailPlus-related tooling.",
+        visibility: "public",
+        owner: "OMT-Global",
+        defaultBranch: "main"
+      },
+      repo: {
+        class: "library",
+        managedPaths: [
+          "project.bootstrap.yaml",
+          "AGENTS.md",
+          "CLAUDE.md",
+          "CODEOWNERS",
+          "CONTRIBUTING.md",
+          "LICENSE",
+          "SECURITY.md",
+          ".githooks/**",
+          ".devcontainer/**",
+          ".github/workflows/pr-fast-ci.yml",
+          ".github/workflows/extended-validation.yml",
+          ".github/workflows/claude.yml",
+          ".github/workflows/release.yml",
+          "scripts/check-detect-secrets.sh",
+          "scripts/ci/**",
+          "scripts/release/**",
+          "scripts/codex-cloud/**",
+          "scripts/claude-cloud/**",
+          "scripts/claude/**",
+          "docs/bootstrap/**"
+        ],
+        docs: {
+          readme: true,
+          contributing: true,
+          security: true
+        },
+        templates: {
+          pullRequest: "standard",
+          issueTemplates: ["bug", "feature"]
+        },
+        env: {
+          exampleFile: false,
+          strategy: "optional"
+        },
+        hooks: {
+          preCommit: "standard",
+          prePush: "none"
+        }
+      },
+      archetype: {
+        kind: "generic-empty",
+        packageManager: "python",
+        moduleName: "mailplus_intelligence"
+      },
+      github: {
+        createRepo: false,
+        reviewers: ["jmcte"],
+        codeowners: [
+          {
+            pattern: "*",
+            owners: ["@jmcte"]
+          }
+        ],
+        autoMerge: true,
+        deleteBranchOnMerge: true,
+        requiredApprovals: 1,
+        requiredStatusChecks: ["CI Gate"],
+        dismissStaleReviews: true,
+        requireCodeOwnerReviews: true,
+        requireLastPushApproval: true,
+        enforceLinearHistory: true,
+        allowMergeCommit: true,
+        allowSquashMerge: true,
+        allowRebaseMerge: true,
+        repoFeatures: {
+          hasIssues: true,
+          hasProjects: false,
+          hasWiki: false,
+          hasDiscussions: false
+        },
+        security: {
+          dependabot: true,
+          secretScanningHints: true
+        }
+      },
+      ci: {
+        policy: "experimental",
+        runnerPolicy: "hybrid-safe",
+        nodeVersion: "20",
+        pythonVersion: "3.12",
+        fastChecks: ["secrets", "unit-tests"],
+        extendedChecks: ["template-review", "fixture-regression"],
+        nightlyCron: "0 7 * * *",
+        workflows: {
+          prFastCi: true,
+          extendedValidation: true,
+          claude: true,
+          pagesDeploy: false,
+          ci: false,
+          extras: []
+        },
+        additionalWorkflows: []
+      },
+      agents: {
+        manageCodexHome: true,
+        manageClaudeHome: true,
+        codexProfile: "default",
+        claudeProfile: "default",
+        enableClaudeWebEnvironment: true,
+        enableClaudeDevcontainer: true,
+        enableClaudeGitHubAction: true,
+        sharedSkills: []
+      },
+      capabilities: {
+        pages: {
+          enabled: false,
+          provider: "cloudflare-pages",
+          outputDir: "dist"
+        },
+        release: {
+          enabled: true,
+          kind: "github-release"
+        },
+        docsPublish: {
+          enabled: false
+        },
+        containers: {
+          enabled: false
+        }
+      },
+      environments: {
+        dev: {
+          reviewers: [],
+          requireApproval: false,
+          preventSelfReview: false,
+          branches: []
+        },
+        stage: {
+          reviewers: ["jmcte"],
+          requireApproval: true,
+          preventSelfReview: true,
+          branches: []
+        },
+        prod: {
+          reviewers: ["jmcte"],
+          requireApproval: true,
+          preventSelfReview: true,
+          branches: ["main"]
+        }
+      }
+    });
+
+    const plan = await planRepo(manifest, targetDir);
+
+    expect(plan.changes.some((change) => change.path === ".github/PULL_REQUEST_TEMPLATE.md")).toBe(true);
+    expect(plan.files.some((file) => file.path === ".github/PULL_REQUEST_TEMPLATE.md")).toBe(true);
+  });
+
   it("rejects selected guidance when repo.managedPaths excludes referenced companion files", async () => {
     const targetDir = await makeTempDir();
     const manifest = normalizeManifest({


### PR DESCRIPTION
## Summary
- accept and normalize project.bootstrap.yaml version 2 manifests while preserving v1 compatibility
- preserve v2 repo/docs/templates/env/hooks, github.security, ci.policy/workflows, agent Claude fields, and capabilities blocks
- render v2-controlled SECURITY, issue templates, Claude surfaces, env-file omission, and workflow toggles
- expand required managed-path companion guidance for v2 manifests during plan/apply so canonical restricted v2 manifests still use the real operator path
- refresh the branch onto bootstrap main after #51 and retain `standard-public` as a valid v2 CI policy

## Governing Issue
No governing issue is linked; this is a follow-up repair to the held bootstrap v2 support PR after #51 landed.

## Validation
- [x] `npm run typecheck`
- [x] `npx vitest run tests/manifest.test.ts tests/render.test.ts`
- [x] `npm test`
- [x] `npm run build`
- [x] `npm run check`
- [x] `node dist/cli.js plan --manifest /tmp/mailplus-origin-main.project.bootstrap.yaml --target /tmp/bootstrap-athena-smoke --json` using `OMT-Global/mailplus-intelligence` `origin/main:project.bootstrap.yaml`
- [x] Required PR checks are expected to satisfy `CI Gate`
- [x] Skipped checks are explained below: none expected after the branch refresh

## Bootstrap Governance
- [x] Changes are scoped to v2 parse/validate/render support for bootstrap tooling
- [x] Contributor or PR guidance changes are reflected where applicable: v2 plan/apply now auto-includes required companion guidance when selected managed paths reference it
- [x] Auto-merge is enabled, or GitHub plan-limit evidence is recorded and the fallback merge-readiness policy applies
- [x] No real secrets, runtime auth, or machine-local env files are committed

## Merge Automation
- Auto-merge is armed with `gh pr merge --auto --squash`; GitHub still requires checks and Athena review before merge.

## Notes
- This does not apply v2 manifests to other repos; it only updates bootstrap tooling support.
