### PR TITLE
feat: detect repository language profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Confirm branch protection points at the `CI Gate` status and require approval fr
 - Archetype: `generic-empty`
 
 For the Flow v1 repository-class transition, see [the explicit class-migration guide](docs/bootstrap/repository-class-migration.md).
+Use [language-profile detection](docs/bootstrap/language-profiles.md) to review target toolchain evidence before applying a plan.
 
 
 ## Release Standard

--- a/docs/bootstrap/language-profiles.md
+++ b/docs/bootstrap/language-profiles.md
@@ -1,0 +1,12 @@
+# Language profiles
+
+`bootstrap plan` detects repository markers before proposing changes. It selects
+only the relevant profiles from TypeScript, Python, Rust, Go, Swift, Terraform,
+Shell, SQL/SQLite, and documentation. Generated output is ignored during
+detection, including `node_modules`, `dist`, `build`, `coverage`, and `.git`.
+
+The plan reports a warning when the manifest archetype conflicts with detected
+language evidence. For example, a `node-ts-service` manifest targeting a
+Python-only repository reports the missing TypeScript profile while preserving
+the detected Python profile. This is report-first: it does not rewrite the
+manifest or execute project code.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -30,6 +30,12 @@ function formatRepoChanges(changes: Awaited<ReturnType<typeof planRepo>>["change
   ].join("\n");
 }
 
