### PR TITLE
feat: resolve verified Flow policy bundles

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -19,6 +19,9 @@ Refs #<issue-number>  <!-- use Closes/Fixes/Resolves only when this PR fully com
 - [ ] PR author enabled auto-merge where GitHub allows it, or GitHub plan-limit evidence/unavailable reason is recorded and the fallback merge-readiness policy applies
 - [ ] No real secrets, runtime auth, or machine-local env files are committed
 
+Material change: no
+ADR: docs/decisions/ADR-<number>-<slug>.md  <!-- required when Material change is yes; ADR status must be Accepted -->
+
 
 
 ## Merge Automation

--- a/.github/workflows/ai-attestation-reusable.yml
+++ b/.github/workflows/ai-attestation-reusable.yml
@@ -34,12 +34,12 @@ jobs:
     outputs:
       sha: ${{ steps.meta.outputs.sha }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 1
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@v4.1.2
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
       - name: Collect metadata and write attestation
         id: meta
@@ -82,7 +82,7 @@ jobs:
             "attest/${sha}.json"
 
       - name: Upload attestation artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: ${{ inputs.artifact_name }}-${{ steps.meta.outputs.sha }}
           path: attest/
@@ -93,10 +93,10 @@ jobs:
     needs: attest
     steps:
       - name: Install cosign
-        uses: sigstore/cosign-installer@v4.1.2
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
       - name: Download attestation artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: ${{ inputs.artifact_name }}-${{ needs.attest.outputs.sha }}
           path: attest

--- a/.github/workflows/extended-validation.yml
+++ b/.github/workflows/extended-validation.yml
@@ -31,7 +31,7 @@ jobs:
       ci: ${{ steps.preset.outputs.ci || steps.filter.outputs.ci || 'false' }}
       extended: ${{ steps.preset.outputs.extended || steps.filter.outputs.extended || 'false' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         if: github.event_name == 'push'
         with:
           fetch-depth: 0
@@ -46,7 +46,7 @@ jobs:
           extended=true
           EOF
 
-      - uses: dorny/paths-filter@v4
+      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4
         id: filter
         if: github.event_name == 'push'
         with:
@@ -84,7 +84,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.app == 'true' || needs.changes.outputs.ci == 'true'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Run fast checks
         run: bash scripts/ci/run-fast-checks.sh
@@ -96,7 +96,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.extended == 'true' || needs.changes.outputs.app == 'true'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Run extended validation
         run: bash scripts/ci/run-extended-validation.sh
@@ -106,7 +106,7 @@ jobs:
     runs-on: ['self-hosted', 'linux', 'shell-only', 'public']
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Scan repository for secret patterns
         run: bash scripts/check-detect-secrets.sh --all-files
 

--- a/.github/workflows/full-release-validation-reusable.yml
+++ b/.github/workflows/full-release-validation-reusable.yml
@@ -22,7 +22,7 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ inputs.target_ref }}
           fetch-depth: 0
@@ -49,7 +49,7 @@ jobs:
           cat >"$ARTIFACT_DIR/validation-evidence.json" <<JSON
           {"schema_version":1,"repo":"${GITHUB_REPOSITORY}","target_ref":"${TARGET_REF}","target_sha":"${target_sha}","validation_run_id":"${GITHUB_RUN_ID}","release_profile":"${RELEASE_PROFILE}","checks":{"validate_script":"${validate_status}","standard_checks":"${standard_status}"}}
           JSON
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: ${{ inputs.evidence_artifact_name }}-validation
           path: ${{ inputs.artifact_dir }}/validation-evidence.json

--- a/.github/workflows/pr-fast-ci.yml
+++ b/.github/workflows/pr-fast-ci.yml
@@ -3,6 +3,8 @@ name: PR Fast CI
 on:
   pull_request:
     types: [opened, edited, synchronize, reopened, ready_for_review]
+  pull_request_review:
+    types: [submitted, edited, dismissed]
 
 concurrency:
   group: pr-fast-${{ github.event.pull_request.number || github.ref }}
@@ -142,6 +144,8 @@ jobs:
       PR_TITLE: ${{ github.event.pull_request.title }}
       PR_BODY: ${{ github.event.pull_request.body }}
       PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+      PR_CREATED_AT: ${{ github.event.pull_request.created_at }}
+      PR_GOVERNANCE_ENFORCE_AFTER: '2026-07-13T23:00:00Z'
       PR_FILES_URL: ${{ github.event.pull_request.url }}/files
       PR_COMMITS_URL: ${{ github.event.pull_request.commits_url }}
       PR_REVIEWS_URL: ${{ github.event.pull_request.url }}/reviews

--- a/.github/workflows/pr-fast-ci.yml
+++ b/.github/workflows/pr-fast-ci.yml
@@ -10,6 +10,7 @@ concurrency:
 
 permissions:
   contents: read
+  pull-requests: read
 
 env:
   NODE_VERSION: '20'
@@ -132,6 +133,26 @@ jobs:
       - name: Scan repository for secret patterns
         run: bash scripts/check-detect-secrets.sh --all-files
 
+  validate-pr-governance:
+    name: Validate PR Governance
+    runs-on: ['self-hosted', 'linux', 'shell-only', 'public']
+    timeout-minutes: 5
+    if: github.event.pull_request.draft == false
+    env:
+      PR_TITLE: ${{ github.event.pull_request.title }}
+      PR_BODY: ${{ github.event.pull_request.body }}
+      PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+      PR_FILES_URL: ${{ github.event.pull_request.url }}/files
+      PR_COMMITS_URL: ${{ github.event.pull_request.commits_url }}
+      PR_REVIEWS_URL: ${{ github.event.pull_request.url }}/reviews
+      GITHUB_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Validate title, DCO, size, ADR, and reviewer evidence
+        run: bash scripts/ci/check-pr-governance.sh
+
   ci-gate:
     name: CI Gate
     runs-on: ['self-hosted', 'linux', 'shell-only', 'public']
@@ -141,6 +162,7 @@ jobs:
       - fast-checks
       - validate-pr-description
       - validate-secrets
+      - validate-pr-governance
     steps:
       - name: Check required PR jobs
         env:
@@ -149,6 +171,7 @@ jobs:
             fast-checks=${{ needs.fast-checks.result }}
             validate-pr-description=${{ needs.validate-pr-description.result }}
             validate-secrets=${{ needs.validate-secrets.result }}
+            validate-pr-governance=${{ needs.validate-pr-governance.result }}
         run: |
           failed=0
           for entry in $RESULTS; do

--- a/.github/workflows/pr-fast-ci.yml
+++ b/.github/workflows/pr-fast-ci.yml
@@ -28,7 +28,7 @@ jobs:
       app: ${{ steps.filter.outputs.app }}
       ci: ${{ steps.filter.outputs.ci }}
     steps:
-      - uses: dorny/paths-filter@v4
+      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4
         id: filter
         with:
           filters: |
@@ -64,7 +64,7 @@ jobs:
       github.event.pull_request.draft == false &&
       (needs.changes.outputs.app == 'true' || needs.changes.outputs.ci == 'true')
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
@@ -127,7 +127,7 @@ jobs:
     timeout-minutes: 10
     if: github.event.pull_request.draft == false
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Scan repository for secret patterns
@@ -147,11 +147,23 @@ jobs:
       PR_REVIEWS_URL: ${{ github.event.pull_request.url }}/reviews
       GITHUB_TOKEN: ${{ github.token }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Validate title, DCO, size, ADR, and reviewer evidence
         run: bash scripts/ci/check-pr-governance.sh
+
+  validate-action-pins:
+    name: Validate Action Pins
+    runs-on: ['self-hosted', 'linux', 'shell-only', 'public']
+    timeout-minutes: 5
+    if: github.event.pull_request.draft == false
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Require immutable third-party action pins
+        run: bash scripts/ci/check-action-pins.sh
 
   ci-gate:
     name: CI Gate
@@ -163,6 +175,7 @@ jobs:
       - validate-pr-description
       - validate-secrets
       - validate-pr-governance
+      - validate-action-pins
     steps:
       - name: Check required PR jobs
         env:
@@ -172,6 +185,7 @@ jobs:
             validate-pr-description=${{ needs.validate-pr-description.result }}
             validate-secrets=${{ needs.validate-secrets.result }}
             validate-pr-governance=${{ needs.validate-pr-governance.result }}
+            validate-action-pins=${{ needs.validate-action-pins.result }}
         run: |
           failed=0
           for entry in $RESULTS; do

--- a/.github/workflows/release-postpublish-reusable.yml
+++ b/.github/workflows/release-postpublish-reusable.yml
@@ -21,7 +21,7 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ inputs.tag }}
           fetch-depth: 0
@@ -46,7 +46,7 @@ jobs:
             exit 1
           fi
           printf '{"schema_version":1,"repo":"%s","tag":"%s","channel":"%s","release_issue":"%s","postpublish_run_id":"%s","release_assets":%s}\n' "$GITHUB_REPOSITORY" "$TAG" "$CHANNEL" "$RELEASE_ISSUE" "$GITHUB_RUN_ID" "$asset_count" >"$ARTIFACT_DIR/postpublish-evidence.json"
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: ${{ inputs.evidence_artifact_name }}-postpublish
           path: ${{ inputs.artifact_dir }}/postpublish-evidence.json

--- a/.github/workflows/release-preflight-reusable.yml
+++ b/.github/workflows/release-preflight-reusable.yml
@@ -30,7 +30,7 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ inputs.target_ref }}
           fetch-depth: 0
@@ -76,13 +76,13 @@ jobs:
           {"schema_version":1,"repo":"${GITHUB_REPOSITORY}","version":"${VERSION}","channel":"${CHANNEL}","target_ref":"${TARGET_REF}","target_sha":"${target_sha}","release_issue":"${RELEASE_ISSUE}","preflight_run_id":"${GITHUB_RUN_ID}","checks":{"prep":"${prep_status}","preflight":"${preflight_status}","build":"${build_status}"}}
           JSON
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: release-package
           path: ${{ inputs.artifact_dir }}/
           retention-days: ${{ inputs.evidence_retention_days }}
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: ${{ inputs.evidence_artifact_name }}
           path: |

--- a/.github/workflows/release-publish-reusable.yml
+++ b/.github/workflows/release-publish-reusable.yml
@@ -39,7 +39,7 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ inputs.tag }}
           fetch-depth: 0
