### PR TITLE
ci: upgrade paths-filter templates to v4

### DIFF
--- a/.github/workflows/extended-validation.yml
+++ b/.github/workflows/extended-validation.yml
@@ -46,7 +46,7 @@ jobs:
           extended=true
           EOF
 
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@v4
         id: filter
         if: github.event_name == 'push'
         with:

--- a/.github/workflows/pr-fast-ci.yml
+++ b/.github/workflows/pr-fast-ci.yml
@@ -27,7 +27,7 @@ jobs:
       app: ${{ steps.filter.outputs.app }}
       ci: ${{ steps.filter.outputs.ci }}
     steps:
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@v4
         id: filter
         with:
           filters: |

--- a/src/archetypes.ts
+++ b/src/archetypes.ts
@@ -2276,7 +2276,7 @@ function prWorkflow(manifest: BootstrapManifest): string {
           app: \${{ steps.filter.outputs.app }}
           ci: \${{ steps.filter.outputs.ci }}
         steps:
-          - uses: dorny/paths-filter@v3
+          - uses: dorny/paths-filter@v4
             id: filter
             with:
               filters: |
@@ -2449,7 +2449,7 @@ function extendedWorkflow(manifest: BootstrapManifest): string {
               extended=true
               EOF
 
-          - uses: dorny/paths-filter@v3
+          - uses: dorny/paths-filter@v4
             id: filter
             if: github.event_name == 'push'
             with:

--- a/tests/render.test.ts
+++ b/tests/render.test.ts
@@ -40,7 +40,12 @@ describe("renderManagedFiles", () => {
       ).toMatchSnapshot();
 
       const prWorkflow = files.find((file) => file.path === ".github/workflows/pr-fast-ci.yml");
+      const extendedValidationWorkflow = files.find((file) => file.path === ".github/workflows/extended-validation.yml");
       expect(prWorkflow?.contents).toContain("name: CI Gate");
+      expect(prWorkflow?.contents).toContain("dorny/paths-filter@v4");
+      expect(prWorkflow?.contents).not.toContain("dorny/paths-filter@v3");
+      expect(extendedValidationWorkflow?.contents).toContain("dorny/paths-filter@v4");
+      expect(extendedValidationWorkflow?.contents).not.toContain("dorny/paths-filter@v3");
       expect(prWorkflow?.contents).toContain("types: [opened, edited, synchronize, reopened, ready_for_review]");
       expect(prWorkflow?.contents).toContain("['self-hosted', 'linux'");
       expect(prWorkflow?.contents).toContain("validate-pr-description:");
@@ -245,6 +250,7 @@ describe("renderManagedFiles", () => {
     const files = renderManagedFiles(manifest);
     const paths = files.map((file) => file.path);
     const renderedManifest = files.find((file) => file.path === "project.bootstrap.yaml");
+    const prWorkflow = files.find((file) => file.path === ".github/workflows/pr-fast-ci.yml");
     const claudeWorkflow = files.find((file) => file.path === ".github/workflows/claude.yml");
 
     expect(paths).toContain("SECURITY.md");
@@ -261,6 +267,8 @@ describe("renderManagedFiles", () => {
     expect(renderedManifest?.contents).toContain("version: 2");
     expect(renderedManifest?.contents).toContain("capabilities:");
     expect(renderedManifest?.contents).not.toContain("\nrelease:\n");
+    expect(prWorkflow?.contents).toContain("dorny/paths-filter@v4");
+    expect(prWorkflow?.contents).not.toContain("dorny/paths-filter@v3");
     expect(claudeWorkflow?.contents).toContain("name: Claude Code");
     expect(claudeWorkflow?.contents).toContain("anthropics/claude-code-action@v1");
   });


### PR DESCRIPTION
## Summary

- Upgrade Bootstrap's generated PR Fast CI and Extended Validation templates from `dorny/paths-filter@v3` to `@v4`.
- Align Bootstrap's own checked-in workflows with the templates and add private/hybrid plus public render assertions.
- Record the required plan-first rollout inventory: `bootstrap`, `apw-cli`, `dockyard`, `Flapline`, and `machete` each have the two affected managed workflows.

## Governing Issue

Refs #50. This PR completes the control-plane update; the downstream repository refreshes and replacement-CI proof remain before the issue can close.

## Validation

- [x] `npm test -- --run tests/render.test.ts` (16 tests passed)
- [x] `npm run build`
- [x] `node dist/cli.js plan --manifest project.bootstrap.yaml --target . --json` (both Bootstrap workflow paths unchanged after rendering)
- [ ] `npm run check` is currently blocked by the pre-existing `test/release-workflow-guards.test.ts` expectation for `validation-evidence.json`; the same mismatch exists at `origin/main` and is outside this change.

## Bootstrap Governance

- [x] Changes are scoped to issue #50 and Bootstrap-managed workflow paths.
- [x] The v4 review found the existing positive inline globs and boolean filter outputs remain supported; no new `list-files`, `ref`, or pattern semantics are used.
- [x] No real secrets, runtime auth, or machine-local env files are committed.

## Merge Automation

- [ ] Enable auto-merge after the required review and CI checks pass.

## Notes

- Auto-merge is enabled with squash merge; independent review and required checks remain enforced.
- The plan-first inventory was read-only; no downstream repository workflows were changed in this PR.
