### PR TITLE
feat: require explicit repository class migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ Confirm branch protection points at the `CI Gate` status and require approval fr
 - Default branch: `main`
 - Archetype: `generic-empty`
 
+For the Flow v1 repository-class transition, see [the explicit class-migration guide](docs/bootstrap/repository-class-migration.md).
+
 
 ## Release Standard
 

--- a/docs/bootstrap/repository-class-migration.md
+++ b/docs/bootstrap/repository-class-migration.md
@@ -1,0 +1,25 @@
+# Repository class migration
+
+Flow's Public Repository Standard v1 has seven canonical repository classes:
+`cli`, `library`, `service`, `infrastructure`, `github-action`,
+`specification`, and `documentation`.
+
+Existing Bootstrap manifests may still use `application` or `tooling`. These
+legacy names never map silently. Declare the chosen canonical target alongside
+the legacy value, then regenerate the manifest to retain the migration record:
+
+```yaml
+repo:
+  class: tooling
+  classMigration:
+    target: cli
+```
+
+An `application` may map to `service`, `library`, or another canonical class
+only after the repository owner selects the real product boundary. A `tooling`
+repository commonly maps to `cli`, but an infrastructure control plane may map
+to `infrastructure` instead.
+
+`project.maturity` describes the product lifecycle (`experimental` through
+`archived`). It is intentionally independent from `release.maturity`, which
+selects the release-automation profile.

--- a/project.bootstrap.yaml
+++ b/project.bootstrap.yaml
@@ -9,6 +9,8 @@ project:
   defaultBranch: main
 repo:
   class: tooling
