### PR TITLE
feat: load Flow policy bundles from manifests

### DIFF
--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -187,6 +187,14 @@ const capabilitiesSchema = z.object({
     .optional()
 });
 
+const policySchema = z.object({
+  flow: z.object({
+    ref: z.string().min(1),
+    sha256: z.string().regex(/^[0-9a-fA-F]{64}$/),
+    bundlePath: z.string().min(1)
+  })
+});
+
 const dependabotEcosystemSchema = z.object({
   packageEcosystem: z.enum(["npm", "github-actions", "docker"]),
   directory: z.string().min(1).optional(),
@@ -372,6 +380,7 @@ const manifestSchema = z.object({
     })
     .optional(),
   capabilities: capabilitiesSchema.optional(),
+  policy: policySchema.optional(),
   environments: z
     .object({
       dev: environmentSchema.optional(),
@@ -813,6 +822,9 @@ export function normalizeManifest(raw: z.input<typeof manifestSchema>): Bootstra
       sharedSkills: parsed.agents?.sharedSkills ?? []
     },
     ...(capabilities ? { capabilities } : {}),
+    ...(parsed.policy
+      ? { policy: { flow: { ...parsed.policy.flow, sha256: parsed.policy.flow.sha256.toLowerCase() } } }
+      : {}),
     environments: {
       dev: applyEnvironmentDefaults(defaultEnvironment(environments.dev), reviewers, defaultBranch, "dev"),
       stage: applyEnvironmentDefaults(

--- a/src/policy.ts
+++ b/src/policy.ts
@@ -1,4 +1,7 @@
 import { createHash } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import YAML from "yaml";
 
 import type { BootstrapManifest } from "./types.js";
 
@@ -65,4 +68,14 @@ export function resolveFlowPolicy(
   }
 
   return { manifest, policy, source: { ...source, sha256: source.sha256.toLowerCase() }, unknownManifestSettings: [...unknownManifestSettings].sort() };
+}
+
+export async function loadResolvedFlowPolicy(manifest: BootstrapManifest, manifestDir: string): Promise<ResolvedPolicyContract> {
+  if (!manifest.policy?.flow) {
+    throw new Error("Manifest does not declare a Flow policy bundle.");
+  }
+  const source = manifest.policy.flow;
+  const bundlePath = path.resolve(manifestDir, source.bundlePath);
+  const bundle = YAML.parse(await readFile(bundlePath, "utf8"));
+  return resolveFlowPolicy(manifest, bundle, source);
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -258,6 +258,13 @@ export interface BootstrapManifest {
       enabled: boolean;
     };
   };
+  policy?: {
+    flow: {
+      ref: string;
+      sha256: string;
+      bundlePath: string;
+    };
+  };
   environments: {
     dev: EnvironmentConfig;
     stage: EnvironmentConfig;

--- a/tests/policy.test.ts
+++ b/tests/policy.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from "vitest";
+import { mkdtemp, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 
 import { normalizeManifest } from "../src/manifest.js";
-import { flowPolicyDigest, resolveFlowPolicy } from "../src/policy.js";
+import { flowPolicyDigest, loadResolvedFlowPolicy, resolveFlowPolicy } from "../src/policy.js";
 
 const bundle = { standard: "public-repository-standard" as const, version: "1.0.0", publisher: { identitySource: "publisherKey" } };
 const manifest = normalizeManifest({ project: { name: "example", owner: "acme" }, archetype: { kind: "generic-empty" } });
@@ -12,6 +15,13 @@ describe("resolveFlowPolicy", () => {
     expect(resolved.manifest).toBe(manifest);
     expect(resolved.policy.version).toBe("1.0.0");
     expect(resolved.unknownManifestSettings).toEqual(["future.setting"]);
+  });
+
+  it("loads a verified manifest-declared bundle without network access", async () => {
+    const directory = await mkdtemp(path.join(os.tmpdir(), "bootstrap-policy-"));
+    await writeFile(path.join(directory, "flow-policy.yaml"), JSON.stringify(bundle));
+    const configured = normalizeManifest({ project: { name: "example", owner: "acme" }, archetype: { kind: "generic-empty" }, policy: { flow: { ref: "refs/tags/v1.0.0", sha256: flowPolicyDigest(bundle), bundlePath: "flow-policy.yaml" } } } as never);
+    await expect(loadResolvedFlowPolicy(configured, directory)).resolves.toMatchObject({ policy: { version: "1.0.0" } });
   });
 
   it("fails closed for floating refs, mismatched digests, and incompatible bundles", () => {


### PR DESCRIPTION
## Summary

- Add manifest configuration for a pinned, locally stored Flow policy bundle.
- Load that bundle offline and pass it through the verified resolver from #67.

## Governing Issue

Refs #54. Stacked on #67.

## Validation

- [x] `npm test -- --run tests/policy.test.ts`
- [x] `npm run typecheck`

## Bootstrap Governance

- [x] Policy loading is local-file only; no runtime credentials or network access are introduced.
- [x] No rendering changes are included.
- [x] No real secrets, runtime auth, or machine-local env files are committed.

## Merge Automation

- [x] Auto-merge is enabled with squash merge; independent review and required checks remain enforced.

## Notes

- The PR base is the verified resolver in #67 and will rebase to `main` after it lands.