+function formatLanguageProfiles(profiles: Awaited<ReturnType<typeof planRepo>>["languageProfiles"]): string {
+  const selected = profiles.selected.length === 0 ? "none" : profiles.selected.join(", ");
+  const conflicts = profiles.conflicts.map((conflict) => `- [warn] ${conflict.reason}`);
+  return ["**Language profiles**", `- Selected: ${selected}`, ...conflicts].join("\n");
+}
+
 function formatGitHubActions(actions: Awaited<ReturnType<typeof planGitHub>>): string {
   return [
     "**GitHub**",
@@ -128,6 +134,7 @@ async function main(): Promise<void> {
             {
               targetDir,
               repo: repoPlan.changes,
+              languageProfiles: repoPlan.languageProfiles,
               github: githubPlan,
               home: homePlan.actions
             },
@@ -139,7 +146,7 @@ async function main(): Promise<void> {
       }
 
       process.stdout.write(
-        `${formatRepoChanges(repoPlan.changes)}\n\n${formatGitHubActions(githubPlan)}\n\n${formatHomeActions(
+        `${formatRepoChanges(repoPlan.changes)}\n\n${formatLanguageProfiles(repoPlan.languageProfiles)}\n\n${formatGitHubActions(githubPlan)}\n\n${formatHomeActions(
           homePlan.actions
         )}\n`
       );

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ export * from "./fleet.js";
 export * from "./github/client.js";
 export * from "./github/provision.js";
 export * from "./home/sync.js";
+export * from "./language-profiles.js";
 export * from "./manifest.js";
 export * from "./policy.js";
 export * from "./render.js";

--- a/src/language-profiles.ts
+++ b/src/language-profiles.ts
@@ -1,0 +1,107 @@
+import { readdir } from "node:fs/promises";
+import type { Dirent } from "node:fs";
+import path from "node:path";
+
+import type { ArchetypeKind, BootstrapManifest } from "./types.js";
+
+export const LANGUAGE_PROFILES = [
+  "typescript",
+  "python",
+  "rust",
+  "go",
+  "swift",
+  "terraform",
+  "shell",
+  "sql-sqlite",
+  "documentation"
+] as const;
+
+export type LanguageProfile = (typeof LANGUAGE_PROFILES)[number];
+
+export interface LanguageProfileConflict {
+  profile: LanguageProfile;
+  reason: string;
+}
+
+export interface LanguageProfileResolution {
+  detected: LanguageProfile[];
+  selected: LanguageProfile[];
+  conflicts: LanguageProfileConflict[];
+}
+
+const ignoredDirectories = new Set([".git", ".next", ".turbo", "build", "coverage", "dist", "node_modules", "target", "vendor"]);
+
+function profileForPath(relativePath: string): LanguageProfile[] {
+  const basename = path.posix.basename(relativePath).toLowerCase();
+  const extension = path.posix.extname(relativePath).toLowerCase();
+  const profiles = new Set<LanguageProfile>();
+
+  if (basename === "package.swift" || extension === ".swift") profiles.add("swift");
+  if (basename === "cargo.toml" || extension === ".rs") profiles.add("rust");
+  if (basename === "go.mod" || extension === ".go") profiles.add("go");
+  if (basename === "pyproject.toml" || basename === "setup.py" || extension === ".py") profiles.add("python");
+  if (basename === "tsconfig.json" || basename === "tsconfig.base.json" || extension === ".ts" || extension === ".tsx") profiles.add("typescript");
+  if (extension === ".tf") profiles.add("terraform");
+  if (extension === ".sh") profiles.add("shell");
+  if (extension === ".sql" || extension === ".sqlite" || extension === ".db") profiles.add("sql-sqlite");
+  if (basename.startsWith("readme") || relativePath.startsWith("docs/")) profiles.add("documentation");
+
+  return [...profiles];
+}
+
+async function collectProfiles(root: string, relativeDir = "", profiles = new Set<LanguageProfile>()): Promise<void> {
+  let entries: Dirent<string>[];
+  try {
+    entries = await readdir(path.join(root, relativeDir), { encoding: "utf8", withFileTypes: true });
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return;
+    throw error;
+  }
+
+  for (const entry of entries) {
+    const relativePath = relativeDir ? `${relativeDir}/${entry.name}` : entry.name;
+    if (entry.isDirectory()) {
+      if (!ignoredDirectories.has(entry.name)) {
+        if (relativePath === "docs") profiles.add("documentation");
+        await collectProfiles(root, relativePath, profiles);
+      }
+      continue;
+    }
+    if (entry.isFile()) {
+      for (const profile of profileForPath(relativePath)) profiles.add(profile);
+    }
+  }
+}
+
+function expectedProfiles(kind: ArchetypeKind): LanguageProfile[] {
+  switch (kind) {
+    case "nextjs-web":
+    case "node-ts-service":
+      return ["typescript"];
+    case "python-service":
+      return ["python"];
+    case "generic-empty":
+      return [];
+  }
+}
+
+export async function resolveLanguageProfiles(
+  manifest: BootstrapManifest,
+  targetDir: string
+): Promise<LanguageProfileResolution> {
+  const profileSet = new Set<LanguageProfile>();
+  await collectProfiles(targetDir, "", profileSet);
+  const detected = LANGUAGE_PROFILES.filter((profile) => profileSet.has(profile));
+  const expected = expectedProfiles(manifest.archetype.kind);
+  const conflicts =
+    detected.length === 0
+      ? []
+      : expected
+          .filter((profile) => !profileSet.has(profile))
+          .map((profile) => ({
+            profile,
+            reason: `${manifest.archetype.kind} expects the ${profile} profile, but the target detects ${detected.join(", ")}.`
+          }));
+
+  return { detected, selected: detected, conflicts };
+}

--- a/src/render.ts
+++ b/src/render.ts
@@ -2,12 +2,14 @@ import path from "node:path";
 
 import { renderManagedFiles } from "./archetypes.js";
 import { readTextIfExists, removeFileIfExists, writeTextFile } from "./lib/fs.js";
+import { resolveLanguageProfiles, type LanguageProfileResolution } from "./language-profiles.js";
 import { createRepoState, loadRepoState, writeRepoState } from "./state.js";
 import type { BootstrapManifest, PlannedFileChange, RenderedFile } from "./types.js";
 
 export interface RepoPlan {
   changes: PlannedFileChange[];
   files: RenderedFile[];
+  languageProfiles: LanguageProfileResolution;
 }
 
 function globToRegExp(pattern: string): RegExp {
@@ -123,6 +125,7 @@ function validateManagedPathDependencies(files: RenderedFile[]): void {
 
 export async function planRepo(manifest: BootstrapManifest, targetDir: string): Promise<RepoPlan> {
   const files = selectManagedFiles(manifest, renderManagedFiles(manifest));
+  const languageProfiles = await resolveLanguageProfiles(manifest, targetDir);
   const existingState = await loadRepoState(targetDir);
   const changes: PlannedFileChange[] = [];
 
@@ -157,7 +160,8 @@ export async function planRepo(manifest: BootstrapManifest, targetDir: string): 
 
   return {
     changes: changes.sort((left, right) => left.path.localeCompare(right.path)),
-    files
+    files,
+    languageProfiles
   };
 }
 

--- a/tests/language-profiles.test.ts
+++ b/tests/language-profiles.test.ts
@@ -1,0 +1,58 @@
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+import { normalizeManifest } from "../src/manifest.js";
+import { resolveLanguageProfiles } from "../src/language-profiles.js";
+import { planRepo } from "../src/render.js";
+
+async function fixtureDirectory(): Promise<string> {
+  return mkdtemp(path.join(os.tmpdir(), "bootstrap-language-profiles-"));
+}
+
+describe("resolveLanguageProfiles", () => {
+  it("selects only profiles supported by repository markers and ignores build output", async () => {
+    const directory = await fixtureDirectory();
+    await mkdir(path.join(directory, "docs"));
+    await mkdir(path.join(directory, "node_modules", "ignored"), { recursive: true });
+    await Promise.all([
+      writeFile(path.join(directory, "src.ts"), "export {};\n"),
+      writeFile(path.join(directory, "main.py"), "print('hello')\n"),
+      writeFile(path.join(directory, "docs", "guide.md"), "# Guide\n"),
+      writeFile(path.join(directory, "node_modules", "ignored", "package.swift"), "// ignored\n")
+    ]);
+
+    const manifest = normalizeManifest({ project: { name: "polyglot", owner: "acme" }, archetype: { kind: "generic-empty" } });
+    await expect(resolveLanguageProfiles(manifest, directory)).resolves.toEqual({
+      detected: ["typescript", "python", "documentation"],
+      selected: ["typescript", "python", "documentation"],
+      conflicts: []
+    });
+  });
+
+  it("reports an archetype mismatch without suppressing detected profiles", async () => {
+    const directory = await fixtureDirectory();
+    await writeFile(path.join(directory, "pyproject.toml"), "[project]\nname = 'service'\n");
+    const manifest = normalizeManifest({ project: { name: "mismatch", owner: "acme" }, archetype: { kind: "node-ts-service" } });
+
+    const resolution = await resolveLanguageProfiles(manifest, directory);
+    expect(resolution.selected).toEqual(["python"]);
+    expect(resolution.conflicts).toEqual([
+      {
+        profile: "typescript",
+        reason: "node-ts-service expects the typescript profile, but the target detects python."
+      }
+    ]);
+  });
+
+  it("includes language-profile evidence in the non-mutating repository plan", async () => {
+    const directory = await fixtureDirectory();
+    await writeFile(path.join(directory, "main.go"), "package main\n");
+    const manifest = normalizeManifest({ project: { name: "go-tool", owner: "acme" }, archetype: { kind: "generic-empty" } });
+
+    await expect(planRepo(manifest, directory)).resolves.toMatchObject({
+      languageProfiles: { selected: ["go"], conflicts: [] }
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Detect relevant repository language profiles without executing project code.
- Surface selected profiles and archetype mismatches in the non-mutating `bootstrap plan` output, including JSON.
- Document the supported profile markers and generated-output exclusions.

## Governing Issue

Refs #56. Stacked on #67 while the resolved policy contract awaits independent re-review.

## Validation

- [x] `npm test -- --run tests/language-profiles.test.ts tests/manifest.test.ts tests/policy.test.ts` (23 passing tests)
- [x] `npm run typecheck`
- [x] `npm run dev -- plan --manifest project.bootstrap.yaml --target . --json`
- [x] `git diff --check`
- [ ] `npm test` still has the unchanged `test/release-workflow-guards.test.ts` assertion mismatch for `scripts/ci/run-release-build.sh`; it will be repaired separately under #64.

## Bootstrap Governance

- [x] Changes are scoped to language-profile detection and conflict reporting for #56.
- [x] The new operator-facing behavior is documented.
- [x] No real secrets, runtime auth, or machine-local env files are committed.

## Merge Automation

- Auto-merge is unavailable while this PR targets the unmerged #67 branch; it will be armed after #67 lands and the PR is rebased to `main`.

## Notes

- Detection is report-first: it produces evidence and warnings but does not rewrite manifests or execute repository code.
