### PR TITLE
feat: report unknown manifest policy settings

### DIFF
--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -388,7 +388,11 @@ const manifestSchema = z.object({
       prod: environmentSchema.optional()
     })
     .optional()
-});
+}).passthrough();
+
+const KNOWN_MANIFEST_SETTINGS = new Set([
+  "version", "project", "repo", "archetype", "github", "ci", "release", "agents", "capabilities", "policy", "environments"
+]);
 
 function slugify(value: string): string {
   return value
@@ -672,6 +676,7 @@ function normalizeCustomScripts(
 
 export function normalizeManifest(raw: z.input<typeof manifestSchema>): BootstrapManifest {
   const parsed = manifestSchema.parse(raw);
+  const unknownSettings = Object.keys(parsed).filter((key) => !KNOWN_MANIFEST_SETTINGS.has(key)).sort();
   const version = parsed.version ?? 1;
   const reviewers = (parsed.github?.reviewers ?? []).map((reviewer) => reviewer.replace(/^@/, ""));
   const defaultBranch = parsed.project.defaultBranch ?? "main";
@@ -698,6 +703,7 @@ export function normalizeManifest(raw: z.input<typeof manifestSchema>): Bootstra
 
   return {
     version,
+    unknownSettings,
     project: {
       name: parsed.project.name,
       ...(parsed.project.displayName ? { displayName: parsed.project.displayName } : {}),
@@ -903,11 +909,12 @@ export function createSampleManifest(overrides?: ManifestOverrides): string {
 }
 
 function serializableManifest(manifest: BootstrapManifest): BootstrapManifest | Record<string, unknown> {
+  const { unknownSettings: _unknownSettings, ...serializable } = manifest;
   if (manifest.version !== 2 || !manifest.capabilities?.release) {
-    return manifest;
+    return serializable;
   }
 
-  const { release: _release, ...withoutRelease } = manifest;
+  const { release: _release, ...withoutRelease } = serializable;
   return withoutRelease;
 }
 

--- a/src/policy.ts
+++ b/src/policy.ts
@@ -84,5 +84,5 @@ export async function loadResolvedFlowPolicy(manifest: BootstrapManifest, manife
     throw new Error("Flow policy bundle path must stay within the manifest directory.");
   }
   const bundle = YAML.parse(await readFile(bundlePath, "utf8"));
-  return resolveFlowPolicy(manifest, bundle, source);
+  return resolveFlowPolicy(manifest, bundle, source, manifest.unknownSettings);
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -140,6 +140,7 @@ export interface OrganizationConfig {
 
 export interface BootstrapManifest {
   version: 1 | 2;
+  unknownSettings: string[];
   project: {
     name: string;
     displayName?: string;

--- a/tests/manifest.test.ts
+++ b/tests/manifest.test.ts
@@ -41,6 +41,16 @@ describe("normalizeManifest", () => {
     expect(manifest.github.requiredStatusChecks).toEqual(["CI Gate"]);
   });
 
+  it("preserves unknown top-level settings for resolver reporting", () => {
+    const manifest = normalizeManifest({
+      project: { name: "future-compatible", owner: "acme" },
+      archetype: { kind: "generic-empty" },
+      futurePolicySetting: { enabled: true }
+    } as never);
+
+    expect(manifest.unknownSettings).toEqual(["futurePolicySetting"]);
+  });
+
   it("applies defaults and reviewer-derived governance", () => {
     const manifest = normalizeManifest({
       project: {

--- a/tests/policy.test.ts
+++ b/tests/policy.test.ts
@@ -20,8 +20,8 @@ describe("resolveFlowPolicy", () => {
   it("loads a verified manifest-declared bundle without network access", async () => {
     const directory = await mkdtemp(path.join(os.tmpdir(), "bootstrap-policy-"));
     await writeFile(path.join(directory, "flow-policy.yaml"), JSON.stringify(bundle));
-    const configured = normalizeManifest({ project: { name: "example", owner: "acme" }, archetype: { kind: "generic-empty" }, policy: { flow: { ref: "refs/tags/v1.0.0", sha256: flowPolicyDigest(bundle), bundlePath: "flow-policy.yaml" } } } as never);
-    await expect(loadResolvedFlowPolicy(configured, directory)).resolves.toMatchObject({ policy: { version: "1.0.0" } });
+    const configured = normalizeManifest({ project: { name: "example", owner: "acme" }, archetype: { kind: "generic-empty" }, policy: { flow: { ref: "refs/tags/v1.0.0", sha256: flowPolicyDigest(bundle), bundlePath: "flow-policy.yaml" } }, futurePolicySetting: true } as never);
+    await expect(loadResolvedFlowPolicy(configured, directory)).resolves.toMatchObject({ policy: { version: "1.0.0" }, unknownManifestSettings: ["futurePolicySetting"] });
   });
 
   it("rejects absolute and traversal bundle paths before reading", async () => {


### PR DESCRIPTION
## Summary

- Preserve unknown top-level manifest settings for Flow policy resolution instead of silently discarding them.
- Keep internal unknown-setting reports out of rendered manifests.

## Governing Issue

Refs #54. Stacked on #67.

## Validation

- [x] `npm test -- --run tests/manifest.test.ts tests/policy.test.ts`
- [x] `npm run typecheck`

## Bootstrap Governance

- [x] No rendering behavior changes beyond excluding internal resolver metadata.
- [x] No real secrets, runtime auth, or machine-local env files are committed.

## Merge Automation

- Auto-merge is unavailable while this PR targets the unmerged #67 branch; it will be armed after #67 lands and the PR is rebased to `main`.

## Notes

- This closes the forward-compatibility reporting gap in the #54 resolver contract.