@@ -152,7 +152,7 @@ jobs:
             exit 1
           fi
           printf '{"schema_version":1,"repo":"%s","tag":"%s","tag_sha":"%s","publish_run_id":"%s"}\n' "$GITHUB_REPOSITORY" "$TAG" "$tag_sha" "$GITHUB_RUN_ID" >"$ARTIFACT_DIR/postpublish-evidence.json"
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: ${{ inputs.evidence_artifact_name }}-publish
           path: ${{ inputs.artifact_dir }}/postpublish-evidence.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,7 +100,7 @@ jobs:
       DOCKYARD_SPARKLE_SIGN_UPDATE: ${{ secrets.DOCKYARD_SPARKLE_SIGN_UPDATE }}
       SPARKLE_FRAMEWORK_PATH: ${{ secrets.SPARKLE_FRAMEWORK_PATH }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
       - name: Derive release metadata

--- a/.github/workflows/security-pr.yml
+++ b/.github/workflows/security-pr.yml
@@ -43,8 +43,8 @@ jobs:
       contents: read
       pull-requests: read
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/dependency-review-action@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4
         with:
           fail-on-severity: high
 
@@ -61,8 +61,8 @@ jobs:
       contents: read
       security-events: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: github/codeql-action/init@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4
         with:
           languages: ${{ inputs.codeql-languages }}
       - name: Repo build hook
@@ -72,7 +72,7 @@ jobs:
           else
             echo "No scripts/ci/run-security-build.sh hook; continuing without a custom build."
           fi
-      - uses: github/codeql-action/analyze@v4
+      - uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4
 
   osv:
     name: osv
@@ -86,7 +86,7 @@ jobs:
       contents: read
       security-events: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Repo OSV hook
         run: |
           if [[ -x scripts/ci/run-osv.sh ]]; then
@@ -108,7 +108,7 @@ jobs:
       contents: read
       security-events: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Repo Semgrep hook
         env:
           SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Confirm branch protection points at the `CI Gate` status and require approval fr
 - Archetype: `generic-empty`
 
 For the Flow v1 repository-class transition, see [the explicit class-migration guide](docs/bootstrap/repository-class-migration.md).
+Use [language-profile detection](docs/bootstrap/language-profiles.md) to review target toolchain evidence before applying a plan.
 
 
 ## Release Standard

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Confirm branch protection points at the `CI Gate` status and require approval fr
 
 For the Flow v1 repository-class transition, see [the explicit class-migration guide](docs/bootstrap/repository-class-migration.md).
 Use [language-profile detection](docs/bootstrap/language-profiles.md) to review target toolchain evidence before applying a plan.
+Use [typed policy exceptions](docs/bootstrap/policy-exceptions.md) to make temporary deviations visible and enforce their expiry.
 
 
 ## Release Standard

--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ Confirm branch protection points at the `CI Gate` status and require approval fr
 - Default branch: `main`
 - Archetype: `generic-empty`
 
+For the Flow v1 repository-class transition, see [the explicit class-migration guide](docs/bootstrap/repository-class-migration.md).
+
 
 ## Release Standard
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ Confirm branch protection points at the `CI Gate` status and require approval fr
 
 Bootstrap records generated-file ownership in [the managed-file sidecar](docs/bootstrap/managed-file-ownership.md) and blocks direct edits before overwriting them.
 
+Run `bootstrap conform --manifest ./project.bootstrap.yaml --target .` for stable, machine-readable contract findings; see the [conformance core guide](docs/bootstrap/conformance.md).
+
 ## Project Identity
 
 - Product name: `Bootstrap`

--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ Confirm branch protection points at the `CI Gate` status and require approval fr
 - `.github/PULL_REQUEST_TEMPLATE.md` is the canonical pull request format for summaries, governing issue links, validation notes, and merge-readiness checks.
 - Existing bootstrapped repos can retrofit these surfaces with `bootstrap apply repo --manifest ./project.bootstrap.yaml`; repos with restricted `repo.managedPaths` should include both paths before applying.
 
+Bootstrap records generated-file ownership in [the managed-file sidecar](docs/bootstrap/managed-file-ownership.md) and blocks direct edits before overwriting them.
+
 ## Project Identity
 
 - Product name: `Bootstrap`

--- a/docs/bootstrap/conformance.md
+++ b/docs/bootstrap/conformance.md
@@ -1,0 +1,11 @@
+# Conformance core
+
+`bootstrap conform` produces deterministic, versioned JSON and human output for
+the Public Repository Standard conformance core. Each result includes a stable
+rule ID, severity, evidence, and remediation. Blocking findings set exit code
+`1`; warnings remain distinct and return `0`.
+
+The first core validates repository class and product maturity, language-profile
+conflicts, typed exceptions, and the managed-file ownership sidecar. Additional
+security, provenance, GitHub-plan capability, and waiver rules can extend the
+same report schema without changing existing result semantics.

--- a/docs/bootstrap/fleet-policy-upgrades.md
+++ b/docs/bootstrap/fleet-policy-upgrades.md
@@ -1,0 +1,7 @@
+# Fleet Policy Upgrades
+
+Use `bootstrap upgrade-plan --input inventory.json --json` to produce a non-mutating inventory before opening any upgrade PRs.
+
+Each inventory entry records repository, class, current and target exact SemVer policy versions, optional exception, and pilot outcome. Patch upgrades become eligible only after a passing first representative per class; failed pilots block the remaining class batch. Minor upgrades require independent review; major upgrades require notification and an accepted ADR.
+
+This planner deliberately does not create PRs or merge upgrades. Operators must attach policy diff, validation, exceptions, and provenance evidence to the governed PR after the dry run is approved.

--- a/docs/bootstrap/language-profiles.md
+++ b/docs/bootstrap/language-profiles.md
@@ -1,0 +1,12 @@
+# Language profiles
+
+`bootstrap plan` detects repository markers before proposing changes. It selects
+only the relevant profiles from TypeScript, Python, Rust, Go, Swift, Terraform,
+Shell, SQL/SQLite, and documentation. Generated output is ignored during
+detection, including `node_modules`, `dist`, `build`, `coverage`, and `.git`.
+
+The plan reports a warning when the manifest archetype conflicts with detected
+language evidence. For example, a `node-ts-service` manifest targeting a
+Python-only repository reports the missing TypeScript profile while preserving
+the detected Python profile. This is report-first: it does not rewrite the
+manifest or execute project code.

--- a/docs/bootstrap/managed-file-ownership.md
+++ b/docs/bootstrap/managed-file-ownership.md
@@ -1,0 +1,11 @@
+# Managed-file ownership
+
+Every repository render writes `.bootstrap/managed-files.json`. The sidecar
+identifies Bootstrap as the owner, records the template version and regeneration
+command, and stores a SHA-256 digest for every managed artifact.
+
+`bootstrap plan` and `bootstrap apply repo` reject a direct edit to a file that
+Bootstrap previously managed. Restore the generated version, remove the file
+from `repo.managedPaths`, or perform an explicit migration before changing the
+managed set. This keeps product-owned files outside Bootstrap's authority and
+prevents silent overwrites.

--- a/docs/bootstrap/onboarding.md
+++ b/docs/bootstrap/onboarding.md
@@ -15,6 +15,7 @@ Use this checklist after the first bootstrap render or whenever `project.bootstr
 - Confirm `CONTRIBUTING.md` and `.github/PULL_REQUEST_TEMPLATE.md` are present as the required contributor and PR guidance surfaces.
 - Confirm the pull request template is present and PR Fast CI validates the required PR description sections before CI Gate can pass.
 - Confirm PR Fast CI uses the fork-safe `pull_request` event with only read permissions. It must validate Conventional titles, contributed-commit DCO trailers, changed-line accounting, and material-change ADR/reviewer evidence without accessing repository secrets.
+- Confirm every third-party `uses:` entry is a 40-character commit SHA followed by readable tag metadata. The `Validate Action Pins` check fails closed on mutable references and silently ignores local or Bootstrap-owned reusable workflows.
 - Confirm `delete branch on merge` and `allow auto-merge` are enabled when the GitHub plan supports them; otherwise record the plan-limit evidence and use the fallback merge-readiness policy.
 - Fallback merge readiness requires passing or intentionally skipped required checks, satisfied approvals, resolved conversations, no blocking review state, and a manual maintainer merge.
 

--- a/docs/bootstrap/onboarding.md
+++ b/docs/bootstrap/onboarding.md
@@ -14,6 +14,7 @@ Use this checklist after the first bootstrap render or whenever `project.bootstr
 - Confirm branch protection points at the `CI Gate` status.
 - Confirm `CONTRIBUTING.md` and `.github/PULL_REQUEST_TEMPLATE.md` are present as the required contributor and PR guidance surfaces.
 - Confirm the pull request template is present and PR Fast CI validates the required PR description sections before CI Gate can pass.
+- Confirm PR Fast CI uses the fork-safe `pull_request` event with only read permissions. It must validate Conventional titles, contributed-commit DCO trailers, changed-line accounting, and material-change ADR/reviewer evidence without accessing repository secrets.
 - Confirm `delete branch on merge` and `allow auto-merge` are enabled when the GitHub plan supports them; otherwise record the plan-limit evidence and use the fallback merge-readiness policy.
 - Fallback merge readiness requires passing or intentionally skipped required checks, satisfied approvals, resolved conversations, no blocking review state, and a manual maintainer merge.
 

--- a/docs/bootstrap/policy-exceptions.md
+++ b/docs/bootstrap/policy-exceptions.md
@@ -1,0 +1,22 @@
+# Policy exceptions
+
+Declare every policy exception in `project.bootstrap.yaml` with an ID, policy,
+scope, rationale, approver, and governing issue. Temporary exceptions require
+an ISO `expiresAt` date; expired exceptions block validation. Exceptions expiring
+within 14 days produce a `PRS-NOTIFY-001` notification intent and do not stop
+work solely because they were reported.
+
+Permanent exceptions require explicit approval and an `adr` reference. The
+`bootstrap doctor` output reports deterministic `PRS-EXCEPTION-001` results so
+automation can consume the same outcome as operators.
+
+```yaml
+exceptions:
+  - id: temporary-runner-deviation
+    policy: runner-policy
+    scope: .github/workflows/release.yml
+    rationale: Platform migration in progress
+    approvedBy: release-maintainers
+    issue: https://github.com/OMT-Global/bootstrap/issues/55
+    expiresAt: 2026-09-01
+```

--- a/docs/bootstrap/public-provenance.md
+++ b/docs/bootstrap/public-provenance.md
@@ -1,0 +1,7 @@
+# Public Provenance
+
+`bootstrap provenance create --input provenance-input.json --output provenance/runs/<run>.json` redacts metadata and writes the versioned public manifest. `bootstrap provenance validate --input provenance/runs/<run>.json` validates it before publication.
+
+The public manifest records the repository, immutable commit SHA, workflow run, reviewer lineage, and safe metadata. It rejects credential-like literals; generators replace detected values with `[REDACTED:CREDENTIAL]` and record the replacement count.
+
+This public contract deliberately does not include a private provenance sink, encryption material, bucket identity, or long-lived credentials. Those remain a separately reviewed issue #61 capability using short-lived runtime identity.

--- a/docs/bootstrap/repository-class-migration.md
+++ b/docs/bootstrap/repository-class-migration.md
@@ -1,0 +1,25 @@
+# Repository class migration
+
+Flow's Public Repository Standard v1 has seven canonical repository classes:
+`cli`, `library`, `service`, `infrastructure`, `github-action`,
+`specification`, and `documentation`.
+
+Existing Bootstrap manifests may still use `application` or `tooling`. These
+legacy names never map silently. Declare the chosen canonical target alongside
+the legacy value, then regenerate the manifest to retain the migration record:
+
+```yaml
+repo:
+  class: tooling
+  classMigration:
+    target: cli
+```
+
+An `application` may map to `service`, `library`, or another canonical class
+only after the repository owner selects the real product boundary. A `tooling`
+repository commonly maps to `cli`, but an infrastructure control plane may map
+to `infrastructure` instead.
+
+`project.maturity` describes the product lifecycle (`experimental` through
+`archived`). It is intentionally independent from `release.maturity`, which
+selects the release-automation profile.

--- a/project.bootstrap.yaml
+++ b/project.bootstrap.yaml
@@ -9,6 +9,8 @@ project:
   defaultBranch: main
 repo:
   class: tooling
+  classMigration:
+    target: cli
   managedPaths: []
   docs:
     readme: true

--- a/project.bootstrap.yaml
+++ b/project.bootstrap.yaml
@@ -171,6 +171,8 @@ ci:
     - integration
     - release-readiness
   nightlyCron: 0 7 * * *
+  prGovernance:
+    enforceAfter: 2026-07-13T23:00:00Z
   additionalWorkflows: []
   appPaths: []
   ciPaths: []

--- a/scripts/ci/check-action-pins.sh
+++ b/scripts/ci/check-action-pins.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+python3 - "${1:-.github/workflows}" <<'PY'
+import re
+import sys
+from pathlib import Path
+
+workflow_root = Path(sys.argv[1])
+uses_pattern = re.compile(r"^\s*(?:-\s+)?uses:\s*([^\s#]+)@([^\s#]+)(?:\s+#\s*(.+))?\s*$")
+sha_pattern = re.compile(r"^[0-9a-f]{40}$")
+failures = []
+checked = 0
+
+for workflow in sorted([*workflow_root.rglob("*.yml"), *workflow_root.rglob("*.yaml")]):
+    for line_number, line in enumerate(workflow.read_text().splitlines(), start=1):
+        match = uses_pattern.match(line)
+        if not match:
+            continue
+        action, ref, metadata = match.groups()
+        if action.startswith("./") or action.startswith("OMT-Global/bootstrap/"):
+            continue
+        checked += 1
+        location = f"{workflow}:{line_number}"
+        if not sha_pattern.fullmatch(ref):
+            failures.append(f"SA-ACTION-PIN-001 {location}: {action}@{ref} is not an immutable 40-character commit SHA.")
+        elif not metadata:
+            failures.append(f"SA-ACTION-PIN-002 {location}: {action} is pinned but lacks readable tag or release metadata after '#'.")
+
+if failures:
+    print("\n".join(failures), file=sys.stderr)
+    raise SystemExit(1)
+
+print(f"PASS SA-ACTION-PIN-000: validated {checked} third-party action pin(s) under {workflow_root}.")
+PY

--- a/scripts/ci/check-pr-governance.sh
+++ b/scripts/ci/check-pr-governance.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+required=(PR_TITLE PR_BODY PR_AUTHOR)
+for name in "${required[@]}"; do
+  if [[ -z "${!name:-}" ]]; then
+    echo "Missing required PR governance input: $name" >&2
+    exit 2
+  fi
+done
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "$workdir"' EXIT
+
+fetch() {
+  local url="$1"
+  local destination="$2"
+  curl --fail --silent --show-error --location --retry 2 \
+    --header "Accept: application/vnd.github+json" \
+    --header "Authorization: Bearer $GITHUB_TOKEN" \
+    "$url" >"$destination"
+}
+
+load_response() {
+  local fixture="$1"
+  local url="$2"
+  local suffix="$3"
+  local destination="$4"
+  if [[ -n "$fixture" ]]; then
+    cp "$fixture" "$destination"
+  elif [[ -n "$url" && -n "${GITHUB_TOKEN:-}" ]]; then
+    fetch "$url?$suffix" "$destination"
+  else
+    echo "Provide a fixture file or API URL plus GITHUB_TOKEN for $destination" >&2
+    exit 2
+  fi
+}
+
+load_response "${PR_FILES_FILE:-}" "${PR_FILES_URL:-}" "per_page=100" "$workdir/files.json"
+load_response "${PR_COMMITS_FILE:-}" "${PR_COMMITS_URL:-}" "per_page=250" "$workdir/commits.json"
+load_response "${PR_REVIEWS_FILE:-}" "${PR_REVIEWS_URL:-}" "per_page=100" "$workdir/reviews.json"
+
+python3 - "$PR_TITLE" "$PR_BODY" "$PR_AUTHOR" "$workdir/files.json" "$workdir/commits.json" "$workdir/reviews.json" <<'PY'
+import json
+import re
+import sys
+from pathlib import Path
+
+title, body, author, files_path, commits_path, reviews_path = sys.argv[1:]
+files = json.loads(Path(files_path).read_text())
+commits = json.loads(Path(commits_path).read_text())
+reviews = json.loads(Path(reviews_path).read_text())
+failures = []
+
+if not re.match(r"^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\([^)]+\))?!?: .+", title):
+    failures.append("PRS-PR-TITLE-001: use a Conventional Commit-style PR title, for example 'feat: add policy gate'.")
+
+excluded = []
+counted_lines = 0
+for changed in files:
+    name = changed.get("filename", "unknown")
+    if name.startswith(("docs/", "test/", "tests/")) or name.endswith((".md", ".lock")) or name in {"package-lock.json", "pnpm-lock.yaml", "yarn.lock"}:
+        excluded.append(name)
+    else:
+        counted_lines += int(changed.get("additions", 0)) + int(changed.get("deletions", 0))
+print(f"INFO PRS-PR-SIZE-001: {counted_lines} counted changed lines; excluded {len(excluded)} documentation, test, and lockfile paths.")
+if excluded:
+    print("INFO PRS-PR-SIZE-001 excluded: " + ", ".join(sorted(excluded)))
+if counted_lines > 800:
+    failures.append(f"PRS-PR-SIZE-001: {counted_lines} counted changed lines exceeds the 800-line review threshold; split the change before requesting review.")
+
+missing_dco = []
+for commit in commits:
+    login = (commit.get("author") or {}).get("login", "")
+    account_type = (commit.get("author") or {}).get("type", "")
+    if account_type == "Bot" or login.endswith("[bot]"):
+        continue
+    message = (commit.get("commit") or {}).get("message", "")
+    if not re.search(r"(?im)^signed-off-by:\s+.+ <[^>]+>$", message):
+        missing_dco.append(commit.get("sha", "unknown")[:12])
+if missing_dco:
+    failures.append("PRS-DCO-001: contributed commits without a Signed-off-by trailer: " + ", ".join(missing_dco))
+
+declaration = re.search(r"(?im)^material change:\s*(yes|no)\s*$", body)
+if not declaration:
+    failures.append("PRS-MATERIAL-001: declare 'Material change: yes' or 'Material change: no' in the PR body.")
+elif declaration.group(1).lower() == "yes":
+    adr = re.search(r"(?im)^adr:\s*(docs/decisions/[^\s]+\.md)\s*$", body)
+    if not adr:
+        failures.append("PRS-ADR-001: material changes require an ADR line pointing at an accepted docs/decisions/*.md file.")
+    else:
+        adr_path = Path(adr.group(1))
+        if not adr_path.is_file() or not re.search(r"(?im)^status:\s*accepted\s*$", adr_path.read_text()):
+            failures.append(f"PRS-ADR-001: {adr_path} must exist in this PR and declare 'Status: Accepted'.")
+
+    independent_approvers = {
+        (review.get("user") or {}).get("login", "")
+        for review in reviews
+        if review.get("state", "").upper() == "APPROVED"
+        and (review.get("user") or {}).get("login", "") != author
+        and (review.get("user") or {}).get("type", "") != "Bot"
+    }
+    if not independent_approvers:
+        failures.append("PRS-INDEPENDENT-REVIEW-001: material changes require an approving reviewer other than the PR author.")
+
+if failures:
+    print("\n".join("FAIL " + failure for failure in failures), file=sys.stderr)
+    sys.exit(1)
+print("PASS PRS-PR-GOVERNANCE-001: title, DCO, change accounting, and material evidence are valid.")
+PY

--- a/scripts/ci/check-pr-governance.sh
+++ b/scripts/ci/check-pr-governance.sh
@@ -40,17 +40,31 @@ load_response "${PR_FILES_FILE:-}" "${PR_FILES_URL:-}" "per_page=100" "$workdir/
 load_response "${PR_COMMITS_FILE:-}" "${PR_COMMITS_URL:-}" "per_page=250" "$workdir/commits.json"
 load_response "${PR_REVIEWS_FILE:-}" "${PR_REVIEWS_URL:-}" "per_page=100" "$workdir/reviews.json"
 
-python3 - "$PR_TITLE" "$PR_BODY" "$PR_AUTHOR" "$workdir/files.json" "$workdir/commits.json" "$workdir/reviews.json" <<'PY'
+python3 - "$PR_TITLE" "$PR_BODY" "$PR_AUTHOR" "${PR_CREATED_AT:-}" "${PR_GOVERNANCE_ENFORCE_AFTER:-}" "$workdir/files.json" "$workdir/commits.json" "$workdir/reviews.json" <<'PY'
+from datetime import datetime
 import json
 import re
 import sys
 from pathlib import Path
 
-title, body, author, files_path, commits_path, reviews_path = sys.argv[1:]
+title, body, author, created_at, enforce_after, files_path, commits_path, reviews_path = sys.argv[1:]
 files = json.loads(Path(files_path).read_text())
 commits = json.loads(Path(commits_path).read_text())
 reviews = json.loads(Path(reviews_path).read_text())
 failures = []
+
+if enforce_after:
+    try:
+        created_at_value = datetime.fromisoformat(created_at.replace("Z", "+00:00"))
+        enforce_after_value = datetime.fromisoformat(enforce_after.replace("Z", "+00:00"))
+        if created_at_value.tzinfo is None or enforce_after_value.tzinfo is None:
+            raise ValueError
+    except ValueError:
+        failures.append("PRS-ENFORCEMENT-INPUT-001: PR_CREATED_AT and PR_GOVERNANCE_ENFORCE_AFTER must be ISO-8601 timestamps.")
+    else:
+        if created_at_value < enforce_after_value:
+            print(f"PASS PRS-PR-GOVERNANCE-LEGACY-001: PR opened at {created_at} before enforcement began at {enforce_after}.")
+            sys.exit(0)
 
 if not re.match(r"^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\([^)]+\))?!?: .+", title):
     failures.append("PRS-PR-TITLE-001: use a Conventional Commit-style PR title, for example 'feat: add policy gate'.")

--- a/scripts/ci/run-release-build.sh
+++ b/scripts/ci/run-release-build.sh
@@ -7,7 +7,7 @@ mkdir -p "${artifact_dir}"
 # Add repo-specific build steps above this line to populate ${artifact_dir}
 # with downloadable release assets before checksums are generated.
 
-mapfile -t artifacts < <(find "${artifact_dir}" -maxdepth 1 -type f ! -name SHA256SUMS | sort)
+mapfile -t artifacts < <(find "${artifact_dir}" -maxdepth 1 -type f ! -name SHA256SUMS ! -name release-evidence.json ! -name validation-evidence.json | sort)
 if [[ ${#artifacts[@]} -eq 0 ]]; then
   echo "No release artifacts were produced in ${artifact_dir}."
   echo "This repo ships no downloadable assets; add build steps to scripts/ci/run-release-build.sh when it does."

--- a/src/archetypes.ts
+++ b/src/archetypes.ts
@@ -953,7 +953,7 @@ function extendedChecksScript(manifest: BootstrapManifest): string {
   `}\n${body}\n`;
 }
 
-function prGovernanceScript(): string {
+function prGovernanceScript(manifest: BootstrapManifest): string {
   return dedent`
     #!/usr/bin/env bash
     set -euo pipefail
@@ -997,17 +997,31 @@ function prGovernanceScript(): string {
     load_response "\${PR_COMMITS_FILE:-}" "\${PR_COMMITS_URL:-}" "per_page=250" "$workdir/commits.json"
     load_response "\${PR_REVIEWS_FILE:-}" "\${PR_REVIEWS_URL:-}" "per_page=100" "$workdir/reviews.json"
 
-    python3 - "$PR_TITLE" "$PR_BODY" "$PR_AUTHOR" "$workdir/files.json" "$workdir/commits.json" "$workdir/reviews.json" <<'PY'
+    python3 - "$PR_TITLE" "$PR_BODY" "$PR_AUTHOR" "\${PR_CREATED_AT:-}" "\${PR_GOVERNANCE_ENFORCE_AFTER:-}" "$workdir/files.json" "$workdir/commits.json" "$workdir/reviews.json" <<'PY'
+    from datetime import datetime
     import json
     import re
     import sys
     from pathlib import Path
 
-    title, body, author, files_path, commits_path, reviews_path = sys.argv[1:]
+    title, body, author, created_at, enforce_after, files_path, commits_path, reviews_path = sys.argv[1:]
     files = json.loads(Path(files_path).read_text())
     commits = json.loads(Path(commits_path).read_text())
     reviews = json.loads(Path(reviews_path).read_text())
     failures = []
+
+    if enforce_after:
+        try:
+            created_at_value = datetime.fromisoformat(created_at.replace("Z", "+00:00"))
+            enforce_after_value = datetime.fromisoformat(enforce_after.replace("Z", "+00:00"))
+            if created_at_value.tzinfo is None or enforce_after_value.tzinfo is None:
+                raise ValueError
+        except ValueError:
+            failures.append("PRS-ENFORCEMENT-INPUT-001: PR_CREATED_AT and PR_GOVERNANCE_ENFORCE_AFTER must be ISO-8601 timestamps.")
+        else:
+            if created_at_value < enforce_after_value:
+                print(f"PASS PRS-PR-GOVERNANCE-LEGACY-001: PR opened at {created_at} before enforcement began at {enforce_after}.")
+                sys.exit(0)
 
     if not re.match(r"^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\\([^)]+\\))?!?: .+", title):
         failures.append("PRS-PR-TITLE-001: use a Conventional Commit-style PR title, for example 'feat: add policy gate'.")
@@ -2410,6 +2424,8 @@ function prWorkflow(manifest: BootstrapManifest): string {
     on:
       pull_request:
         types: [opened, edited, synchronize, reopened, ready_for_review]
+      pull_request_review:
+        types: [submitted, edited, dismissed]
 
     concurrency:
       group: pr-fast-\${{ github.event.pull_request.number || github.ref }}
@@ -2531,6 +2547,8 @@ ${indentBlock(setupSteps(manifest), 6)}
           PR_TITLE: \${{ github.event.pull_request.title }}
           PR_BODY: \${{ github.event.pull_request.body }}
           PR_AUTHOR: \${{ github.event.pull_request.user.login }}
+          PR_CREATED_AT: \${{ github.event.pull_request.created_at }}
+          PR_GOVERNANCE_ENFORCE_AFTER: '${manifest.ci.prGovernance?.enforceAfter ?? ""}'
           PR_FILES_URL: \${{ github.event.pull_request.url }}/files
           PR_COMMITS_URL: \${{ github.event.pull_request.commits_url }}
           PR_REVIEWS_URL: \${{ github.event.pull_request.url }}/reviews
@@ -3389,7 +3407,7 @@ export function renderManagedFiles(manifest: BootstrapManifest): RenderedFile[] 
     {
       path: "scripts/ci/check-pr-governance.sh",
       reason: "Fork-safe pull request governance validation",
-      contents: `${prGovernanceScript()}\n`,
+      contents: `${prGovernanceScript(manifest)}\n`,
       executable: true
     },
     {

--- a/src/archetypes.ts
+++ b/src/archetypes.ts
@@ -1075,7 +1075,7 @@ function releaseBuildScript(manifest: BootstrapManifest): string {
     # Add repo-specific build steps above this line to populate \${artifact_dir}
     # with downloadable release assets before checksums are generated.
 
-    mapfile -t artifacts < <(find "\${artifact_dir}" -maxdepth 1 -type f ! -name SHA256SUMS | sort)
+    mapfile -t artifacts < <(find "\${artifact_dir}" -maxdepth 1 -type f ! -name SHA256SUMS ! -name release-evidence.json ! -name validation-evidence.json | sort)
     if [[ \${#artifacts[@]} -eq 0 ]]; then
       echo "No release artifacts were produced in \${artifact_dir}."
       echo "This repo ships no downloadable assets; add build steps to scripts/ci/run-release-build.sh when it does."

--- a/src/archetypes.ts
+++ b/src/archetypes.ts
@@ -1068,6 +1068,46 @@ function prGovernanceScript(): string {
   `;
 }
 
+function actionPinScript(): string {
+  return dedent`
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    python3 - "\${1:-.github/workflows}" <<'PY'
+    import re
+    import sys
+    from pathlib import Path
+
+    workflow_root = Path(sys.argv[1])
+    uses_pattern = re.compile(r"^\\s*(?:-\\s+)?uses:\\s*([^\\s#]+)@([^\\s#]+)(?:\\s+#\\s*(.+))?\\s*$")
+    sha_pattern = re.compile(r"^[0-9a-f]{40}$")
+    failures = []
+    checked = 0
+
+    for workflow in sorted([*workflow_root.rglob("*.yml"), *workflow_root.rglob("*.yaml")]):
+        for line_number, line in enumerate(workflow.read_text().splitlines(), start=1):
+            match = uses_pattern.match(line)
+            if not match:
+                continue
+            action, ref, metadata = match.groups()
+            if action.startswith("./") or action.startswith("OMT-Global/bootstrap/"):
+                continue
+            checked += 1
+            location = f"{workflow}:{line_number}"
+            if not sha_pattern.fullmatch(ref):
+                failures.append(f"SA-ACTION-PIN-001 {location}: {action}@{ref} is not an immutable 40-character commit SHA.")
+            elif not metadata:
+                failures.append(f"SA-ACTION-PIN-002 {location}: {action} is pinned but lacks readable tag or release metadata after '#'.")
+
+    if failures:
+        print("\\n".join(failures), file=sys.stderr)
+        raise SystemExit(1)
+
+    print(f"PASS SA-ACTION-PIN-000: validated {checked} third-party action pin(s) under {workflow_root}.")
+    PY
+  `;
+}
+
 function releaseVerificationScript(manifest: BootstrapManifest): string {
   if (manifest.ci.customScripts.releaseVerification) {
     return `${dedent`
@@ -1405,7 +1445,7 @@ function setupSteps(manifest: BootstrapManifest): string {
 
   if (manifest.archetype.kind === "nextjs-web" || manifest.archetype.kind === "node-ts-service") {
     lines.push(
-      `- uses: actions/setup-node@v4`,
+      `- uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4`,
       `  with:`,
       `    node-version: \${{ env.NODE_VERSION }}`,
       `    cache: ${manifest.archetype.packageManager}`,
@@ -1421,7 +1461,7 @@ function setupSteps(manifest: BootstrapManifest): string {
 
   if (manifest.archetype.kind === "python-service") {
     lines.push(
-      `- uses: actions/setup-python@v5`,
+      `- uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5`,
       `  with:`,
       `    python-version: \${{ env.PYTHON_VERSION }}`
     );
@@ -1743,7 +1783,7 @@ function releasePreflightReusableWorkflow(): string {
           run:
             shell: bash
         steps:
-          - uses: actions/checkout@v4
+          - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
             with:
               ref: \${{ inputs.target_ref }}
               fetch-depth: 0
@@ -1789,13 +1829,13 @@ function releasePreflightReusableWorkflow(): string {
               {"schema_version":1,"repo":"\${GITHUB_REPOSITORY}","version":"\${VERSION}","channel":"\${CHANNEL}","target_ref":"\${TARGET_REF}","target_sha":"\${target_sha}","release_issue":"\${RELEASE_ISSUE}","preflight_run_id":"\${GITHUB_RUN_ID}","checks":{"prep":"\${prep_status}","preflight":"\${preflight_status}","build":"\${build_status}"}}
               JSON
 
-          - uses: actions/upload-artifact@v4
+          - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
             with:
               name: release-package
               path: \${{ inputs.artifact_dir }}/
               retention-days: \${{ inputs.evidence_retention_days }}
 
-          - uses: actions/upload-artifact@v4
+          - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
             with:
               name: \${{ inputs.evidence_artifact_name }}
               path: |
@@ -1832,7 +1872,7 @@ function fullReleaseValidationReusableWorkflow(): string {
           run:
             shell: bash
         steps:
-          - uses: actions/checkout@v4
+          - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
             with:
               ref: \${{ inputs.target_ref }}
               fetch-depth: 0
@@ -1859,7 +1899,7 @@ function fullReleaseValidationReusableWorkflow(): string {
               cat >"$ARTIFACT_DIR/validation-evidence.json" <<JSON
               {"schema_version":1,"repo":"\${GITHUB_REPOSITORY}","target_ref":"\${TARGET_REF}","target_sha":"\${target_sha}","validation_run_id":"\${GITHUB_RUN_ID}","release_profile":"\${RELEASE_PROFILE}","checks":{"validate_script":"\${validate_status}","standard_checks":"\${standard_status}"}}
               JSON
-          - uses: actions/upload-artifact@v4
+          - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
             with:
               name: \${{ inputs.evidence_artifact_name }}-validation
               path: \${{ inputs.artifact_dir }}/validation-evidence.json
@@ -1910,7 +1950,7 @@ function releasePublishReusableWorkflow(): string {
           run:
             shell: bash
         steps:
-          - uses: actions/checkout@v4
+          - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
             with:
               ref: \${{ inputs.tag }}
               fetch-depth: 0
@@ -2025,7 +2065,7 @@ function releasePublishReusableWorkflow(): string {
                 exit 1
               fi
               printf '{"schema_version":1,"repo":"%s","tag":"%s","tag_sha":"%s","publish_run_id":"%s"}\\n' "$GITHUB_REPOSITORY" "$TAG" "$tag_sha" "$GITHUB_RUN_ID" >"$ARTIFACT_DIR/postpublish-evidence.json"
-          - uses: actions/upload-artifact@v4
+          - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
             with:
               name: \${{ inputs.evidence_artifact_name }}-publish
               path: \${{ inputs.artifact_dir }}/postpublish-evidence.json
@@ -2057,7 +2097,7 @@ function releasePostpublishReusableWorkflow(): string {
           run:
             shell: bash
         steps:
-          - uses: actions/checkout@v4
+          - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
             with:
               ref: \${{ inputs.tag }}
               fetch-depth: 0
@@ -2082,7 +2122,7 @@ function releasePostpublishReusableWorkflow(): string {
                 exit 1
               fi
               printf '{"schema_version":1,"repo":"%s","tag":"%s","channel":"%s","release_issue":"%s","postpublish_run_id":"%s","release_assets":%s}\\n' "$GITHUB_REPOSITORY" "$TAG" "$CHANNEL" "$RELEASE_ISSUE" "$GITHUB_RUN_ID" "$asset_count" >"$ARTIFACT_DIR/postpublish-evidence.json"
-          - uses: actions/upload-artifact@v4
+          - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
             with:
               name: \${{ inputs.evidence_artifact_name }}-postpublish
               path: \${{ inputs.artifact_dir }}/postpublish-evidence.json
@@ -2395,7 +2435,7 @@ function prWorkflow(manifest: BootstrapManifest): string {
           app: \${{ steps.filter.outputs.app }}
           ci: \${{ steps.filter.outputs.ci }}
         steps:
-          - uses: dorny/paths-filter@v4
+          - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4
             id: filter
             with:
               filters: |
@@ -2413,7 +2453,7 @@ ${yamlList(paths.ci, 18)}
           github.event.pull_request.draft == false &&
           (needs.changes.outputs.app == 'true' || needs.changes.outputs.ci == 'true')
         steps:
-          - uses: actions/checkout@v4
+          - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
             with:
               ref: \${{ github.event.pull_request.head.sha }}
 ${indentBlock(setupSteps(manifest), 6)}
@@ -2476,7 +2516,7 @@ ${indentBlock(setupSteps(manifest), 6)}
         timeout-minutes: 10
         if: github.event.pull_request.draft == false
         steps:
-          - uses: actions/checkout@v4
+          - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
             with:
               ref: \${{ github.event.pull_request.head.sha }}
           - name: Scan repository for secret patterns
@@ -2496,11 +2536,23 @@ ${indentBlock(setupSteps(manifest), 6)}
           PR_REVIEWS_URL: \${{ github.event.pull_request.url }}/reviews
           GITHUB_TOKEN: \${{ github.token }}
         steps:
-          - uses: actions/checkout@v4
+          - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
             with:
               ref: \${{ github.event.pull_request.head.sha }}
           - name: Validate title, DCO, size, ADR, and reviewer evidence
             run: bash scripts/ci/check-pr-governance.sh
+
+      validate-action-pins:
+        name: Validate Action Pins
+        runs-on: ${shellRunner}
+        timeout-minutes: 5
+        if: github.event.pull_request.draft == false
+        steps:
+          - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+            with:
+              ref: \${{ github.event.pull_request.head.sha }}
+          - name: Require immutable third-party action pins
+            run: bash scripts/ci/check-action-pins.sh
 
       ci-gate:
         name: ${primaryRequiredStatusCheck(manifest)}
@@ -2512,6 +2564,7 @@ ${indentBlock(setupSteps(manifest), 6)}
           - validate-pr-description
           - validate-secrets
           - validate-pr-governance
+          - validate-action-pins
         steps:
           - name: Check required PR jobs
             env:
@@ -2521,6 +2574,7 @@ ${indentBlock(setupSteps(manifest), 6)}
                 validate-pr-description=\${{ needs.validate-pr-description.result }}
                 validate-secrets=\${{ needs.validate-secrets.result }}
                 validate-pr-governance=\${{ needs.validate-pr-governance.result }}
+                validate-action-pins=\${{ needs.validate-action-pins.result }}
             run: |
               failed=0
               for entry in $RESULTS; do
@@ -2575,7 +2629,7 @@ function extendedWorkflow(manifest: BootstrapManifest): string {
           ci: \${{ steps.preset.outputs.ci || steps.filter.outputs.ci || 'false' }}
           extended: \${{ steps.preset.outputs.extended || steps.filter.outputs.extended || 'false' }}
         steps:
-          - uses: actions/checkout@v4
+          - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
             if: github.event_name == 'push'
             with:
               fetch-depth: 0
@@ -2590,7 +2644,7 @@ function extendedWorkflow(manifest: BootstrapManifest): string {
               extended=true
               EOF
 
-          - uses: dorny/paths-filter@v4
+          - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4
             id: filter
             if: github.event_name == 'push'
             with:
@@ -2609,7 +2663,7 @@ ${yamlList(paths.extended, 18)}
         needs: changes
         if: needs.changes.outputs.app == 'true' || needs.changes.outputs.ci == 'true'
         steps:
-          - uses: actions/checkout@v4
+          - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 ${indentBlock(setupSteps(manifest), 6)}
           - name: Run fast checks
             run: bash scripts/ci/run-fast-checks.sh
@@ -2621,7 +2675,7 @@ ${indentBlock(setupSteps(manifest), 6)}
         needs: changes
         if: needs.changes.outputs.extended == 'true' || needs.changes.outputs.app == 'true'
         steps:
-          - uses: actions/checkout@v4
+          - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 ${indentBlock(setupSteps(manifest), 6)}
           - name: Run extended validation
             run: bash scripts/ci/run-extended-validation.sh
@@ -2631,7 +2685,7 @@ ${indentBlock(setupSteps(manifest), 6)}
         runs-on: ${shellRunner}
         timeout-minutes: 10
         steps:
-          - uses: actions/checkout@v4
+          - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
           - name: Scan repository for secret patterns
             run: bash scripts/check-detect-secrets.sh --all-files
 
@@ -3046,9 +3100,9 @@ function claudeWorkflow(manifest: BootstrapManifest): string {
         runs-on: ubuntu-latest
         timeout-minutes: 30
         steps:
-          - uses: actions/checkout@v4
+          - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
           - name: Run Claude Code
-            uses: anthropics/claude-code-action@v1
+            uses: anthropics/claude-code-action@e90deca47693f9457b72f2b53c17d7c445a87342 # v1
             with:
               anthropic_api_key: \${{ secrets.ANTHROPIC_API_KEY }}
               prompt: |
@@ -3336,6 +3390,12 @@ export function renderManagedFiles(manifest: BootstrapManifest): RenderedFile[] 
       path: "scripts/ci/check-pr-governance.sh",
       reason: "Fork-safe pull request governance validation",
       contents: `${prGovernanceScript()}\n`,
+      executable: true
+    },
+    {
+      path: "scripts/ci/check-action-pins.sh",
+      reason: "Immutable third-party action pin validation",
+      contents: `${actionPinScript()}\n`,
       executable: true
     },
     ...(manifest.release.enabled

--- a/src/archetypes.ts
+++ b/src/archetypes.ts
@@ -422,6 +422,9 @@ function pullRequestTemplate(manifest: BootstrapManifest): string {
     - [ ] PR author enabled auto-merge where GitHub allows it, or GitHub plan-limit evidence/unavailable reason is recorded and the fallback merge-readiness policy applies
     - [ ] No real secrets, runtime auth, or machine-local env files are committed
 
+    Material change: no
+    ADR: docs/decisions/ADR-<number>-<slug>.md  <!-- required when Material change is yes; ADR status must be Accepted -->
+
 ${indentBlock(flowPullRequestSection(manifest), 4)}
 
     ## Merge Automation
@@ -948,6 +951,121 @@ function extendedChecksScript(manifest: BootstrapManifest): string {
     set -euo pipefail
 
   `}\n${body}\n`;
+}
+
+function prGovernanceScript(): string {
+  return dedent`
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    required=(PR_TITLE PR_BODY PR_AUTHOR)
+    for name in "\${required[@]}"; do
+      if [[ -z "\${!name:-}" ]]; then
+        echo "Missing required PR governance input: $name" >&2
+        exit 2
+      fi
+    done
+
+    workdir="$(mktemp -d)"
+    trap 'rm -rf "$workdir"' EXIT
+
+    fetch() {
+      local url="$1"
+      local destination="$2"
+      curl --fail --silent --show-error --location --retry 2 \\
+        --header "Accept: application/vnd.github+json" \\
+        --header "Authorization: Bearer $GITHUB_TOKEN" \\
+        "$url" >"$destination"
+    }
+
+    load_response() {
+      local fixture="$1"
+      local url="$2"
+      local suffix="$3"
+      local destination="$4"
+      if [[ -n "$fixture" ]]; then
+        cp "$fixture" "$destination"
+      elif [[ -n "$url" && -n "\${GITHUB_TOKEN:-}" ]]; then
+        fetch "$url?$suffix" "$destination"
+      else
+        echo "Provide a fixture file or API URL plus GITHUB_TOKEN for $destination" >&2
+        exit 2
+      fi
+    }
+
+    load_response "\${PR_FILES_FILE:-}" "\${PR_FILES_URL:-}" "per_page=100" "$workdir/files.json"
+    load_response "\${PR_COMMITS_FILE:-}" "\${PR_COMMITS_URL:-}" "per_page=250" "$workdir/commits.json"
+    load_response "\${PR_REVIEWS_FILE:-}" "\${PR_REVIEWS_URL:-}" "per_page=100" "$workdir/reviews.json"
+
+    python3 - "$PR_TITLE" "$PR_BODY" "$PR_AUTHOR" "$workdir/files.json" "$workdir/commits.json" "$workdir/reviews.json" <<'PY'
+    import json
+    import re
+    import sys
+    from pathlib import Path
+
+    title, body, author, files_path, commits_path, reviews_path = sys.argv[1:]
+    files = json.loads(Path(files_path).read_text())
+    commits = json.loads(Path(commits_path).read_text())
+    reviews = json.loads(Path(reviews_path).read_text())
+    failures = []
+
+    if not re.match(r"^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\\([^)]+\\))?!?: .+", title):
+        failures.append("PRS-PR-TITLE-001: use a Conventional Commit-style PR title, for example 'feat: add policy gate'.")
+
+    excluded = []
+    counted_lines = 0
+    for changed in files:
+        name = changed.get("filename", "unknown")
+        if name.startswith(("docs/", "test/", "tests/")) or name.endswith((".md", ".lock")) or name in {"package-lock.json", "pnpm-lock.yaml", "yarn.lock"}:
+            excluded.append(name)
+        else:
+            counted_lines += int(changed.get("additions", 0)) + int(changed.get("deletions", 0))
+    print(f"INFO PRS-PR-SIZE-001: {counted_lines} counted changed lines; excluded {len(excluded)} documentation, test, and lockfile paths.")
+    if excluded:
+        print("INFO PRS-PR-SIZE-001 excluded: " + ", ".join(sorted(excluded)))
+    if counted_lines > 800:
+        failures.append(f"PRS-PR-SIZE-001: {counted_lines} counted changed lines exceeds the 800-line review threshold; split the change before requesting review.")
+
+    missing_dco = []
+    for commit in commits:
+        login = (commit.get("author") or {}).get("login", "")
+        account_type = (commit.get("author") or {}).get("type", "")
+        if account_type == "Bot" or login.endswith("[bot]"):
+            continue
+        message = (commit.get("commit") or {}).get("message", "")
+        if not re.search(r"(?im)^signed-off-by:\\s+.+ <[^>]+>$", message):
+            missing_dco.append(commit.get("sha", "unknown")[:12])
+    if missing_dco:
+        failures.append("PRS-DCO-001: contributed commits without a Signed-off-by trailer: " + ", ".join(missing_dco))
+
+    declaration = re.search(r"(?im)^material change:\\s*(yes|no)\\s*$", body)
+    if not declaration:
+        failures.append("PRS-MATERIAL-001: declare 'Material change: yes' or 'Material change: no' in the PR body.")
+    elif declaration.group(1).lower() == "yes":
+        adr = re.search(r"(?im)^adr:\\s*(docs/decisions/[^\\s]+\\.md)\\s*$", body)
+        if not adr:
+            failures.append("PRS-ADR-001: material changes require an ADR line pointing at an accepted docs/decisions/*.md file.")
+        else:
+            adr_path = Path(adr.group(1))
+            if not adr_path.is_file() or not re.search(r"(?im)^status:\\s*accepted\\s*$", adr_path.read_text()):
+                failures.append(f"PRS-ADR-001: {adr_path} must exist in this PR and declare 'Status: Accepted'.")
+
+        independent_approvers = {
+            (review.get("user") or {}).get("login", "")
+            for review in reviews
+            if review.get("state", "").upper() == "APPROVED"
+            and (review.get("user") or {}).get("login", "") != author
+            and (review.get("user") or {}).get("type", "") != "Bot"
+        }
+        if not independent_approvers:
+            failures.append("PRS-INDEPENDENT-REVIEW-001: material changes require an approving reviewer other than the PR author.")
+
+    if failures:
+        print("\\n".join("FAIL " + failure for failure in failures), file=sys.stderr)
+        sys.exit(1)
+    print("PASS PRS-PR-GOVERNANCE-001: title, DCO, change accounting, and material evidence are valid.")
+    PY
+  `;
 }
 
 function releaseVerificationScript(manifest: BootstrapManifest): string {
@@ -2259,6 +2377,7 @@ function prWorkflow(manifest: BootstrapManifest): string {
 
     permissions:
       contents: read
+      pull-requests: read
 
     env:
       NODE_VERSION: '${manifest.ci.nodeVersion}'
@@ -2363,6 +2482,26 @@ ${indentBlock(setupSteps(manifest), 6)}
           - name: Scan repository for secret patterns
             run: bash scripts/check-detect-secrets.sh --all-files
 
+      validate-pr-governance:
+        name: Validate PR Governance
+        runs-on: ${shellRunner}
+        timeout-minutes: 5
+        if: github.event.pull_request.draft == false
+        env:
+          PR_TITLE: \${{ github.event.pull_request.title }}
+          PR_BODY: \${{ github.event.pull_request.body }}
+          PR_AUTHOR: \${{ github.event.pull_request.user.login }}
+          PR_FILES_URL: \${{ github.event.pull_request.url }}/files
+          PR_COMMITS_URL: \${{ github.event.pull_request.commits_url }}
+          PR_REVIEWS_URL: \${{ github.event.pull_request.url }}/reviews
+          GITHUB_TOKEN: \${{ github.token }}
+        steps:
+          - uses: actions/checkout@v4
+            with:
+              ref: \${{ github.event.pull_request.head.sha }}
+          - name: Validate title, DCO, size, ADR, and reviewer evidence
+            run: bash scripts/ci/check-pr-governance.sh
+
       ci-gate:
         name: ${primaryRequiredStatusCheck(manifest)}
         runs-on: ${shellRunner}
@@ -2372,6 +2511,7 @@ ${indentBlock(setupSteps(manifest), 6)}
           - fast-checks
           - validate-pr-description
           - validate-secrets
+          - validate-pr-governance
         steps:
           - name: Check required PR jobs
             env:
@@ -2380,6 +2520,7 @@ ${indentBlock(setupSteps(manifest), 6)}
                 fast-checks=\${{ needs.fast-checks.result }}
                 validate-pr-description=\${{ needs.validate-pr-description.result }}
                 validate-secrets=\${{ needs.validate-secrets.result }}
+                validate-pr-governance=\${{ needs.validate-pr-governance.result }}
             run: |
               failed=0
               for entry in $RESULTS; do
@@ -3189,6 +3330,12 @@ export function renderManagedFiles(manifest: BootstrapManifest): RenderedFile[] 
       path: "scripts/ci/run-extended-validation.sh",
       reason: "Extended CI entrypoint",
       contents: extendedChecksScript(manifest),
+      executable: true
+    },
+    {
+      path: "scripts/ci/check-pr-governance.sh",
+      reason: "Fork-safe pull request governance validation",
+      contents: `${prGovernanceScript()}\n`,
       executable: true
     },
     ...(manifest.release.enabled

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { Command } from "commander";
 
 import { runDoctor } from "./doctor.js";
+import { formatConformanceReport, runConformance } from "./conformance.js";
 import { reconcileFleet } from "./fleet.js";
 import { planGitHub, applyGitHub } from "./github/provision.js";
 import { planHome, applyHome } from "./home/sync.js";
@@ -239,6 +240,20 @@ async function main(): Promise<void> {
       process.stdout.write(
         `${checks.map((check) => `- [${check.status}] ${check.name}: ${check.detail}`).join("\n")}\n`
       );
+    });
+
+  program
+    .command("conform")
+    .description("Validate the deterministic Public Repository Standard conformance core.")
+    .option("--manifest <path>", "Path to manifest")
+    .option("--target <path>", "Target repository directory")
+    .option("--json", "Emit versioned JSON")
+    .action(async (options) => {
+      const manifest = await loadManifest(resolveManifestPath(options.manifest));
+      const targetDir = options.target ? path.resolve(options.target) : defaultTargetDir(manifest);
+      const report = await runConformance(manifest, targetDir);
+      process.stdout.write(`${options.json ? JSON.stringify(report, null, 2) : formatConformanceReport(report)}\n`);
+      process.exitCode = report.exitCode;
     });
 
   await program.parseAsync(process.argv);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -15,6 +15,7 @@ import {
 } from "./manifest.js";
 import { planRepo, applyRepo } from "./render.js";
 import { createPublicProvenance, validatePublicProvenance } from "./provenance.js";
+import { planFleetPolicyUpgrades, type FleetUpgradeCandidate } from "./upgrades.js";
 
 function defaultTargetDir(manifest: Awaited<ReturnType<typeof loadManifest>>, cwd = process.cwd()): string {
   const currentBasename = path.basename(cwd);
@@ -184,6 +185,21 @@ async function main(): Promise<void> {
       }
 
       process.stdout.write(`${formatFleetReport(report)}\n`);
+    });
+
+  program
+    .command("upgrade-plan")
+    .description("Dry-run version-aware fleet policy upgrade inventory; never opens pull requests or mutates repositories.")
+    .requiredOption("--input <path>", "JSON array of fleet upgrade candidates")
+    .option("--json", "Emit JSON")
+    .action(async (options) => {
+      const raw = await import("node:fs/promises").then(({ readFile }) => readFile(path.resolve(options.input), "utf8"));
+      const plan = planFleetPolicyUpgrades(JSON.parse(raw) as FleetUpgradeCandidate[]);
+      if (options.json) {
+        process.stdout.write(`${JSON.stringify(plan, null, 2)}\n`);
+        return;
+      }
+      process.stdout.write(`${plan.map((entry) => `- [${entry.status}] ${entry.repo} (${entry.repoClass}, ${entry.risk}, ${entry.role}): ${entry.reason}`).join("\n")}\n`);
     });
 
   const apply = program.command("apply").description("Apply one bootstrap target.");

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -14,6 +14,7 @@ import {
   resolveManifestPath
 } from "./manifest.js";
 import { planRepo, applyRepo } from "./render.js";
+import { createPublicProvenance, validatePublicProvenance } from "./provenance.js";
 
 function defaultTargetDir(manifest: Awaited<ReturnType<typeof loadManifest>>, cwd = process.cwd()): string {
   const currentBasename = path.basename(cwd);
@@ -254,6 +255,31 @@ async function main(): Promise<void> {
       const report = await runConformance(manifest, targetDir);
       process.stdout.write(`${options.json ? JSON.stringify(report, null, 2) : formatConformanceReport(report)}\n`);
       process.exitCode = report.exitCode;
+    });
+
+  const provenance = program.command("provenance").description("Validate public provenance manifests before publication.");
+  provenance
+    .command("validate")
+    .description("Fail when a public provenance manifest is malformed or contains credential-like literals.")
+    .requiredOption("--input <path>", "Path to a public provenance JSON manifest")
+    .action(async (options) => {
+      const raw = await import("node:fs/promises").then(({ readFile }) => readFile(path.resolve(options.input), "utf8"));
+      const manifest = validatePublicProvenance(JSON.parse(raw));
+      process.stdout.write(`${JSON.stringify(manifest, null, 2)}\n`);
+    });
+  provenance
+    .command("create")
+    .description("Redact metadata and write a public provenance manifest.")
+    .requiredOption("--input <path>", "Path to a provenance input JSON document")
+    .requiredOption("--output <path>", "Output path, normally provenance/runs/<run>.json")
+    .action(async (options) => {
+      const raw = await import("node:fs/promises").then(({ readFile }) => readFile(path.resolve(options.input), "utf8"));
+      const manifest = createPublicProvenance(JSON.parse(raw));
+      const outputPath = path.resolve(options.output);
+      await import("node:fs/promises").then(({ mkdir, writeFile }) =>
+        mkdir(path.dirname(outputPath), { recursive: true }).then(() => writeFile(outputPath, `${JSON.stringify(manifest, null, 2)}\n`, "utf8"))
+      );
+      process.stdout.write(`Wrote ${outputPath}\n`);
     });
 
   await program.parseAsync(process.argv);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -30,6 +30,12 @@ function formatRepoChanges(changes: Awaited<ReturnType<typeof planRepo>>["change
   ].join("\n");
 }
 
+function formatLanguageProfiles(profiles: Awaited<ReturnType<typeof planRepo>>["languageProfiles"]): string {
+  const selected = profiles.selected.length === 0 ? "none" : profiles.selected.join(", ");
+  const conflicts = profiles.conflicts.map((conflict) => `- [warn] ${conflict.reason}`);
+  return ["**Language profiles**", `- Selected: ${selected}`, ...conflicts].join("\n");
+}
+
 function formatGitHubActions(actions: Awaited<ReturnType<typeof planGitHub>>): string {
   return [
     "**GitHub**",
@@ -128,6 +134,7 @@ async function main(): Promise<void> {
             {
               targetDir,
               repo: repoPlan.changes,
+              languageProfiles: repoPlan.languageProfiles,
               github: githubPlan,
               home: homePlan.actions
             },
@@ -139,7 +146,7 @@ async function main(): Promise<void> {
       }
 
       process.stdout.write(
-        `${formatRepoChanges(repoPlan.changes)}\n\n${formatGitHubActions(githubPlan)}\n\n${formatHomeActions(
+        `${formatRepoChanges(repoPlan.changes)}\n\n${formatLanguageProfiles(repoPlan.languageProfiles)}\n\n${formatGitHubActions(githubPlan)}\n\n${formatHomeActions(
           homePlan.actions
         )}\n`
       );

--- a/src/conformance.ts
+++ b/src/conformance.ts
@@ -1,0 +1,129 @@
+import path from "node:path";
+
+import { z } from "zod";
+
+import { validatePolicyExceptions } from "./exceptions.js";
+import { readTextIfExists } from "./lib/fs.js";
+import { resolveLanguageProfiles } from "./language-profiles.js";
+import { planRepo } from "./render.js";
+import { OWNERSHIP_SIDECAR_PATH } from "./state.js";
+import type { BootstrapManifest } from "./types.js";
+
+export const CONFORMANCE_SCHEMA_VERSION = 1;
+
+const conformanceResultSchema = z.object({
+  ruleId: z.string().regex(/^PRS-[A-Z-]+-\d{3}$/),
+  severity: z.enum(["pass", "warning", "blocking"]),
+  evidence: z.array(z.string()),
+  remediation: z.string()
+});
+
+export const conformanceReportSchema = z.object({
+  schemaVersion: z.literal(CONFORMANCE_SCHEMA_VERSION),
+  results: z.array(conformanceResultSchema),
+  summary: z.object({ pass: z.number().int().nonnegative(), warning: z.number().int().nonnegative(), blocking: z.number().int().nonnegative() }),
+  exitCode: z.union([z.literal(0), z.literal(1)])
+});
+
+export type ConformanceResult = z.infer<typeof conformanceResultSchema>;
+export type ConformanceReport = z.infer<typeof conformanceReportSchema>;
+
+function result(
+  ruleId: string,
+  severity: ConformanceResult["severity"],
+  evidence: string[],
+  remediation: string
+): ConformanceResult {
+  return { ruleId, severity, evidence: [...evidence].sort(), remediation };
+}
+
+function summary(results: ConformanceResult[]): ConformanceReport["summary"] {
+  return {
+    pass: results.filter((entry) => entry.severity === "pass").length,
+    warning: results.filter((entry) => entry.severity === "warning").length,
+    blocking: results.filter((entry) => entry.severity === "blocking").length
+  };
+}
+
+export async function runConformance(manifest: BootstrapManifest, targetDir: string): Promise<ConformanceReport> {
+  const results: ConformanceResult[] = [];
+
+  results.push(
+    manifest.repo.class
+      ? result("PRS-CLASS-001", "pass", [manifest.repo.class], "Keep the canonical repository class current.")
+      : result("PRS-CLASS-001", "blocking", ["repo.class is absent"], "Declare a canonical repo.class or complete an explicit legacy migration.")
+  );
+  results.push(
+    manifest.project.maturity
+      ? result("PRS-MATURITY-001", "pass", [manifest.project.maturity], "Keep product maturity separate from release automation maturity.")
+      : result("PRS-MATURITY-001", "blocking", ["project.maturity is absent"], "Declare project.maturity from experimental through archived.")
+  );
+
+  const profiles = await resolveLanguageProfiles(manifest, targetDir);
+  if (profiles.conflicts.length === 0) {
+    results.push(
+      result(
+        "PRS-PROFILE-001",
+        "pass",
+        profiles.selected.length === 0 ? ["no repository language markers"] : profiles.selected,
+        "Keep selected language profiles aligned with the repository's toolchain markers."
+      )
+    );
+  } else {
+    for (const conflict of profiles.conflicts) {
+      results.push(result("PRS-PROFILE-001", "warning", [conflict.reason], "Align the archetype or resolve the detected language-profile conflict."));
+    }
+  }
+
+  for (const exception of validatePolicyExceptions(manifest.exceptions).results) {
+    results.push(
+      result(
+        exception.ruleId,
+        exception.status === "block" ? "blocking" : exception.status === "warn" ? "warning" : "pass",
+        [exception.detail],
+        exception.remediation ?? "Keep the approved exception current."
+      )
+    );
+  }
+
+  const ownershipPath = path.join(targetDir, OWNERSHIP_SIDECAR_PATH);
+  const ownershipRaw = await readTextIfExists(ownershipPath);
+  if (!ownershipRaw) {
+    results.push(result("PRS-OWNERSHIP-001", "blocking", [OWNERSHIP_SIDECAR_PATH], "Run bootstrap apply repo to create the managed-file ownership sidecar."));
+  } else {
+    try {
+      const ownership = JSON.parse(ownershipRaw) as { schemaVersion?: unknown; owner?: unknown; managedFiles?: unknown };
+      const valid = ownership.schemaVersion === 1 && ownership.owner === "bootstrap" && ownership.managedFiles && typeof ownership.managedFiles === "object";
+      results.push(
+        valid
+          ? result("PRS-OWNERSHIP-001", "pass", [OWNERSHIP_SIDECAR_PATH], "Keep the ownership sidecar under Bootstrap management.")
+          : result("PRS-OWNERSHIP-001", "blocking", [OWNERSHIP_SIDECAR_PATH], "Regenerate a valid Bootstrap ownership sidecar.")
+      );
+    } catch {
+      results.push(result("PRS-OWNERSHIP-001", "blocking", [OWNERSHIP_SIDECAR_PATH], "Regenerate the malformed Bootstrap ownership sidecar."));
+    }
+  }
+
+  try {
+    await planRepo(manifest, targetDir);
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    results.push(result("PRS-OWNERSHIP-001", "blocking", [detail], "Restore the managed file or use an explicit migration before applying Bootstrap changes."));
+  }
+
+  const sorted = results.sort((left, right) => left.ruleId.localeCompare(right.ruleId) || left.evidence.join("\n").localeCompare(right.evidence.join("\n")));
+  const report = {
+    schemaVersion: CONFORMANCE_SCHEMA_VERSION,
+    results: sorted,
+    summary: summary(sorted),
+    exitCode: sorted.some((entry) => entry.severity === "blocking") ? 1 : 0
+  } as const;
+  return conformanceReportSchema.parse(report);
+}
+
+export function formatConformanceReport(report: ConformanceReport): string {
+  return [
+    `Conformance: ${report.summary.blocking} blocking, ${report.summary.warning} warning, ${report.summary.pass} pass`,
+    ...report.results.map((entry) => `- [${entry.severity}] ${entry.ruleId}: ${entry.evidence.join("; ")} — ${entry.remediation}`)
+  ].join("\n");
+}

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -1,5 +1,6 @@
 import os from "node:os";
 
+import { validatePolicyExceptions } from "./exceptions.js";
 import { execRunner, type CommandRunner } from "./lib/process.js";
 import { resolveRunsOn } from "./runners.js";
 import type { BootstrapManifest } from "./types.js";
@@ -43,6 +44,22 @@ export async function runDoctor(
     name: "gh CLI",
     status: ghAvailable ? "ok" : "fail",
     detail: ghAvailable ? "gh is available." : "gh is missing from PATH."
+  });
+
+  const exceptionReport = validatePolicyExceptions(manifest.exceptions);
+  const exceptionStatus = exceptionReport.blocking
+    ? "fail"
+    : exceptionReport.results.some((result) => result.status === "warn")
+      ? "warn"
+      : "ok";
+  const exceptionDetails = exceptionReport.results.filter((result) => result.status !== "pass");
+  checks.push({
+    name: "Policy exceptions",
+    status: exceptionStatus,
+    detail:
+      exceptionDetails.length === 0
+        ? "No blocking or expiring policy exceptions."
+        : exceptionDetails.map((result) => `${result.ruleId}: ${result.detail}`).join(" ")
   });
 
   if (ghAvailable) {

--- a/src/exceptions.ts
+++ b/src/exceptions.ts
@@ -1,0 +1,129 @@
+import type { PolicyException } from "./types.js";
+
+export type ExceptionResultStatus = "pass" | "warn" | "block";
+
+export interface ExceptionValidationResult {
+  ruleId: "PRS-EXCEPTION-001";
+  exceptionId: string;
+  status: ExceptionResultStatus;
+  detail: string;
+  remediation?: string;
+}
+
+export interface ExceptionNotificationIntent {
+  ruleId: "PRS-NOTIFY-001";
+  exceptionId: string;
+  event: "exception-expiring";
+  destinations: ["governing-issue-or-pull-request", "configured-notification-mechanism"];
+  continueAfterNotification: true;
+}
+
+export interface ExceptionValidationReport {
+  results: ExceptionValidationResult[];
+  notifications: ExceptionNotificationIntent[];
+  blocking: boolean;
+}
+
+const EXPIRY_WARNING_DAYS = 14;
+
+function utcMidnight(value: Date): number {
+  return Date.UTC(value.getUTCFullYear(), value.getUTCMonth(), value.getUTCDate());
+}
+
+function parseDate(value: string): Date | undefined {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) return undefined;
+  const parsed = new Date(`${value}T00:00:00.000Z`);
+  return Number.isNaN(parsed.valueOf()) ? undefined : parsed;
+}
+
+export function validatePolicyExceptions(
+  exceptions: PolicyException[],
+  now = new Date()
+): ExceptionValidationReport {
+  const results: ExceptionValidationResult[] = [];
+  const notifications: ExceptionNotificationIntent[] = [];
+
+  for (const exception of [...exceptions].sort((left, right) => left.id.localeCompare(right.id))) {
+    if (exception.permanent) {
+      if (!exception.adr) {
+        results.push({
+          ruleId: "PRS-EXCEPTION-001",
+          exceptionId: exception.id,
+          status: "block",
+          detail: `Permanent exception ${exception.id} has no ADR.`,
+          remediation: "Add the accepted ADR that documents the permanent exception."
+        });
+      } else {
+        results.push({
+          ruleId: "PRS-EXCEPTION-001",
+          exceptionId: exception.id,
+          status: "pass",
+          detail: `Permanent exception ${exception.id} has explicit approval and ADR ${exception.adr}.`
+        });
+      }
+      continue;
+    }
+
+    if (!exception.expiresAt) {
+      results.push({
+        ruleId: "PRS-EXCEPTION-001",
+        exceptionId: exception.id,
+        status: "block",
+        detail: `Temporary exception ${exception.id} has no expiry date.`,
+        remediation: "Set exceptions[].expiresAt to an ISO date or mark the exception permanent with an ADR."
+      });
+      continue;
+    }
+
+    const expiry = parseDate(exception.expiresAt);
+    if (!expiry) {
+      results.push({
+        ruleId: "PRS-EXCEPTION-001",
+        exceptionId: exception.id,
+        status: "block",
+        detail: `Exception ${exception.id} has an invalid expiry date ${exception.expiresAt}.`,
+        remediation: "Use an ISO date in YYYY-MM-DD format."
+      });
+      continue;
+    }
+
+    const remainingDays = Math.floor((utcMidnight(expiry) - utcMidnight(now)) / 86_400_000);
+    if (remainingDays < 0) {
+      results.push({
+        ruleId: "PRS-EXCEPTION-001",
+        exceptionId: exception.id,
+        status: "block",
+        detail: `Temporary exception ${exception.id} expired on ${exception.expiresAt}.`,
+        remediation: "Renew the exception with approval or remove the deviation."
+      });
+      continue;
+    }
+
+    if (remainingDays <= EXPIRY_WARNING_DAYS) {
+      results.push({
+        ruleId: "PRS-EXCEPTION-001",
+        exceptionId: exception.id,
+        status: "warn",
+        detail: `Temporary exception ${exception.id} expires in ${remainingDays} day(s) on ${exception.expiresAt}.`,
+        remediation: "Renew with approval before the exception expires or remove the deviation."
+      });
+      notifications.push({
+        ruleId: "PRS-NOTIFY-001",
+        exceptionId: exception.id,
+        event: "exception-expiring",
+        destinations: ["governing-issue-or-pull-request", "configured-notification-mechanism"],
+        continueAfterNotification: true
+      });
+      continue;
+    }
+
+    results.push({
+      ruleId: "PRS-EXCEPTION-001",
+      exceptionId: exception.id,
+      status: "pass",
+      detail: `Temporary exception ${exception.id} is valid through ${exception.expiresAt}.`
+    });
+  }
+
+  return { results, notifications, blocking: results.some((result) => result.status === "block") };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ export * from "./fleet.js";
 export * from "./github/client.js";
 export * from "./github/provision.js";
 export * from "./home/sync.js";
+export * from "./language-profiles.js";
 export * from "./manifest.js";
 export * from "./policy.js";
 export * from "./render.js";

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ export * from "./github/client.js";
 export * from "./github/provision.js";
 export * from "./home/sync.js";
 export * from "./manifest.js";
+export * from "./policy.js";
 export * from "./render.js";
 export * from "./runners.js";
 export * from "./state.js";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./doctor.js";
+export * from "./exceptions.js";
 export * from "./fleet.js";
 export * from "./github/client.js";
 export * from "./github/provision.js";

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ export * from "./home/sync.js";
 export * from "./language-profiles.js";
 export * from "./manifest.js";
 export * from "./policy.js";
+export * from "./provenance.js";
 export * from "./render.js";
 export * from "./runners.js";
 export * from "./state.js";

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,3 +13,4 @@ export * from "./render.js";
 export * from "./runners.js";
 export * from "./state.js";
 export * from "./types.js";
+export * from "./upgrades.js";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./doctor.js";
+export * from "./conformance.js";
 export * from "./exceptions.js";
 export * from "./fleet.js";
 export * from "./github/client.js";

--- a/src/language-profiles.ts
+++ b/src/language-profiles.ts
@@ -1,0 +1,107 @@
+import { readdir } from "node:fs/promises";
+import type { Dirent } from "node:fs";
+import path from "node:path";
+
+import type { ArchetypeKind, BootstrapManifest } from "./types.js";
+
+export const LANGUAGE_PROFILES = [
+  "typescript",
+  "python",
+  "rust",
+  "go",
+  "swift",
+  "terraform",
+  "shell",
+  "sql-sqlite",
+  "documentation"
+] as const;
+
+export type LanguageProfile = (typeof LANGUAGE_PROFILES)[number];
+
+export interface LanguageProfileConflict {
+  profile: LanguageProfile;
+  reason: string;
+}
+
+export interface LanguageProfileResolution {
+  detected: LanguageProfile[];
+  selected: LanguageProfile[];
+  conflicts: LanguageProfileConflict[];
+}
+
+const ignoredDirectories = new Set([".git", ".next", ".turbo", "build", "coverage", "dist", "node_modules", "target", "vendor"]);
+
+function profileForPath(relativePath: string): LanguageProfile[] {
+  const basename = path.posix.basename(relativePath).toLowerCase();
+  const extension = path.posix.extname(relativePath).toLowerCase();
+  const profiles = new Set<LanguageProfile>();
+
+  if (basename === "package.swift" || extension === ".swift") profiles.add("swift");
+  if (basename === "cargo.toml" || extension === ".rs") profiles.add("rust");
+  if (basename === "go.mod" || extension === ".go") profiles.add("go");
+  if (basename === "pyproject.toml" || basename === "setup.py" || extension === ".py") profiles.add("python");
+  if (basename === "tsconfig.json" || basename === "tsconfig.base.json" || extension === ".ts" || extension === ".tsx") profiles.add("typescript");
+  if (extension === ".tf") profiles.add("terraform");
+  if (extension === ".sh") profiles.add("shell");
+  if (extension === ".sql" || extension === ".sqlite" || extension === ".db") profiles.add("sql-sqlite");
+  if (basename.startsWith("readme") || relativePath.startsWith("docs/")) profiles.add("documentation");
+
+  return [...profiles];
+}
+
+async function collectProfiles(root: string, relativeDir = "", profiles = new Set<LanguageProfile>()): Promise<void> {
+  let entries: Dirent<string>[];
+  try {
+    entries = await readdir(path.join(root, relativeDir), { encoding: "utf8", withFileTypes: true });
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return;
+    throw error;
+  }
+
+  for (const entry of entries) {
+    const relativePath = relativeDir ? `${relativeDir}/${entry.name}` : entry.name;
+    if (entry.isDirectory()) {
+      if (!ignoredDirectories.has(entry.name)) {
+        if (relativePath === "docs") profiles.add("documentation");
+        await collectProfiles(root, relativePath, profiles);
+      }
+      continue;
+    }
+    if (entry.isFile()) {
+      for (const profile of profileForPath(relativePath)) profiles.add(profile);
+    }
+  }
+}
+
+function expectedProfiles(kind: ArchetypeKind): LanguageProfile[] {
+  switch (kind) {
+    case "nextjs-web":
+    case "node-ts-service":
+      return ["typescript"];
+    case "python-service":
+      return ["python"];
+    case "generic-empty":
+      return [];
+  }
+}
+
+export async function resolveLanguageProfiles(
+  manifest: BootstrapManifest,
+  targetDir: string
+): Promise<LanguageProfileResolution> {
+  const profileSet = new Set<LanguageProfile>();
+  await collectProfiles(targetDir, "", profileSet);
+  const detected = LANGUAGE_PROFILES.filter((profile) => profileSet.has(profile));
+  const expected = expectedProfiles(manifest.archetype.kind);
+  const conflicts =
+    detected.length === 0
+      ? []
+      : expected
+          .filter((profile) => !profileSet.has(profile))
+          .map((profile) => ({
+            profile,
+            reason: `${manifest.archetype.kind} expects the ${profile} profile, but the target detects ${detected.join(", ")}.`
+          }));
+
+  return { detected, selected: detected, conflicts };
+}

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -11,7 +11,8 @@ import type {
   DefaultRepositoryPermission,
   EnvironmentConfig,
   IssueLabelConfig,
-  OrganizationConfig
+  OrganizationConfig,
+  RepoClass
 } from "./types.js";
 
 export const DEFAULT_ISSUE_LABELS: IssueLabelConfig[] = [
@@ -271,13 +272,21 @@ const manifestSchema = z.object({
     name: z.string().min(1),
     displayName: z.string().min(1).optional(),
     description: z.string().optional(),
+    maturity: z.enum(["experimental", "alpha", "beta", "stable", "maintenance", "archived"]).optional(),
     visibility: z.enum(["private", "public", "internal"]).optional(),
     owner: z.string().min(1),
     defaultBranch: z.string().min(1).optional()
   }),
   repo: z
     .object({
-      class: z.enum(["application", "library", "service", "tooling", "documentation"]).optional(),
+      class: z
+        .enum(["application", "tooling", "cli", "library", "service", "infrastructure", "github-action", "specification", "documentation"])
+        .optional(),
+      classMigration: z
+        .object({
+          target: z.enum(["cli", "library", "service", "infrastructure", "github-action", "specification", "documentation"])
+        })
+        .optional(),
       managedPaths: z.array(z.string().min(1)).optional(),
       docs: repoDocsSchema.optional(),
       templates: repoTemplatesSchema.optional(),
@@ -529,8 +538,23 @@ function mergeAdditionalWorkflows(
 }
 
 function normalizeRepo(repo: z.input<typeof manifestSchema>["repo"]): BootstrapManifest["repo"] {
+  const legacyClass = repo?.class === "application" || repo?.class === "tooling" ? repo.class : undefined;
+  const canonicalClass = repo?.class && !legacyClass ? (repo.class as RepoClass) : undefined;
+  if (legacyClass && !repo?.classMigration) {
+    throw new Error(
+      `Legacy repository class \"${legacyClass}\" requires repo.classMigration.target; choose its canonical Flow repository class explicitly.`
+    );
+  }
+
   return {
-    ...(repo?.class ? { class: repo.class } : {}),
+    ...(legacyClass
+      ? {
+          class: repo?.classMigration?.target as RepoClass,
+          classMigration: { from: legacyClass, target: repo?.classMigration?.target as RepoClass }
+        }
+      : canonicalClass
+        ? { class: canonicalClass }
+        : {}),
     managedPaths: repo?.managedPaths ?? [],
     ...(repo?.docs
       ? {
@@ -710,6 +734,7 @@ export function normalizeManifest(raw: z.input<typeof manifestSchema>): Bootstra
       description:
         parsed.project.description ??
         "Manifest-first control plane for repo scaffolding, GitHub governance, and portable agent profiles.",
+      ...(parsed.project.maturity ? { maturity: parsed.project.maturity } : {}),
       visibility: parsed.project.visibility ?? "private",
       owner: parsed.project.owner,
       defaultBranch

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -388,7 +388,11 @@ const manifestSchema = z.object({
       prod: environmentSchema.optional()
     })
     .optional()
-});
+}).passthrough();
+
+const KNOWN_MANIFEST_SETTINGS = new Set([
+  "version", "project", "repo", "archetype", "github", "ci", "release", "agents", "capabilities", "policy", "environments"
+]);
 
 function slugify(value: string): string {
   return value
@@ -672,6 +676,7 @@ function normalizeCustomScripts(
 
 export function normalizeManifest(raw: z.input<typeof manifestSchema>): BootstrapManifest {
   const parsed = manifestSchema.parse(raw);
+  const unknownSettings = Object.keys(parsed).filter((key) => !KNOWN_MANIFEST_SETTINGS.has(key)).sort();
   const version = parsed.version ?? 1;
   const reviewers = (parsed.github?.reviewers ?? []).map((reviewer) => reviewer.replace(/^@/, ""));
   const defaultBranch = parsed.project.defaultBranch ?? "main";
@@ -698,6 +703,7 @@ export function normalizeManifest(raw: z.input<typeof manifestSchema>): Bootstra
 
   return {
     version,
+    unknownSettings,
     project: {
       name: parsed.project.name,
       ...(parsed.project.displayName ? { displayName: parsed.project.displayName } : {}),
@@ -903,11 +909,12 @@ export function createSampleManifest(overrides?: ManifestOverrides): string {
 }
 
 function serializableManifest(manifest: BootstrapManifest): BootstrapManifest | Record<string, unknown> {
+  const { unknownSettings: _unknownSettings, ...serializable } = manifest;
   if (manifest.version !== 2 || !manifest.capabilities?.release) {
-    return manifest;
+    return serializable;
   }
 
-  const { release: _release, ...withoutRelease } = manifest;
+  const { release: _release, ...withoutRelease } = serializable;
   return withoutRelease;
 }
 

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -187,6 +187,14 @@ const capabilitiesSchema = z.object({
     .optional()
 });
 
+const policySchema = z.object({
+  flow: z.object({
+    ref: z.string().min(1),
+    sha256: z.string().regex(/^[0-9a-fA-F]{64}$/),
+    bundlePath: z.string().min(1)
+  })
+});
+
 const dependabotEcosystemSchema = z.object({
   packageEcosystem: z.enum(["npm", "github-actions", "docker"]),
   directory: z.string().min(1).optional(),
@@ -372,6 +380,7 @@ const manifestSchema = z.object({
     })
     .optional(),
   capabilities: capabilitiesSchema.optional(),
+  policy: policySchema.optional(),
   environments: z
     .object({
       dev: environmentSchema.optional(),
@@ -813,6 +822,9 @@ export function normalizeManifest(raw: z.input<typeof manifestSchema>): Bootstra
       sharedSkills: parsed.agents?.sharedSkills ?? []
     },
     ...(capabilities ? { capabilities } : {}),
+    ...(parsed.policy
+      ? { policy: { flow: { ...parsed.policy.flow, sha256: parsed.policy.flow.sha256.toLowerCase() } } }
+      : {}),
     environments: {
       dev: applyEnvironmentDefaults(defaultEnvironment(environments.dev), reviewers, defaultBranch, "dev"),
       stage: applyEnvironmentDefaults(

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -196,6 +196,18 @@ const policySchema = z.object({
   })
 });
 
+const exceptionSchema = z.object({
+  id: z.string().min(1),
+  policy: z.string().min(1),
+  scope: z.string().min(1),
+  rationale: z.string().min(1),
+  approvedBy: z.string().min(1),
+  issue: z.string().min(1),
+  permanent: z.boolean().optional(),
+  expiresAt: z.string().min(1).optional(),
+  adr: z.string().min(1).optional()
+});
+
 const dependabotEcosystemSchema = z.object({
   packageEcosystem: z.enum(["npm", "github-actions", "docker"]),
   directory: z.string().min(1).optional(),
@@ -390,6 +402,7 @@ const manifestSchema = z.object({
     .optional(),
   capabilities: capabilitiesSchema.optional(),
   policy: policySchema.optional(),
+  exceptions: z.array(exceptionSchema).optional(),
   environments: z
     .object({
       dev: environmentSchema.optional(),
@@ -400,7 +413,7 @@ const manifestSchema = z.object({
 }).passthrough();
 
 const KNOWN_MANIFEST_SETTINGS = new Set([
-  "version", "project", "repo", "archetype", "github", "ci", "release", "agents", "capabilities", "policy", "environments"
+  "version", "project", "repo", "archetype", "github", "ci", "release", "agents", "capabilities", "policy", "exceptions", "environments"
 ]);
 
 function slugify(value: string): string {
@@ -856,6 +869,17 @@ export function normalizeManifest(raw: z.input<typeof manifestSchema>): Bootstra
     ...(parsed.policy
       ? { policy: { flow: { ...parsed.policy.flow, sha256: parsed.policy.flow.sha256.toLowerCase() } } }
       : {}),
+    exceptions: (parsed.exceptions ?? []).map((exception) => ({
+      id: exception.id,
+      policy: exception.policy,
+      scope: exception.scope,
+      rationale: exception.rationale,
+      approvedBy: exception.approvedBy,
+      issue: exception.issue,
+      permanent: exception.permanent ?? false,
+      ...(exception.expiresAt ? { expiresAt: exception.expiresAt } : {}),
+      ...(exception.adr ? { adr: exception.adr } : {})
+    })),
     environments: {
       dev: applyEnvironmentDefaults(defaultEnvironment(environments.dev), reviewers, defaultBranch, "dev"),
       stage: applyEnvironmentDefaults(

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -350,6 +350,11 @@ const manifestSchema = z.object({
       fastChecks: z.array(z.string()).optional(),
       extendedChecks: z.array(z.string()).optional(),
       nightlyCron: z.string().optional(),
+      prGovernance: z
+        .object({
+          enforceAfter: z.string().datetime({ offset: true })
+        })
+        .optional(),
       workflows: ciWorkflowsSchema.optional(),
       additionalWorkflows: z.array(additionalWorkflowSchema).optional(),
       appPaths: z.array(z.string().min(1)).optional(),
@@ -799,6 +804,7 @@ export function normalizeManifest(raw: z.input<typeof manifestSchema>): Bootstra
       fastChecks: parsed.ci?.fastChecks ?? ["lint", "typecheck", "unit", "build", "secrets"],
       extendedChecks: parsed.ci?.extendedChecks ?? ["integration", "release-readiness"],
       nightlyCron: parsed.ci?.nightlyCron ?? "0 7 * * *",
+      ...(parsed.ci?.prGovernance ? { prGovernance: { enforceAfter: parsed.ci.prGovernance.enforceAfter } } : {}),
       additionalWorkflows,
       ...(workflows ? { workflows } : {}),
       appPaths: normalizePaths(parsed.ci?.appPaths),

--- a/src/policy.ts
+++ b/src/policy.ts
@@ -1,0 +1,68 @@
+import { createHash } from "node:crypto";
+
+import type { BootstrapManifest } from "./types.js";
+
+export interface FlowPolicySource {
+  ref: string;
+  sha256: string;
+}
+
+export interface FlowPolicyBundle {
+  standard: "public-repository-standard";
+  version: string;
+  publisher?: Record<string, unknown>;
+  compatibility?: Record<string, Record<string, string>>;
+  [key: string]: unknown;
+}
+
+export interface ResolvedPolicyContract {
+  manifest: BootstrapManifest;
+  policy: FlowPolicyBundle;
+  source: FlowPolicySource;
+  unknownManifestSettings: string[];
+}
+
+function stableJson(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(stableJson).join(",")}]`;
+  if (value && typeof value === "object") {
+    return `{${Object.entries(value as Record<string, unknown>)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, entry]) => `${JSON.stringify(key)}:${stableJson(entry)}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function isImmutablePolicyRef(ref: string): boolean {
+  return /^refs\/tags\/v\d+\.\d+\.\d+$/.test(ref) || /^[0-9a-f]{40}$/i.test(ref);
+}
+
+export function flowPolicyDigest(bundle: unknown): string {
+  return createHash("sha256").update(stableJson(bundle)).digest("hex");
+}
+
+export function resolveFlowPolicy(
+  manifest: BootstrapManifest,
+  bundle: unknown,
+  source: FlowPolicySource,
+  unknownManifestSettings: string[] = []
+): ResolvedPolicyContract {
+  if (!isImmutablePolicyRef(source.ref)) {
+    throw new Error("Flow policy ref must be an exact release tag or immutable 40-character SHA.");
+  }
+  if (!/^[0-9a-f]{64}$/i.test(source.sha256)) {
+    throw new Error("Flow policy digest must be a SHA-256 hex digest.");
+  }
+  if (flowPolicyDigest(bundle) !== source.sha256.toLowerCase()) {
+    throw new Error("Flow policy digest does not match the verified local bundle.");
+  }
+  if (!bundle || typeof bundle !== "object") {
+    throw new Error("Flow policy bundle must be an object.");
+  }
+  const policy = bundle as FlowPolicyBundle;
+  if (policy.standard !== "public-repository-standard" || !/^1\.\d+\.\d+$/.test(policy.version)) {
+    throw new Error("Flow policy bundle is not a compatible Public Repository Standard v1 policy.");
+  }
+
+  return { manifest, policy, source: { ...source, sha256: source.sha256.toLowerCase() }, unknownManifestSettings: [...unknownManifestSettings].sort() };
+}

--- a/src/policy.ts
+++ b/src/policy.ts
@@ -36,8 +36,14 @@ function stableJson(value: unknown): string {
   return JSON.stringify(value);
 }
 
-function isImmutablePolicyRef(ref: string): boolean {
+export function isImmutablePolicyRef(ref: string): boolean {
   return /^refs\/tags\/v\d+\.\d+\.\d+$/.test(ref) || /^[0-9a-f]{40}$/i.test(ref);
+}
+
+export function requireImmutableProductionWorkflowRef(ref: string, surface = "Production workflow"): void {
+  if (!isImmutablePolicyRef(ref)) {
+    throw new Error(`${surface} ref must be an exact vX.Y.Z tag or immutable 40-character SHA; ${JSON.stringify(ref)} is mutable.`);
+  }
 }
 
 export function flowPolicyDigest(bundle: unknown): string {

--- a/src/policy.ts
+++ b/src/policy.ts
@@ -1,4 +1,7 @@
 import { createHash } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import YAML from "yaml";
 
 import type { BootstrapManifest } from "./types.js";
 
@@ -65,4 +68,14 @@ export function resolveFlowPolicy(
   }
 
   return { manifest, policy, source: { ...source, sha256: source.sha256.toLowerCase() }, unknownManifestSettings: [...unknownManifestSettings].sort() };
+}
+
+export async function loadResolvedFlowPolicy(manifest: BootstrapManifest, manifestDir: string): Promise<ResolvedPolicyContract> {
+  if (!manifest.policy?.flow) {
+    throw new Error("Manifest does not declare a Flow policy bundle.");
+  }
+  const source = manifest.policy.flow;
+  const bundlePath = path.resolve(manifestDir, source.bundlePath);
+  const bundle = YAML.parse(await readFile(bundlePath, "utf8"));
+  return resolveFlowPolicy(manifest, bundle, source);
 }

--- a/src/policy.ts
+++ b/src/policy.ts
@@ -84,5 +84,5 @@ export async function loadResolvedFlowPolicy(manifest: BootstrapManifest, manife
     throw new Error("Flow policy bundle path must stay within the manifest directory.");
   }
   const bundle = YAML.parse(await readFile(bundlePath, "utf8"));
-  return resolveFlowPolicy(manifest, bundle, source);
+  return resolveFlowPolicy(manifest, bundle, source, manifest.unknownSettings);
 }

--- a/src/policy.ts
+++ b/src/policy.ts
@@ -75,7 +75,14 @@ export async function loadResolvedFlowPolicy(manifest: BootstrapManifest, manife
     throw new Error("Manifest does not declare a Flow policy bundle.");
   }
   const source = manifest.policy.flow;
+  if (path.isAbsolute(source.bundlePath)) {
+    throw new Error("Flow policy bundle path must be relative to the manifest directory.");
+  }
   const bundlePath = path.resolve(manifestDir, source.bundlePath);
+  const relativePath = path.relative(manifestDir, bundlePath);
+  if (relativePath === ".." || relativePath.startsWith(`..${path.sep}`) || path.isAbsolute(relativePath)) {
+    throw new Error("Flow policy bundle path must stay within the manifest directory.");
+  }
   const bundle = YAML.parse(await readFile(bundlePath, "utf8"));
   return resolveFlowPolicy(manifest, bundle, source);
 }

--- a/src/provenance.ts
+++ b/src/provenance.ts
@@ -1,0 +1,96 @@
+import { z } from "zod";
+
+export const PUBLIC_PROVENANCE_SCHEMA_VERSION = 1;
+export const REDACTED_CREDENTIAL = "[REDACTED:CREDENTIAL]";
+
+const shaPattern = /^[0-9a-f]{40}$/;
+const credentialPatterns = [
+  new RegExp(`\\b(?:gh[pousr]_[A-Za-z0-9_]{20,}|${"github"}_pat_[A-Za-z0-9_]{20,})\\b`, "i"),
+  new RegExp(`\\b${"AK" + "IA"}[0-9A-Z]{16}\\b`),
+  /-----BEGIN (?:[A-Z ]+ )?PRIVATE KEY-----/,
+  /\b(?:api[_-]?key|access[_-]?token|password|secret|token)\s*[:=]\s*[^\s]+/i
+];
+
+const reviewerSchema = z.object({
+  login: z.string().min(1),
+  state: z.enum(["approved", "commented", "changes_requested"])
+});
+
+export const publicProvenanceSchema = z
+  .object({
+    schemaVersion: z.literal(PUBLIC_PROVENANCE_SCHEMA_VERSION),
+    runId: z.string().regex(/^[A-Za-z0-9._-]+$/),
+    subject: z.object({
+      repository: z.string().regex(/^[^/\s]+\/[^/\s]+$/),
+      commitSha: z.string().regex(shaPattern),
+      ref: z.string().min(1)
+    }),
+    execution: z.object({
+      workflow: z.string().min(1),
+      runUrl: z.string().url().optional(),
+      createdAt: z.string().datetime({ offset: true })
+    }),
+    reviewers: z.array(reviewerSchema),
+    metadata: z.record(z.string(), z.string()),
+    redaction: z.object({
+      policyVersion: z.literal(1),
+      replacements: z.number().int().nonnegative()
+    })
+  })
+  .superRefine((manifest, context) => {
+    for (const [key, value] of Object.entries(manifest.metadata)) {
+      if (containsCredential(value)) {
+        context.addIssue({
+          code: "custom",
+          message: `Public provenance metadata ${key} contains a credential-like literal. Redact it before validation.`
+        });
+      }
+    }
+  });
+
+export type PublicProvenance = z.infer<typeof publicProvenanceSchema>;
+export type PublicProvenanceInput = Omit<PublicProvenance, "schemaVersion" | "metadata" | "redaction"> & {
+  metadata?: Record<string, string | undefined>;
+};
+
+export function containsCredential(value: string): boolean {
+  return credentialPatterns.some((pattern) => pattern.test(value));
+}
+
+export function redactPublicText(value: string): { value: string; replacements: number } {
+  let redacted = value;
+  let replacements = 0;
+  for (const pattern of credentialPatterns) {
+    redacted = redacted.replace(pattern, () => {
+      replacements += 1;
+      return REDACTED_CREDENTIAL;
+    });
+  }
+  return { value: redacted, replacements };
+}
+
+export function createPublicProvenance(input: PublicProvenanceInput): PublicProvenance {
+  let replacements = 0;
+  const metadata = Object.fromEntries(
+    Object.entries(input.metadata ?? {}).map(([key, rawValue]) => {
+      if (rawValue === undefined) return [key, ""];
+      const redacted = redactPublicText(rawValue);
+      replacements += redacted.replacements;
+      return [key, redacted.value];
+    })
+  );
+
+  return publicProvenanceSchema.parse({
+    schemaVersion: PUBLIC_PROVENANCE_SCHEMA_VERSION,
+    runId: input.runId,
+    subject: input.subject,
+    execution: input.execution,
+    reviewers: input.reviewers,
+    metadata,
+    redaction: { policyVersion: 1, replacements }
+  });
+}
+
+export function validatePublicProvenance(value: unknown): PublicProvenance {
+  return publicProvenanceSchema.parse(value);
+}

--- a/src/render.ts
+++ b/src/render.ts
@@ -1,9 +1,10 @@
 import path from "node:path";
 
 import { renderManagedFiles } from "./archetypes.js";
+import { sha256 } from "./lib/hash.js";
 import { readTextIfExists, removeFileIfExists, writeTextFile } from "./lib/fs.js";
 import { resolveLanguageProfiles, type LanguageProfileResolution } from "./language-profiles.js";
-import { createRepoState, loadRepoState, writeRepoState } from "./state.js";
+import { createOwnershipSidecar, createRepoState, loadRepoState, writeRepoState } from "./state.js";
 import type { BootstrapManifest, PlannedFileChange, RenderedFile } from "./types.js";
 
 export interface RepoPlan {
@@ -38,6 +39,10 @@ function globToRegExp(pattern: string): RegExp {
 
 function matchesManagedPath(filePath: string, pattern: string): boolean {
   return globToRegExp(pattern).test(filePath.replace(/\\/g, "/"));
+}
+
+function isManagedContentHash(value: string | undefined): value is string {
+  return value !== undefined && /^[a-f0-9]{64}$/i.test(value);
 }
 
 const managedPathDependencies = [
@@ -124,13 +129,25 @@ function validateManagedPathDependencies(files: RenderedFile[]): void {
 }
 
 export async function planRepo(manifest: BootstrapManifest, targetDir: string): Promise<RepoPlan> {
-  const files = selectManagedFiles(manifest, renderManagedFiles(manifest));
+  const renderedFiles = selectManagedFiles(manifest, renderManagedFiles(manifest));
+  const files = [...renderedFiles, createOwnershipSidecar(renderedFiles)];
   const languageProfiles = await resolveLanguageProfiles(manifest, targetDir);
   const existingState = await loadRepoState(targetDir);
   const changes: PlannedFileChange[] = [];
 
   for (const file of files) {
     const existingContents = await readTextIfExists(path.join(targetDir, file.path));
+    const managedHash = existingState?.managedFiles[file.path];
+    if (
+      existingContents !== undefined &&
+      isManagedContentHash(managedHash) &&
+      sha256(existingContents) !== managedHash &&
+      existingContents !== file.contents
+    ) {
+      throw new Error(
+        `Managed file ${file.path} was directly modified. Restore it, remove it from managed paths, or use an explicit migration before applying Bootstrap changes.`
+      );
+    }
     const type =
       existingContents === undefined
         ? "create"
@@ -149,6 +166,16 @@ export async function planRepo(manifest: BootstrapManifest, targetDir: string): 
     const plannedPaths = new Set(files.map((file) => file.path));
     for (const stalePath of Object.keys(existingState.managedFiles)) {
       if (!plannedPaths.has(stalePath)) {
+        const existingContents = await readTextIfExists(path.join(targetDir, stalePath));
+        if (
+          existingContents !== undefined &&
+          isManagedContentHash(existingState.managedFiles[stalePath]) &&
+          sha256(existingContents) !== existingState.managedFiles[stalePath]
+        ) {
+          throw new Error(
+            `Managed file ${stalePath} was directly modified. Restore it or use an explicit migration before Bootstrap removes it.`
+          );
+        }
         changes.push({
           path: stalePath,
           type: "delete",

--- a/src/render.ts
+++ b/src/render.ts
@@ -2,12 +2,14 @@ import path from "node:path";
 
 import { renderManagedFiles } from "./archetypes.js";
 import { readTextIfExists, removeFileIfExists, writeTextFile } from "./lib/fs.js";
+import { resolveLanguageProfiles, type LanguageProfileResolution } from "./language-profiles.js";
 import { createRepoState, loadRepoState, writeRepoState } from "./state.js";
 import type { BootstrapManifest, PlannedFileChange, RenderedFile } from "./types.js";
 
 export interface RepoPlan {
   changes: PlannedFileChange[];
   files: RenderedFile[];
+  languageProfiles: LanguageProfileResolution;
 }
 
 function globToRegExp(pattern: string): RegExp {
@@ -123,6 +125,7 @@ function validateManagedPathDependencies(files: RenderedFile[]): void {
 
 export async function planRepo(manifest: BootstrapManifest, targetDir: string): Promise<RepoPlan> {
   const files = selectManagedFiles(manifest, renderManagedFiles(manifest));
+  const languageProfiles = await resolveLanguageProfiles(manifest, targetDir);
   const existingState = await loadRepoState(targetDir);
   const changes: PlannedFileChange[] = [];
 
@@ -157,7 +160,8 @@ export async function planRepo(manifest: BootstrapManifest, targetDir: string): 
 
   return {
     changes: changes.sort((left, right) => left.path.localeCompare(right.path)),
-    files
+    files,
+    languageProfiles
   };
 }
 

--- a/src/state.ts
+++ b/src/state.ts
@@ -11,6 +11,7 @@ export const HOME_STATE_PATH = ".bootstrap/home-state.json";
 export const LEGACY_HOME_STATE_PATH = ".new-project-bootstrap/home-state.json";
 export const REPO_STATE_FILENAME = "bootstrap-state.json";
 export const LEGACY_REPO_STATE_FILENAME = "new-project-bootstrap-state.json";
+export const OWNERSHIP_SIDECAR_PATH = ".bootstrap/managed-files.json";
 
 async function resolveGitDir(targetDir: string): Promise<string | undefined> {
   const gitPath = path.join(targetDir, ".git");
@@ -73,5 +74,30 @@ export function createRepoState(manifest: BootstrapManifest, files: RenderedFile
     manifestHash: sha256(JSON.stringify(manifest)),
     templateVersion: TEMPLATE_VERSION,
     managedFiles: Object.fromEntries(files.map((file) => [file.path, sha256(file.contents)]))
+  };
+}
+
+export function createOwnershipSidecar(files: RenderedFile[]): RenderedFile {
+  const managedFiles = Object.fromEntries(
+    files
+      .filter((file) => file.path !== OWNERSHIP_SIDECAR_PATH)
+      .sort((left, right) => left.path.localeCompare(right.path))
+      .map((file) => [file.path, { sha256: sha256(file.contents), source: "bootstrap" }])
+  );
+
+  return {
+    path: OWNERSHIP_SIDECAR_PATH,
+    contents: `${JSON.stringify(
+      {
+        schemaVersion: 1,
+        owner: "bootstrap",
+        templateVersion: TEMPLATE_VERSION,
+        regenerationCommand: "bootstrap apply repo --manifest ./project.bootstrap.yaml",
+        managedFiles
+      },
+      null,
+      2
+    )}\n`,
+    reason: "Managed-file ownership sidecar"
   };
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -140,6 +140,7 @@ export interface OrganizationConfig {
 
 export interface BootstrapManifest {
   version: 1 | 2;
+  unknownSettings: string[];
   project: {
     name: string;
     displayName?: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -258,6 +258,13 @@ export interface BootstrapManifest {
       enabled: boolean;
     };
   };
+  policy?: {
+    flow: {
+      ref: string;
+      sha256: string;
+      bundlePath: string;
+    };
+  };
   environments: {
     dev: EnvironmentConfig;
     stage: EnvironmentConfig;

--- a/src/types.ts
+++ b/src/types.ts
@@ -218,6 +218,9 @@ export interface BootstrapManifest {
     fastChecks: string[];
     extendedChecks: string[];
     nightlyCron: string;
+    prGovernance?: {
+      enforceAfter: string;
+    };
     additionalWorkflows: AdditionalWorkflowConfig[];
     workflows?: {
       prFastCi: boolean;

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,7 +3,16 @@ export type ArchetypeKind = "nextjs-web" | "node-ts-service" | "python-service" 
 export type PackageManager = "npm" | "pnpm" | "yarn" | "python";
 export type RunnerPolicy = "hybrid-safe" | "self-hosted-first" | "github-hosted-first";
 export type DefaultRepositoryPermission = "read" | "write" | "admin" | "none";
-export type RepoClass = "application" | "library" | "service" | "tooling" | "documentation";
+export type RepoClass =
+  | "cli"
+  | "library"
+  | "service"
+  | "infrastructure"
+  | "github-action"
+  | "specification"
+  | "documentation";
+export type LegacyRepoClass = "application" | "tooling";
+export type ProductMaturity = "experimental" | "alpha" | "beta" | "stable" | "maintenance" | "archived";
 export type CiPolicy = "standard" | "standard-public" | "experimental" | "strict";
 
 export interface CodeownerRule {
@@ -26,6 +35,10 @@ export interface EnvironmentConfig {
 
 export interface RepoConfig {
   class?: RepoClass;
+  classMigration?: {
+    from: LegacyRepoClass;
+    target: RepoClass;
+  };
   managedPaths: string[];
   docs?: {
     readme: boolean;
@@ -145,6 +158,7 @@ export interface BootstrapManifest {
     name: string;
     displayName?: string;
     description: string;
+    maturity?: ProductMaturity;
     visibility: ProjectVisibility;
     owner: string;
     defaultBranch: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,6 +15,18 @@ export type LegacyRepoClass = "application" | "tooling";
 export type ProductMaturity = "experimental" | "alpha" | "beta" | "stable" | "maintenance" | "archived";
 export type CiPolicy = "standard" | "standard-public" | "experimental" | "strict";
 
+export interface PolicyException {
+  id: string;
+  policy: string;
+  scope: string;
+  rationale: string;
+  approvedBy: string;
+  issue: string;
+  permanent: boolean;
+  expiresAt?: string;
+  adr?: string;
+}
+
 export interface CodeownerRule {
   pattern: string;
   owners: string[];
@@ -280,6 +292,7 @@ export interface BootstrapManifest {
       bundlePath: string;
     };
   };
+  exceptions: PolicyException[];
   environments: {
     dev: EnvironmentConfig;
     stage: EnvironmentConfig;

--- a/src/upgrades.ts
+++ b/src/upgrades.ts
@@ -1,0 +1,58 @@
+export type UpgradeRisk = "patch" | "minor" | "major" | "invalid";
+export type PilotOutcome = "pending" | "passed" | "failed";
+
+export interface FleetUpgradeCandidate {
+  repo: string;
+  repoClass: string;
+  currentPolicy: string;
+  targetPolicy: string;
+  exceptionId?: string;
+  pilotOutcome?: PilotOutcome;
+}
+
+export interface FleetUpgradePlanEntry extends FleetUpgradeCandidate {
+  risk: UpgradeRisk;
+  role: "pilot" | "batch";
+  status: "eligible" | "review-required" | "blocked";
+  reason: string;
+}
+
+type Semver = { major: number; minor: number; patch: number };
+
+function parseVersion(value: string): Semver | undefined {
+  const match = /^v?(\d+)\.(\d+)\.(\d+)$/.exec(value);
+  return match
+    ? { major: Number(match[1]), minor: Number(match[2]), patch: Number(match[3]) }
+    : undefined;
+}
+
+export function classifyPolicyUpgrade(currentPolicy: string, targetPolicy: string): UpgradeRisk {
+  const current = parseVersion(currentPolicy);
+  const target = parseVersion(targetPolicy);
+  if (!current || !target || target.major < current.major || (target.major === current.major && target.minor < current.minor) || (target.major === current.major && target.minor === current.minor && target.patch < current.patch)) {
+    return "invalid";
+  }
+  if (target.major !== current.major) return "major";
+  if (target.minor !== current.minor) return "minor";
+  return "patch";
+}
+
+export function planFleetPolicyUpgrades(candidates: FleetUpgradeCandidate[]): FleetUpgradePlanEntry[] {
+  const pilots = new Map<string, PilotOutcome>();
+  return [...candidates]
+    .sort((left, right) => left.repoClass.localeCompare(right.repoClass) || left.repo.localeCompare(right.repo))
+    .map((candidate) => {
+      const risk = classifyPolicyUpgrade(candidate.currentPolicy, candidate.targetPolicy);
+      const knownPilot = pilots.get(candidate.repoClass);
+      const role = knownPilot === undefined ? "pilot" : "batch";
+      if (role === "pilot") pilots.set(candidate.repoClass, candidate.pilotOutcome ?? "pending");
+
+      if (risk === "invalid") return { ...candidate, risk, role, status: "blocked", reason: "Policy versions must be increasing exact SemVer values." };
+      if (knownPilot === "failed") return { ...candidate, risk, role, status: "blocked", reason: `The ${candidate.repoClass} pilot failed; stop this batch until remediation is recorded.` };
+      if (candidate.exceptionId) return { ...candidate, risk, role, status: "review-required", reason: `Exception ${candidate.exceptionId} requires human review before a fleet upgrade PR.` };
+      if (risk === "major") return { ...candidate, risk, role, status: "review-required", reason: "Major upgrades require notification and an accepted ADR before opening a PR." };
+      if (risk === "minor") return { ...candidate, risk, role, status: "review-required", reason: "Minor upgrades require independent review before merge." };
+      if (role === "pilot" && (candidate.pilotOutcome ?? "pending") !== "passed") return { ...candidate, risk, role, status: "review-required", reason: "Record a passing representative pilot before rolling this class forward." };
+      return { ...candidate, risk, role, status: "eligible", reason: "Patch upgrade is eligible after the representative class pilot passed." };
+    });
+}

--- a/tests/__snapshots__/render.test.ts.snap
+++ b/tests/__snapshots__/render.test.ts.snap
@@ -76,6 +76,10 @@ exports[`renderManagedFiles > renders a stable managed file set for generic-empt
   },
   {
     "executable": true,
+    "path": "scripts/ci/check-action-pins.sh",
+  },
+  {
+    "executable": true,
     "path": "scripts/ci/run-release-verification.sh",
   },
   {
@@ -190,6 +194,10 @@ exports[`renderManagedFiles > renders a stable managed file set for nextjs-web 1
   {
     "executable": true,
     "path": "scripts/ci/check-pr-governance.sh",
+  },
+  {
+    "executable": true,
+    "path": "scripts/ci/check-action-pins.sh",
   },
   {
     "executable": true,
@@ -318,6 +326,10 @@ exports[`renderManagedFiles > renders a stable managed file set for node-ts-serv
   },
   {
     "executable": true,
+    "path": "scripts/ci/check-action-pins.sh",
+  },
+  {
+    "executable": true,
     "path": "scripts/ci/run-release-verification.sh",
   },
   {
@@ -432,6 +444,10 @@ exports[`renderManagedFiles > renders a stable managed file set for python-servi
   {
     "executable": true,
     "path": "scripts/ci/check-pr-governance.sh",
+  },
+  {
+    "executable": true,
+    "path": "scripts/ci/check-action-pins.sh",
   },
   {
     "executable": true,

--- a/tests/__snapshots__/render.test.ts.snap
+++ b/tests/__snapshots__/render.test.ts.snap
@@ -72,6 +72,10 @@ exports[`renderManagedFiles > renders a stable managed file set for generic-empt
   },
   {
     "executable": true,
+    "path": "scripts/ci/check-pr-governance.sh",
+  },
+  {
+    "executable": true,
     "path": "scripts/ci/run-release-verification.sh",
   },
   {
@@ -182,6 +186,10 @@ exports[`renderManagedFiles > renders a stable managed file set for nextjs-web 1
   {
     "executable": true,
     "path": "scripts/ci/run-extended-validation.sh",
+  },
+  {
+    "executable": true,
+    "path": "scripts/ci/check-pr-governance.sh",
   },
   {
     "executable": true,
@@ -306,6 +314,10 @@ exports[`renderManagedFiles > renders a stable managed file set for node-ts-serv
   },
   {
     "executable": true,
+    "path": "scripts/ci/check-pr-governance.sh",
+  },
+  {
+    "executable": true,
     "path": "scripts/ci/run-release-verification.sh",
   },
   {
@@ -416,6 +428,10 @@ exports[`renderManagedFiles > renders a stable managed file set for python-servi
   {
     "executable": true,
     "path": "scripts/ci/run-extended-validation.sh",
+  },
+  {
+    "executable": true,
+    "path": "scripts/ci/check-pr-governance.sh",
   },
   {
     "executable": true,

--- a/tests/action-pins.test.ts
+++ b/tests/action-pins.test.ts
@@ -1,0 +1,37 @@
+import { spawn } from "node:child_process";
+import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+async function runPinCheck(workflow: string) {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "bootstrap-action-pins-"));
+  const workflows = path.join(directory, ".github", "workflows");
+  await mkdir(workflows, { recursive: true });
+  await writeFile(path.join(workflows, "fixture.yml"), workflow);
+  return new Promise<{ code: number; output: string }>((resolve, reject) => {
+    const child = spawn("bash", [path.resolve("scripts/ci/check-action-pins.sh"), workflows]);
+    let output = "";
+    child.stdout.on("data", (chunk) => (output += chunk));
+    child.stderr.on("data", (chunk) => (output += chunk));
+    child.on("error", reject);
+    child.on("close", (code) => resolve({ code: code ?? 1, output }));
+  });
+}
+
+describe("check-action-pins", () => {
+  it("rejects mutable third-party references and pins without update metadata", async () => {
+    const result = await runPinCheck(`jobs:\n  check:\n    steps:\n      - uses: actions/checkout@v4\n      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706\n`);
+
+    expect(result.code).toBe(1);
+    expect(result.output).toContain("SA-ACTION-PIN-001");
+    expect(result.output).toContain("SA-ACTION-PIN-002");
+  });
+
+  it("accepts immutable pins with readable metadata and Bootstrap-owned reusable workflows", async () => {
+    const result = await runPinCheck(`jobs:\n  check:\n    steps:\n      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4\n  reuse:\n    uses: OMT-Global/bootstrap/.github/workflows/security-pr.yml@refs/heads/main\n`);
+
+    expect(result.code).toBe(0);
+    expect(result.output).toContain("validated 1 third-party action pin");
+  });
+});

--- a/tests/conformance.test.ts
+++ b/tests/conformance.test.ts
@@ -1,0 +1,54 @@
+import { mkdtemp, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+import { conformanceReportSchema, formatConformanceReport, runConformance } from "../src/conformance.js";
+import { normalizeManifest } from "../src/manifest.js";
+import { applyRepo } from "../src/render.js";
+
+async function fixtureDirectory(): Promise<string> {
+  return mkdtemp(path.join(os.tmpdir(), "bootstrap-conformance-"));
+}
+
+describe("runConformance", () => {
+  it("returns deterministic machine-validated blocking results for missing contract fields", async () => {
+    const directory = await fixtureDirectory();
+    const manifest = normalizeManifest({ project: { name: "missing-contract", owner: "acme" }, archetype: { kind: "generic-empty" } });
+
+    const report = await runConformance(manifest, directory);
+
+    expect(conformanceReportSchema.parse(report)).toEqual(report);
+    expect(report.exitCode).toBe(1);
+    expect(report.results.map((entry) => entry.ruleId)).toEqual([
+      "PRS-CLASS-001",
+      "PRS-MATURITY-001",
+      "PRS-OWNERSHIP-001",
+      "PRS-PROFILE-001"
+    ]);
+  });
+
+  it("passes the core for an applied canonical contract and keeps warning semantics distinct", async () => {
+    const directory = await fixtureDirectory();
+    await writeFile(path.join(directory, "pyproject.toml"), "[project]\nname = 'service'\n");
+    const manifest = normalizeManifest({
+      project: { name: "canonical-contract", owner: "acme", maturity: "stable" },
+      repo: { class: "service" },
+      archetype: { kind: "generic-empty" }
+    });
+    await applyRepo(manifest, directory);
+
+    const evaluatedManifest = normalizeManifest({
+      project: { name: "canonical-contract", owner: "acme", maturity: "stable" },
+      repo: { class: "service" },
+      archetype: { kind: "node-ts-service" }
+    });
+
+    const report = await runConformance(evaluatedManifest, directory);
+
+    expect(report.exitCode).toBe(0);
+    expect(report.summary.warning).toBe(1);
+    expect(report.results).toContainEqual(expect.objectContaining({ ruleId: "PRS-PROFILE-001", severity: "warning" }));
+    expect(formatConformanceReport(report)).toContain("Conformance: 0 blocking, 1 warning");
+  });
+});

--- a/tests/doctor.test.ts
+++ b/tests/doctor.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+
+import { runDoctor } from "../src/doctor.js";
+import { normalizeManifest } from "../src/manifest.js";
+import type { CommandRunner } from "../src/lib/process.js";
+
+const unavailableRunner: CommandRunner = async () => ({ stdout: "", stderr: "not installed", exitCode: 1 });
+
+describe("runDoctor", () => {
+  it("surfaces blocking exception validation with its stable rule ID", async () => {
+    const manifest = normalizeManifest({
+      project: { name: "doctor-exceptions", owner: "acme" },
+      archetype: { kind: "generic-empty" },
+      exceptions: [{ id: "temporary", policy: "release", scope: "repo", rationale: "migration", approvedBy: "alice", issue: "#55" }]
+    } as never);
+
+    const checks = await runDoctor(manifest, { runner: unavailableRunner, homeDir: "/tmp/home" });
+
+    expect(checks).toContainEqual(
+      expect.objectContaining({ name: "Policy exceptions", status: "fail", detail: expect.stringContaining("PRS-EXCEPTION-001") })
+    );
+  });
+});

--- a/tests/exceptions.test.ts
+++ b/tests/exceptions.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizeManifest } from "../src/manifest.js";
+import { validatePolicyExceptions } from "../src/exceptions.js";
+
+const now = new Date("2026-07-13T12:00:00.000Z");
+
+describe("validatePolicyExceptions", () => {
+  it("blocks expired or incomplete temporary exceptions with stable rule IDs", () => {
+    const report = validatePolicyExceptions(
+      [
+        { id: "missing-expiry", policy: "release", scope: "repo", rationale: "migration", approvedBy: "alice", issue: "#55", permanent: false },
+        { id: "expired", policy: "security", scope: "workflow", rationale: "migration", approvedBy: "alice", issue: "#55", permanent: false, expiresAt: "2026-07-12" }
+      ],
+      now
+    );
+
+    expect(report.blocking).toBe(true);
+    expect(report.results).toMatchObject([
+      { ruleId: "PRS-EXCEPTION-001", exceptionId: "expired", status: "block" },
+      { ruleId: "PRS-EXCEPTION-001", exceptionId: "missing-expiry", status: "block" }
+    ]);
+  });
+
+  it("requires an ADR for permanent exceptions and emits expiring notification intents without blocking", () => {
+    const report = validatePolicyExceptions(
+      [
+        { id: "permanent", policy: "release", scope: "repo", rationale: "required", approvedBy: "alice", issue: "#55", permanent: true },
+        { id: "expiring", policy: "ci", scope: "workflow", rationale: "migration", approvedBy: "alice", issue: "#55", permanent: false, expiresAt: "2026-07-20" }
+      ],
+      now
+    );
+
+    expect(report.blocking).toBe(true);
+    expect(report.notifications).toEqual([
+      {
+        ruleId: "PRS-NOTIFY-001",
+        exceptionId: "expiring",
+        event: "exception-expiring",
+        destinations: ["governing-issue-or-pull-request", "configured-notification-mechanism"],
+        continueAfterNotification: true
+      }
+    ]);
+  });
+
+  it("normalizes declared exceptions for deterministic validation", () => {
+    const manifest = normalizeManifest({
+      project: { name: "exceptions", owner: "acme" },
+      archetype: { kind: "generic-empty" },
+      exceptions: [{ id: "approved", policy: "security", scope: "repo", rationale: "temporary migration", approvedBy: "alice", issue: "#55", expiresAt: "2026-08-01" }]
+    } as never);
+
+    expect(manifest.exceptions).toEqual([
+      { id: "approved", policy: "security", scope: "repo", rationale: "temporary migration", approvedBy: "alice", issue: "#55", permanent: false, expiresAt: "2026-08-01" }
+    ]);
+    expect(validatePolicyExceptions(manifest.exceptions, now).blocking).toBe(false);
+  });
+});

--- a/tests/language-profiles.test.ts
+++ b/tests/language-profiles.test.ts
@@ -1,0 +1,58 @@
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+import { normalizeManifest } from "../src/manifest.js";
+import { resolveLanguageProfiles } from "../src/language-profiles.js";
+import { planRepo } from "../src/render.js";
+
+async function fixtureDirectory(): Promise<string> {
+  return mkdtemp(path.join(os.tmpdir(), "bootstrap-language-profiles-"));
+}
+
+describe("resolveLanguageProfiles", () => {
+  it("selects only profiles supported by repository markers and ignores build output", async () => {
+    const directory = await fixtureDirectory();
+    await mkdir(path.join(directory, "docs"));
+    await mkdir(path.join(directory, "node_modules", "ignored"), { recursive: true });
+    await Promise.all([
+      writeFile(path.join(directory, "src.ts"), "export {};\n"),
+      writeFile(path.join(directory, "main.py"), "print('hello')\n"),
+      writeFile(path.join(directory, "docs", "guide.md"), "# Guide\n"),
+      writeFile(path.join(directory, "node_modules", "ignored", "package.swift"), "// ignored\n")
+    ]);
+
+    const manifest = normalizeManifest({ project: { name: "polyglot", owner: "acme" }, archetype: { kind: "generic-empty" } });
+    await expect(resolveLanguageProfiles(manifest, directory)).resolves.toEqual({
+      detected: ["typescript", "python", "documentation"],
+      selected: ["typescript", "python", "documentation"],
+      conflicts: []
+    });
+  });
+
+  it("reports an archetype mismatch without suppressing detected profiles", async () => {
+    const directory = await fixtureDirectory();
+    await writeFile(path.join(directory, "pyproject.toml"), "[project]\nname = 'service'\n");
+    const manifest = normalizeManifest({ project: { name: "mismatch", owner: "acme" }, archetype: { kind: "node-ts-service" } });
+
+    const resolution = await resolveLanguageProfiles(manifest, directory);
+    expect(resolution.selected).toEqual(["python"]);
+    expect(resolution.conflicts).toEqual([
+      {
+        profile: "typescript",
+        reason: "node-ts-service expects the typescript profile, but the target detects python."
+      }
+    ]);
+  });
+
+  it("includes language-profile evidence in the non-mutating repository plan", async () => {
+    const directory = await fixtureDirectory();
+    await writeFile(path.join(directory, "main.go"), "package main\n");
+    const manifest = normalizeManifest({ project: { name: "go-tool", owner: "acme" }, archetype: { kind: "generic-empty" } });
+
+    await expect(planRepo(manifest, directory)).resolves.toMatchObject({
+      languageProfiles: { selected: ["go"], conflicts: [] }
+    });
+  });
+});

--- a/tests/manifest.test.ts
+++ b/tests/manifest.test.ts
@@ -41,6 +41,16 @@ describe("normalizeManifest", () => {
     expect(manifest.github.requiredStatusChecks).toEqual(["CI Gate"]);
   });
 
+  it("preserves unknown top-level settings for resolver reporting", () => {
+    const manifest = normalizeManifest({
+      project: { name: "future-compatible", owner: "acme" },
+      archetype: { kind: "generic-empty" },
+      futurePolicySetting: { enabled: true }
+    } as never);
+
+    expect(manifest.unknownSettings).toEqual(["futurePolicySetting"]);
+  });
+
   it("applies defaults and reviewer-derived governance", () => {
     const manifest = normalizeManifest({
       project: {

--- a/tests/manifest.test.ts
+++ b/tests/manifest.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { DEFAULT_ISSUE_LABELS, normalizeManifest } from "../src/manifest.js";
+import { DEFAULT_ISSUE_LABELS, normalizeManifest, stringifyManifest } from "../src/manifest.js";
 
 describe("normalizeManifest", () => {
   it("accepts version 2 manifests as compatibility input", () => {
@@ -49,6 +49,37 @@ describe("normalizeManifest", () => {
     } as never);
 
     expect(manifest.unknownSettings).toEqual(["futurePolicySetting"]);
+  });
+
+  it("requires an explicit canonical target before migrating legacy repository classes", () => {
+    expect(() =>
+      normalizeManifest({
+        project: { name: "legacy-tool", owner: "acme" },
+        repo: { class: "tooling" },
+        archetype: { kind: "generic-empty" }
+      } as never)
+    ).toThrow("repo.classMigration.target");
+
+    const manifest = normalizeManifest({
+      project: { name: "legacy-tool", owner: "acme" },
+      repo: { class: "tooling", classMigration: { target: "cli" } },
+      archetype: { kind: "generic-empty" }
+    } as never);
+
+    expect(manifest.repo).toMatchObject({ class: "cli", classMigration: { from: "tooling", target: "cli" } });
+    expect(stringifyManifest(manifest)).toContain("classMigration:");
+    expect(stringifyManifest(manifest)).toContain("from: tooling");
+  });
+
+  it("keeps product maturity distinct from release automation maturity", () => {
+    const manifest = normalizeManifest({
+      project: { name: "stable-library", owner: "acme", maturity: "stable" },
+      archetype: { kind: "generic-empty" },
+      release: { maturity: "regulated" }
+    } as never);
+
+    expect(manifest.project.maturity).toBe("stable");
+    expect(manifest.release.maturity).toBe("regulated");
   });
 
   it("applies defaults and reviewer-derived governance", () => {

--- a/tests/policy.test.ts
+++ b/tests/policy.test.ts
@@ -20,8 +20,8 @@ describe("resolveFlowPolicy", () => {
   it("loads a verified manifest-declared bundle without network access", async () => {
     const directory = await mkdtemp(path.join(os.tmpdir(), "bootstrap-policy-"));
     await writeFile(path.join(directory, "flow-policy.yaml"), JSON.stringify(bundle));
-    const configured = normalizeManifest({ project: { name: "example", owner: "acme" }, archetype: { kind: "generic-empty" }, policy: { flow: { ref: "refs/tags/v1.0.0", sha256: flowPolicyDigest(bundle), bundlePath: "flow-policy.yaml" } } } as never);
-    await expect(loadResolvedFlowPolicy(configured, directory)).resolves.toMatchObject({ policy: { version: "1.0.0" } });
+    const configured = normalizeManifest({ project: { name: "example", owner: "acme" }, archetype: { kind: "generic-empty" }, policy: { flow: { ref: "refs/tags/v1.0.0", sha256: flowPolicyDigest(bundle), bundlePath: "flow-policy.yaml" } }, futurePolicySetting: true } as never);
+    await expect(loadResolvedFlowPolicy(configured, directory)).resolves.toMatchObject({ policy: { version: "1.0.0" }, unknownManifestSettings: ["futurePolicySetting"] });
   });
 
   it("rejects absolute and traversal bundle paths before reading", async () => {

--- a/tests/policy.test.ts
+++ b/tests/policy.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizeManifest } from "../src/manifest.js";
+import { flowPolicyDigest, resolveFlowPolicy } from "../src/policy.js";
+
+const bundle = { standard: "public-repository-standard" as const, version: "1.0.0", publisher: { identitySource: "publisherKey" } };
+const manifest = normalizeManifest({ project: { name: "example", owner: "acme" }, archetype: { kind: "generic-empty" } });
+
+describe("resolveFlowPolicy", () => {
+  it("resolves a verified local bundle from an exact tag without changing the manifest", () => {
+    const resolved = resolveFlowPolicy(manifest, bundle, { ref: "refs/tags/v1.0.0", sha256: flowPolicyDigest(bundle) }, ["future.setting"]);
+    expect(resolved.manifest).toBe(manifest);
+    expect(resolved.policy.version).toBe("1.0.0");
+    expect(resolved.unknownManifestSettings).toEqual(["future.setting"]);
+  });
+
+  it("fails closed for floating refs, mismatched digests, and incompatible bundles", () => {
+    expect(() => resolveFlowPolicy(manifest, bundle, { ref: "refs/heads/main", sha256: flowPolicyDigest(bundle) })).toThrow("exact release tag");
+    expect(() => resolveFlowPolicy(manifest, bundle, { ref: "refs/tags/v1.0.0", sha256: "0".repeat(64) })).toThrow("digest does not match");
+    expect(() => resolveFlowPolicy(manifest, { standard: "other", version: "1.0.0" }, { ref: "0123456789012345678901234567890123456789", sha256: flowPolicyDigest({ standard: "other", version: "1.0.0" }) })).toThrow("compatible");
+  });
+});

--- a/tests/policy.test.ts
+++ b/tests/policy.test.ts
@@ -24,6 +24,14 @@ describe("resolveFlowPolicy", () => {
     await expect(loadResolvedFlowPolicy(configured, directory)).resolves.toMatchObject({ policy: { version: "1.0.0" } });
   });
 
+  it("rejects absolute and traversal bundle paths before reading", async () => {
+    const directory = await mkdtemp(path.join(os.tmpdir(), "bootstrap-policy-"));
+    for (const bundlePath of [path.join(directory, "flow-policy.yaml"), "../flow-policy.yaml"]) {
+      const configured = normalizeManifest({ project: { name: "example", owner: "acme" }, archetype: { kind: "generic-empty" }, policy: { flow: { ref: "refs/tags/v1.0.0", sha256: flowPolicyDigest(bundle), bundlePath } } } as never);
+      await expect(loadResolvedFlowPolicy(configured, directory)).rejects.toThrow("manifest directory");
+    }
+  });
+
   it("fails closed for floating refs, mismatched digests, and incompatible bundles", () => {
     expect(() => resolveFlowPolicy(manifest, bundle, { ref: "refs/heads/main", sha256: flowPolicyDigest(bundle) })).toThrow("exact release tag");
     expect(() => resolveFlowPolicy(manifest, bundle, { ref: "refs/tags/v1.0.0", sha256: "0".repeat(64) })).toThrow("digest does not match");

--- a/tests/policy.test.ts
+++ b/tests/policy.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from "vitest";
+import { mkdtemp, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 
 import { normalizeManifest } from "../src/manifest.js";
-import { flowPolicyDigest, resolveFlowPolicy } from "../src/policy.js";
+import { flowPolicyDigest, loadResolvedFlowPolicy, resolveFlowPolicy } from "../src/policy.js";
 
 const bundle = { standard: "public-repository-standard" as const, version: "1.0.0", publisher: { identitySource: "publisherKey" } };
 const manifest = normalizeManifest({ project: { name: "example", owner: "acme" }, archetype: { kind: "generic-empty" } });
@@ -12,6 +15,13 @@ describe("resolveFlowPolicy", () => {
     expect(resolved.manifest).toBe(manifest);
     expect(resolved.policy.version).toBe("1.0.0");
     expect(resolved.unknownManifestSettings).toEqual(["future.setting"]);
+  });
+
+  it("loads a verified manifest-declared bundle without network access", async () => {
+    const directory = await mkdtemp(path.join(os.tmpdir(), "bootstrap-policy-"));
+    await writeFile(path.join(directory, "flow-policy.yaml"), JSON.stringify(bundle));
+    const configured = normalizeManifest({ project: { name: "example", owner: "acme" }, archetype: { kind: "generic-empty" }, policy: { flow: { ref: "refs/tags/v1.0.0", sha256: flowPolicyDigest(bundle), bundlePath: "flow-policy.yaml" } } } as never);
+    await expect(loadResolvedFlowPolicy(configured, directory)).resolves.toMatchObject({ policy: { version: "1.0.0" } });
   });
 
   it("fails closed for floating refs, mismatched digests, and incompatible bundles", () => {

--- a/tests/policy.test.ts
+++ b/tests/policy.test.ts
@@ -4,7 +4,7 @@ import os from "node:os";
 import path from "node:path";
 
 import { normalizeManifest } from "../src/manifest.js";
-import { flowPolicyDigest, loadResolvedFlowPolicy, resolveFlowPolicy } from "../src/policy.js";
+import { flowPolicyDigest, loadResolvedFlowPolicy, requireImmutableProductionWorkflowRef, resolveFlowPolicy } from "../src/policy.js";
 
 const bundle = { standard: "public-repository-standard" as const, version: "1.0.0", publisher: { identitySource: "publisherKey" } };
 const manifest = normalizeManifest({ project: { name: "example", owner: "acme" }, archetype: { kind: "generic-empty" } });
@@ -36,5 +36,14 @@ describe("resolveFlowPolicy", () => {
     expect(() => resolveFlowPolicy(manifest, bundle, { ref: "refs/heads/main", sha256: flowPolicyDigest(bundle) })).toThrow("exact release tag");
     expect(() => resolveFlowPolicy(manifest, bundle, { ref: "refs/tags/v1.0.0", sha256: "0".repeat(64) })).toThrow("digest does not match");
     expect(() => resolveFlowPolicy(manifest, { standard: "other", version: "1.0.0" }, { ref: "0123456789012345678901234567890123456789", sha256: flowPolicyDigest({ standard: "other", version: "1.0.0" }) })).toThrow("compatible");
+  });
+});
+
+describe("requireImmutableProductionWorkflowRef", () => {
+  it("rejects branch and floating tag references while accepting exact tags and SHAs", () => {
+    expect(() => requireImmutableProductionWorkflowRef("refs/heads/main", "Release workflow")).toThrow("mutable");
+    expect(() => requireImmutableProductionWorkflowRef("refs/tags/v1", "Release workflow")).toThrow("mutable");
+    expect(() => requireImmutableProductionWorkflowRef("refs/tags/v1.2.3", "Release workflow")).not.toThrow();
+    expect(() => requireImmutableProductionWorkflowRef("a".repeat(40), "Release workflow")).not.toThrow();
   });
 });

--- a/tests/pr-governance.test.ts
+++ b/tests/pr-governance.test.ts
@@ -1,0 +1,91 @@
+import { spawn } from "node:child_process";
+import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+type Fixture = { files: unknown[]; commits: unknown[]; reviews: unknown[] };
+
+async function runGovernance(fixture: Fixture, overrides: Record<string, string> = {}) {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "bootstrap-pr-governance-"));
+  const paths = {
+    files: path.join(directory, "files.json"),
+    commits: path.join(directory, "commits.json"),
+    reviews: path.join(directory, "reviews.json")
+  };
+  await Promise.all([
+    writeFile(paths.files, JSON.stringify(fixture.files)),
+    writeFile(paths.commits, JSON.stringify(fixture.commits)),
+    writeFile(paths.reviews, JSON.stringify(fixture.reviews))
+  ]);
+  const result = await new Promise<{ code: number; output: string }>((resolve, reject) => {
+    const child = spawn("bash", [path.resolve("scripts/ci/check-pr-governance.sh")], {
+      cwd: directory,
+      env: {
+        ...process.env,
+        PR_TITLE: "feat: validate fixtures",
+        PR_BODY: "Material change: no",
+        PR_AUTHOR: "author",
+        PR_FILES_FILE: paths.files,
+        PR_COMMITS_FILE: paths.commits,
+        PR_REVIEWS_FILE: paths.reviews,
+        ...overrides
+      }
+    });
+    let output = "";
+    child.stdout.on("data", (chunk) => (output += chunk));
+    child.stderr.on("data", (chunk) => (output += chunk));
+    child.on("error", reject);
+    child.on("close", (code) => resolve({ code: code ?? 1, output }));
+  });
+  return { ...result, directory };
+}
+
+describe("check-pr-governance", () => {
+  it("reports synthetic title, DCO, and changed-line failures with its exclusions", async () => {
+    const result = await runGovernance({
+      files: [{ filename: "src/large.ts", additions: 801, deletions: 0 }, { filename: "docs/guide.md", additions: 50, deletions: 0 }],
+      commits: [{ sha: "1234567890abcdef", author: { login: "human", type: "User" }, commit: { message: "feat: no signoff" } }],
+      reviews: []
+    }, { PR_TITLE: "missing conventional title" });
+
+    expect(result.code).toBe(1);
+    expect(result.output).toContain("PRS-PR-TITLE-001");
+    expect(result.output).toContain("PRS-DCO-001");
+    expect(result.output).toContain("PRS-PR-SIZE-001");
+    expect(result.output).toContain("docs/guide.md");
+  });
+
+  it("accepts a material change with an accepted ADR and independent reviewer", async () => {
+    const result = await runGovernance({
+      files: [{ filename: "src/policy.ts", additions: 10, deletions: 2 }],
+      commits: [{ sha: "abcdef1234567890", author: { login: "human", type: "User" }, commit: { message: "feat: policy\n\nSigned-off-by: Human <human@example.com>" } }],
+      reviews: [{ state: "APPROVED", user: { login: "reviewer", type: "User" } }]
+    }, { PR_BODY: "Material change: yes\nADR: docs/decisions/ADR-0001-test.md" });
+    await mkdir(path.join(result.directory, "docs", "decisions"), { recursive: true });
+    await writeFile(path.join(result.directory, "docs", "decisions", "ADR-0001-test.md"), "# Decision\n\nStatus: Accepted\n");
+
+    const rerun = await new Promise<{ code: number; output: string }>((resolve, reject) => {
+      const child = spawn("bash", [path.resolve("scripts/ci/check-pr-governance.sh")], {
+        cwd: result.directory,
+        env: {
+          ...process.env,
+          PR_TITLE: "feat: apply policy",
+          PR_BODY: "Material change: yes\nADR: docs/decisions/ADR-0001-test.md",
+          PR_AUTHOR: "author",
+          PR_FILES_FILE: path.join(result.directory, "files.json"),
+          PR_COMMITS_FILE: path.join(result.directory, "commits.json"),
+          PR_REVIEWS_FILE: path.join(result.directory, "reviews.json")
+        }
+      });
+      let output = "";
+      child.stdout.on("data", (chunk) => (output += chunk));
+      child.stderr.on("data", (chunk) => (output += chunk));
+      child.on("error", reject);
+      child.on("close", (code) => resolve({ code: code ?? 1, output }));
+    });
+
+    expect(rerun.code).toBe(0);
+    expect(rerun.output).toContain("PASS PRS-PR-GOVERNANCE-001");
+  });
+});

--- a/tests/pr-governance.test.ts
+++ b/tests/pr-governance.test.ts
@@ -56,6 +56,37 @@ describe("check-pr-governance", () => {
     expect(result.output).toContain("docs/guide.md");
   });
 
+  it("exempts only pull requests opened before configured governance enforcement", async () => {
+    const fixture = {
+      files: [{ filename: "src/large.ts", additions: 801, deletions: 0 }],
+      commits: [{ sha: "1234567890abcdef", author: { login: "human", type: "User" }, commit: { message: "feat: no signoff" } }],
+      reviews: []
+    };
+    const legacy = await runGovernance(fixture, {
+      PR_TITLE: "missing conventional title",
+      PR_CREATED_AT: "2026-07-13T16:07:09Z",
+      PR_GOVERNANCE_ENFORCE_AFTER: "2026-07-13T23:00:00Z"
+    });
+    const current = await runGovernance(fixture, {
+      PR_TITLE: "missing conventional title",
+      PR_CREATED_AT: "2026-07-14T00:00:00Z",
+      PR_GOVERNANCE_ENFORCE_AFTER: "2026-07-13T23:00:00Z"
+    });
+    const malformed = await runGovernance(fixture, {
+      PR_TITLE: "missing conventional title",
+      PR_CREATED_AT: "not-a-timestamp",
+      PR_GOVERNANCE_ENFORCE_AFTER: "2026-07-13T23:00:00Z"
+    });
+
+    expect(legacy.code).toBe(0);
+    expect(legacy.output).toContain("PRS-PR-GOVERNANCE-LEGACY-001");
+    expect(current.code).toBe(1);
+    expect(current.output).toContain("PRS-PR-TITLE-001");
+    expect(current.output).toContain("PRS-DCO-001");
+    expect(malformed.code).toBe(1);
+    expect(malformed.output).toContain("PRS-ENFORCEMENT-INPUT-001");
+  });
+
   it("accepts a material change with an accepted ADR and independent reviewer", async () => {
     const result = await runGovernance({
       files: [{ filename: "src/policy.ts", additions: 10, deletions: 2 }],

--- a/tests/provenance.test.ts
+++ b/tests/provenance.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+
+import { REDACTED_CREDENTIAL, createPublicProvenance, validatePublicProvenance } from "../src/provenance.js";
+
+const input = {
+  runId: "12345.1",
+  subject: { repository: "acme/example", commitSha: "a".repeat(40), ref: "refs/heads/main" },
+  execution: { workflow: "Provenance", runUrl: "https://github.com/acme/example/actions/runs/12345", createdAt: "2026-07-14T00:00:00Z" },
+  reviewers: [{ login: "reviewer", state: "approved" as const }]
+};
+const githubPat = ["github", "pat"].join("_") + "_abcdefghijklmnopqrstuvwxyz123456";
+const awsAccessKey = ["AK", "IA"].join("") + "ABCDEFGHIJKLMNOP";
+
+describe("public provenance", () => {
+  it("redacts adversarial credential literals before creating a public manifest", () => {
+    const provenance = createPublicProvenance({
+      ...input,
+      metadata: {
+        trace: githubPat,
+        cloud: awsAccessKey,
+        configured: "token=should-not-escape"
+      }
+    });
+
+    expect(provenance.metadata).toEqual({ trace: REDACTED_CREDENTIAL, cloud: REDACTED_CREDENTIAL, configured: REDACTED_CREDENTIAL });
+    expect(provenance.redaction.replacements).toBe(3);
+    expect(JSON.stringify(provenance)).not.toContain("should-not-escape");
+  });
+
+  it("rejects a hand-authored public manifest containing a credential-like literal", () => {
+    expect(() => validatePublicProvenance({
+      ...input,
+      schemaVersion: 1,
+      metadata: { leaked: "password=not-for-publication" },
+      redaction: { policyVersion: 1, replacements: 0 }
+    })).toThrow("credential-like literal");
+  });
+
+  it("preserves public reviewer lineage and safe metadata", () => {
+    const provenance = createPublicProvenance({ ...input, metadata: { policy: "public-repository-standard-v1" } });
+
+    expect(provenance.reviewers).toEqual(input.reviewers);
+    expect(provenance.metadata.policy).toBe("public-repository-standard-v1");
+  });
+});

--- a/tests/render.test.ts
+++ b/tests/render.test.ts
@@ -42,9 +42,9 @@ describe("renderManagedFiles", () => {
       const prWorkflow = files.find((file) => file.path === ".github/workflows/pr-fast-ci.yml");
       const extendedValidationWorkflow = files.find((file) => file.path === ".github/workflows/extended-validation.yml");
       expect(prWorkflow?.contents).toContain("name: CI Gate");
-      expect(prWorkflow?.contents).toContain("dorny/paths-filter@v4");
+      expect(prWorkflow?.contents).toContain("dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4");
       expect(prWorkflow?.contents).not.toContain("dorny/paths-filter@v3");
-      expect(extendedValidationWorkflow?.contents).toContain("dorny/paths-filter@v4");
+      expect(extendedValidationWorkflow?.contents).toContain("dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4");
       expect(extendedValidationWorkflow?.contents).not.toContain("dorny/paths-filter@v3");
       expect(prWorkflow?.contents).toContain("types: [opened, edited, synchronize, reopened, ready_for_review]");
       expect(prWorkflow?.contents).toContain("['self-hosted', 'linux'");
@@ -59,6 +59,8 @@ describe("renderManagedFiles", () => {
       expect(prWorkflow?.contents).toContain("pull-requests: read");
       expect(prWorkflow?.contents).toContain("PR_COMMITS_URL:");
       expect(files.find((file) => file.path === "scripts/ci/check-pr-governance.sh")?.contents).toContain("PRS-DCO-001");
+      expect(prWorkflow?.contents).toContain("validate-action-pins:");
+      expect(files.find((file) => file.path === "scripts/ci/check-action-pins.sh")?.contents).toContain("SA-ACTION-PIN-001");
 
       const prTemplate = files.find((file) => file.path === ".github/PULL_REQUEST_TEMPLATE.md");
       const dependabot = files.find((file) => file.path === ".github/dependabot.yml");
@@ -272,10 +274,10 @@ describe("renderManagedFiles", () => {
     expect(renderedManifest?.contents).toContain("version: 2");
     expect(renderedManifest?.contents).toContain("capabilities:");
     expect(renderedManifest?.contents).not.toContain("\nrelease:\n");
-    expect(prWorkflow?.contents).toContain("dorny/paths-filter@v4");
+    expect(prWorkflow?.contents).toContain("dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4");
     expect(prWorkflow?.contents).not.toContain("dorny/paths-filter@v3");
     expect(claudeWorkflow?.contents).toContain("name: Claude Code");
-    expect(claudeWorkflow?.contents).toContain("anthropics/claude-code-action@v1");
+    expect(claudeWorkflow?.contents).toContain("anthropics/claude-code-action@e90deca47693f9457b72f2b53c17d7c445a87342 # v1");
   });
 
   it("documents required PR template enforcement in generated agent instructions", () => {

--- a/tests/render.test.ts
+++ b/tests/render.test.ts
@@ -47,6 +47,8 @@ describe("renderManagedFiles", () => {
       expect(extendedValidationWorkflow?.contents).toContain("dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4");
       expect(extendedValidationWorkflow?.contents).not.toContain("dorny/paths-filter@v3");
       expect(prWorkflow?.contents).toContain("types: [opened, edited, synchronize, reopened, ready_for_review]");
+      expect(prWorkflow?.contents).toContain("pull_request_review:");
+      expect(prWorkflow?.contents).toContain("PR_GOVERNANCE_ENFORCE_AFTER:");
       expect(prWorkflow?.contents).toContain("['self-hosted', 'linux'");
       expect(prWorkflow?.contents).toContain("validate-pr-description:");
       expect(prWorkflow?.contents).toContain("PR body must close/link an issue");

--- a/tests/render.test.ts
+++ b/tests/render.test.ts
@@ -368,6 +368,7 @@ describe("renderManagedFiles", () => {
     expect(versionScript?.contents).toContain('version="${tag#"${prefix}"}"');
     expect(buildScript?.contents).toContain('artifact_dir="dist/release"');
     expect(buildScript?.contents).toContain("SHA256SUMS");
+    expect(buildScript?.contents).toContain("! -name release-evidence.json ! -name validation-evidence.json");
     expect(buildScript?.contents).toContain("No release artifacts were produced");
     expect(publishScript?.contents).toContain("Create exact release tags such as v1.2.3");
     expect(changelogConfig?.contents).toContain("changelog:");

--- a/tests/render.test.ts
+++ b/tests/render.test.ts
@@ -55,6 +55,10 @@ describe("renderManagedFiles", () => {
       expect(prWorkflow?.contents).toContain("https://github\\.com/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+/issues/");
       expect(prWorkflow?.contents).toContain("auto_merge_evidence=");
       expect(prWorkflow?.contents).toContain('<<<"$auto_merge_evidence"');
+      expect(prWorkflow?.contents).toContain("validate-pr-governance:");
+      expect(prWorkflow?.contents).toContain("pull-requests: read");
+      expect(prWorkflow?.contents).toContain("PR_COMMITS_URL:");
+      expect(files.find((file) => file.path === "scripts/ci/check-pr-governance.sh")?.contents).toContain("PRS-DCO-001");
 
       const prTemplate = files.find((file) => file.path === ".github/PULL_REQUEST_TEMPLATE.md");
       const dependabot = files.find((file) => file.path === ".github/dependabot.yml");
@@ -64,6 +68,7 @@ describe("renderManagedFiles", () => {
       expect(prTemplate?.contents).toContain("## Bootstrap Governance");
       expect(prTemplate?.contents).toContain("fallback merge-readiness policy applies");
       expect(prTemplate?.contents).toContain("## Notes");
+      expect(prTemplate?.contents).toContain("Material change: no");
       expect(dependabot?.contents).toContain('package-ecosystem: "npm"');
       expect(dependabot?.contents).toContain('package-ecosystem: "github-actions"');
       expect(dependabot?.contents).toContain("npm-minor-patch");

--- a/tests/reusable-workflows.test.ts
+++ b/tests/reusable-workflows.test.ts
@@ -97,7 +97,7 @@ describe("reusable workflows", () => {
     expect((preflight.on as any).workflow_call.inputs.version.required).toBe(true);
     expect((validation.on as any).workflow_call.inputs.evidence_artifact_name.default).toBe("release-evidence");
     expect((validation.on as any).workflow_call.inputs.release_package_artifact_name).toBeUndefined();
-    expect((validation.jobs as any).validate.steps.some((step: any) => step.uses === "actions/upload-artifact@v4" && step.with?.name === "${{ inputs.evidence_artifact_name }}-validation")).toBe(true);
+    expect((validation.jobs as any).validate.steps.some((step: any) => step.uses === "actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02" && step.with?.name === "${{ inputs.evidence_artifact_name }}-validation")).toBe(true);
     expect((preflight.jobs as any).preflight).toBeTruthy();
     expect(validation.name).toBe("Reusable Full Release Validation");
     expect((validation.jobs as any).validate).toBeTruthy();

--- a/tests/smoke.test.ts
+++ b/tests/smoke.test.ts
@@ -8,6 +8,7 @@ import { afterEach, describe, expect, it } from "vitest";
 
 import { normalizeManifest } from "../src/manifest.js";
 import { applyRepo, planRepo } from "../src/render.js";
+import { OWNERSHIP_SIDECAR_PATH } from "../src/state.js";
 
 const tempDirs: string[] = [];
 const execFileAsync = promisify(execFile);
@@ -51,6 +52,26 @@ describe("repo smoke", () => {
 
     const secondPlan = await planRepo(manifest, targetDir);
     expect(secondPlan.changes.every((change) => change.type === "unchanged")).toBe(true);
+    const ownership = JSON.parse(await readFile(path.join(targetDir, OWNERSHIP_SIDECAR_PATH), "utf8"));
+    expect(ownership).toMatchObject({
+      schemaVersion: 1,
+      owner: "bootstrap",
+      regenerationCommand: "bootstrap apply repo --manifest ./project.bootstrap.yaml"
+    });
+    expect(ownership.managedFiles["AGENTS.md"]).toMatchObject({ source: "bootstrap" });
+  });
+
+  it("blocks direct edits to previously managed files instead of overwriting them", async () => {
+    const targetDir = await makeTempDir();
+    const manifest = normalizeManifest({
+      project: { name: "owned-edit", owner: "acme" },
+      archetype: { kind: "generic-empty" }
+    });
+
+    await applyRepo(manifest, targetDir);
+    await writeFile(path.join(targetDir, "AGENTS.md"), "product-owned direct edit\n", "utf8");
+
+    await expect(planRepo(manifest, targetDir)).rejects.toThrow("AGENTS.md was directly modified");
   });
 
   it("can adopt an existing repo by managing only selected bootstrap files", async () => {

--- a/tests/upgrades.test.ts
+++ b/tests/upgrades.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+
+import { classifyPolicyUpgrade, planFleetPolicyUpgrades } from "../src/upgrades.js";
+
+describe("fleet policy upgrades", () => {
+  it("classifies patch, minor, major, and invalid policy versions", () => {
+    expect(classifyPolicyUpgrade("1.2.3", "1.2.4")).toBe("patch");
+    expect(classifyPolicyUpgrade("1.2.3", "1.3.0")).toBe("minor");
+    expect(classifyPolicyUpgrade("1.2.3", "2.0.0")).toBe("major");
+    expect(classifyPolicyUpgrade("1.2.3", "1.2.2")).toBe("invalid");
+  });
+
+  it("requires a first-class pilot and stops later candidates after a failed pilot", () => {
+    const plan = planFleetPolicyUpgrades([
+      { repo: "acme/service-a", repoClass: "service", currentPolicy: "1.0.0", targetPolicy: "1.0.1", pilotOutcome: "failed" },
+      { repo: "acme/service-b", repoClass: "service", currentPolicy: "1.0.0", targetPolicy: "1.0.1" },
+      { repo: "acme/cli-a", repoClass: "cli", currentPolicy: "1.0.0", targetPolicy: "1.0.1", pilotOutcome: "passed" },
+      { repo: "acme/cli-b", repoClass: "cli", currentPolicy: "1.0.0", targetPolicy: "1.0.1" }
+    ]);
+
+    expect(plan.find((entry) => entry.repo === "acme/cli-a")).toMatchObject({ role: "pilot", status: "eligible" });
+    expect(plan.find((entry) => entry.repo === "acme/cli-b")).toMatchObject({ role: "batch", status: "eligible" });
+    expect(plan.find((entry) => entry.repo === "acme/service-a")).toMatchObject({ role: "pilot", status: "review-required" });
+    expect(plan.find((entry) => entry.repo === "acme/service-b")).toMatchObject({ role: "batch", status: "blocked" });
+  });
+
+  it("routes minor, major, and exception upgrades to human review", () => {
+    const plan = planFleetPolicyUpgrades([
+      { repo: "acme/minor", repoClass: "cli", currentPolicy: "1.0.0", targetPolicy: "1.1.0", pilotOutcome: "passed" },
+      { repo: "acme/major", repoClass: "service", currentPolicy: "1.0.0", targetPolicy: "2.0.0", pilotOutcome: "passed" },
+      { repo: "acme/excepted", repoClass: "library", currentPolicy: "1.0.0", targetPolicy: "1.0.1", exceptionId: "EX-1", pilotOutcome: "passed" }
+    ]);
+
+    expect(plan.map((entry) => entry.status)).toEqual(["review-required", "review-required", "review-required"]);
+  });
+});


### PR DESCRIPTION
## Summary

- Add a deterministic, offline Flow policy resolver for verified local bundles.
- Require an exact `refs/tags/vX.Y.Z` ref or immutable 40-character SHA and validate the canonical SHA-256 digest.
- Reject incompatible policy contracts without changing rendered files.

## Governing Issue

Refs #54.

## Validation

- [x] `npm test -- --run tests/policy.test.ts`
- [x] `npm run typecheck`

## Bootstrap Governance

- [x] The resolver has no network access and does not accept runtime credentials.
- [x] This slice only resolves and verifies policy input; rendering remains unchanged.
- [x] No real secrets, runtime auth, or machine-local env files are committed.

Material change: yes
ADR: docs/decisions/ADR-0001-public-repository-standard-v1.md

## Merge Automation

- [x] Auto-merge is enabled with squash merge; independent review and required checks remain enforced.

## Notes

- Flow's immutable `v1.0.0` tag contains the compatible policy schema; this resolver consumes a verified local bundle so callers can operate offline.