+  classMigration:
+    target: cli
   managedPaths: []
   docs:
     readme: true

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -11,7 +11,8 @@ import type {
   DefaultRepositoryPermission,
   EnvironmentConfig,
   IssueLabelConfig,
-  OrganizationConfig
+  OrganizationConfig,
+  RepoClass
 } from "./types.js";
 
 export const DEFAULT_ISSUE_LABELS: IssueLabelConfig[] = [
@@ -271,13 +272,21 @@ const manifestSchema = z.object({
     name: z.string().min(1),
     displayName: z.string().min(1).optional(),
     description: z.string().optional(),
+    maturity: z.enum(["experimental", "alpha", "beta", "stable", "maintenance", "archived"]).optional(),
     visibility: z.enum(["private", "public", "internal"]).optional(),
     owner: z.string().min(1),
     defaultBranch: z.string().min(1).optional()
   }),
   repo: z
     .object({
-      class: z.enum(["application", "library", "service", "tooling", "documentation"]).optional(),
+      class: z
+        .enum(["application", "tooling", "cli", "library", "service", "infrastructure", "github-action", "specification", "documentation"])
+        .optional(),
+      classMigration: z
+        .object({
+          target: z.enum(["cli", "library", "service", "infrastructure", "github-action", "specification", "documentation"])
+        })
+        .optional(),
       managedPaths: z.array(z.string().min(1)).optional(),
       docs: repoDocsSchema.optional(),
       templates: repoTemplatesSchema.optional(),
@@ -529,8 +538,23 @@ function mergeAdditionalWorkflows(
 }
 
 function normalizeRepo(repo: z.input<typeof manifestSchema>["repo"]): BootstrapManifest["repo"] {
+  const legacyClass = repo?.class === "application" || repo?.class === "tooling" ? repo.class : undefined;
+  const canonicalClass = repo?.class && !legacyClass ? (repo.class as RepoClass) : undefined;
+  if (legacyClass && !repo?.classMigration) {
+    throw new Error(
+      `Legacy repository class \"${legacyClass}\" requires repo.classMigration.target; choose its canonical Flow repository class explicitly.`
+    );
+  }
+
   return {
-    ...(repo?.class ? { class: repo.class } : {}),
+    ...(legacyClass
+      ? {
+          class: repo?.classMigration?.target as RepoClass,
+          classMigration: { from: legacyClass, target: repo?.classMigration?.target as RepoClass }
+        }
+      : canonicalClass
+        ? { class: canonicalClass }
+        : {}),
     managedPaths: repo?.managedPaths ?? [],
     ...(repo?.docs
       ? {
@@ -710,6 +734,7 @@ export function normalizeManifest(raw: z.input<typeof manifestSchema>): Bootstra
       description:
         parsed.project.description ??
         "Manifest-first control plane for repo scaffolding, GitHub governance, and portable agent profiles.",
+      ...(parsed.project.maturity ? { maturity: parsed.project.maturity } : {}),
       visibility: parsed.project.visibility ?? "private",
       owner: parsed.project.owner,
       defaultBranch

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,7 +3,16 @@ export type ArchetypeKind = "nextjs-web" | "node-ts-service" | "python-service" 
 export type PackageManager = "npm" | "pnpm" | "yarn" | "python";
 export type RunnerPolicy = "hybrid-safe" | "self-hosted-first" | "github-hosted-first";
 export type DefaultRepositoryPermission = "read" | "write" | "admin" | "none";
-export type RepoClass = "application" | "library" | "service" | "tooling" | "documentation";
+export type RepoClass =
+  | "cli"
+  | "library"
+  | "service"
+  | "infrastructure"
+  | "github-action"
+  | "specification"
+  | "documentation";
+export type LegacyRepoClass = "application" | "tooling";
+export type ProductMaturity = "experimental" | "alpha" | "beta" | "stable" | "maintenance" | "archived";
 export type CiPolicy = "standard" | "standard-public" | "experimental" | "strict";
 
 export interface CodeownerRule {
@@ -26,6 +35,10 @@ export interface EnvironmentConfig {
 
 export interface RepoConfig {
   class?: RepoClass;
+  classMigration?: {
+    from: LegacyRepoClass;
+    target: RepoClass;
+  };
   managedPaths: string[];
   docs?: {
     readme: boolean;
@@ -145,6 +158,7 @@ export interface BootstrapManifest {
     name: string;
     displayName?: string;
     description: string;
+    maturity?: ProductMaturity;
     visibility: ProjectVisibility;
     owner: string;
     defaultBranch: string;

--- a/tests/manifest.test.ts
+++ b/tests/manifest.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { DEFAULT_ISSUE_LABELS, normalizeManifest } from "../src/manifest.js";
+import { DEFAULT_ISSUE_LABELS, normalizeManifest, stringifyManifest } from "../src/manifest.js";
 
 describe("normalizeManifest", () => {
   it("accepts version 2 manifests as compatibility input", () => {
@@ -49,6 +49,37 @@ describe("normalizeManifest", () => {
     } as never);
 
     expect(manifest.unknownSettings).toEqual(["futurePolicySetting"]);
+  });
+
+  it("requires an explicit canonical target before migrating legacy repository classes", () => {
+    expect(() =>
+      normalizeManifest({
+        project: { name: "legacy-tool", owner: "acme" },
+        repo: { class: "tooling" },
+        archetype: { kind: "generic-empty" }
+      } as never)
+    ).toThrow("repo.classMigration.target");
+
+    const manifest = normalizeManifest({
+      project: { name: "legacy-tool", owner: "acme" },
+      repo: { class: "tooling", classMigration: { target: "cli" } },
+      archetype: { kind: "generic-empty" }
+    } as never);
+
+    expect(manifest.repo).toMatchObject({ class: "cli", classMigration: { from: "tooling", target: "cli" } });
+    expect(stringifyManifest(manifest)).toContain("classMigration:");
+    expect(stringifyManifest(manifest)).toContain("from: tooling");
+  });
+
+  it("keeps product maturity distinct from release automation maturity", () => {
+    const manifest = normalizeManifest({
+      project: { name: "stable-library", owner: "acme", maturity: "stable" },
+      archetype: { kind: "generic-empty" },
+      release: { maturity: "regulated" }
+    } as never);
+
+    expect(manifest.project.maturity).toBe("stable");
+    expect(manifest.release.maturity).toBe("regulated");
   });
 
   it("applies defaults and reviewer-derived governance", () => {


### PR DESCRIPTION
## Summary

- Require an explicit canonical Flow class target when migrating legacy `application` or `tooling` manifests.
- Preserve the selected migration in normalized output and document the operator decision.
- Add a typed `project.maturity` distinct from the existing release-automation profile.

## Governing Issue

Refs #56. Stacked on #69, which is itself stacked on #67 for issue #54's resolver contract.

## Validation

- [x] `npm test -- --run tests/manifest.test.ts tests/policy.test.ts` (20 passing tests)
- [x] `npm run typecheck`
- [x] `git diff --check`
- [ ] `npm test` is blocked by an existing `test/release-workflow-guards.test.ts` expectation mismatch on the unchanged `scripts/ci/run-release-build.sh` generated helper.

## Bootstrap Governance

- [x] Changes are scoped to the class/maturity resolution portion of #56.
- [x] The migration guide documents the operator-visible manifest contract.
- [x] No real secrets, runtime auth, or machine-local env files are committed.

## Merge Automation

- Auto-merge is unavailable while this PR targets the unmerged #69 branch; it will be armed after the stacked resolver PRs land and this branch is rebased to `main`.

## Notes

- This is the first reviewable #56 slice; language-profile detection and conformance validation remain follow-up work under the governing issue.
