### PR TITLE
fix: exclude release evidence from artifact checksums

### DIFF
--- a/scripts/ci/run-release-build.sh
+++ b/scripts/ci/run-release-build.sh
@@ -7,7 +7,7 @@ mkdir -p "${artifact_dir}"
 # Add repo-specific build steps above this line to populate ${artifact_dir}
 # with downloadable release assets before checksums are generated.
 
-mapfile -t artifacts < <(find "${artifact_dir}" -maxdepth 1 -type f ! -name SHA256SUMS | sort)
+mapfile -t artifacts < <(find "${artifact_dir}" -maxdepth 1 -type f ! -name SHA256SUMS ! -name release-evidence.json ! -name validation-evidence.json | sort)
 if [[ ${#artifacts[@]} -eq 0 ]]; then
   echo "No release artifacts were produced in ${artifact_dir}."
   echo "This repo ships no downloadable assets; add build steps to scripts/ci/run-release-build.sh when it does."

--- a/src/archetypes.ts
+++ b/src/archetypes.ts
@@ -1075,7 +1075,7 @@ function releaseBuildScript(manifest: BootstrapManifest): string {
     # Add repo-specific build steps above this line to populate \${artifact_dir}
     # with downloadable release assets before checksums are generated.
 
-    mapfile -t artifacts < <(find "\${artifact_dir}" -maxdepth 1 -type f ! -name SHA256SUMS | sort)
+    mapfile -t artifacts < <(find "\${artifact_dir}" -maxdepth 1 -type f ! -name SHA256SUMS ! -name release-evidence.json ! -name validation-evidence.json | sort)
     if [[ \${#artifacts[@]} -eq 0 ]]; then
       echo "No release artifacts were produced in \${artifact_dir}."
       echo "This repo ships no downloadable assets; add build steps to scripts/ci/run-release-build.sh when it does."

--- a/tests/render.test.ts
+++ b/tests/render.test.ts
@@ -368,6 +368,7 @@ describe("renderManagedFiles", () => {
     expect(versionScript?.contents).toContain('version="${tag#"${prefix}"}"');
     expect(buildScript?.contents).toContain('artifact_dir="dist/release"');
     expect(buildScript?.contents).toContain("SHA256SUMS");
+    expect(buildScript?.contents).toContain("! -name release-evidence.json ! -name validation-evidence.json");
     expect(buildScript?.contents).toContain("No release artifacts were produced");
     expect(publishScript?.contents).toContain("Create exact release tags such as v1.2.3");
     expect(changelogConfig?.contents).toContain("changelog:");


### PR DESCRIPTION
## Summary

- Keep release and validation evidence out of generated release asset checksums.
- Restore the invariant in Bootstrap’s own generated build script.
- Add generator-level coverage so the checksum exclusion cannot drift again.

## Governing Issue

Refs #64. Stacked on #67 while the resolved policy contract awaits independent re-review.

## Validation

- [x] `npm test` (72 passing tests)
- [x] `npm run build`
- [x] `git diff --check`

## Bootstrap Governance

- [x] Changes are scoped to the release-provenance checksum guard in #64.
- [x] Generated source and Bootstrap’s generated output remain synchronized.
- [x] No real secrets, runtime auth, or machine-local env files are committed.

## Merge Automation

- Auto-merge is unavailable while this PR targets the unmerged #67 branch; it will be armed after #67 lands and the PR is rebased to `main`.

## Notes

- The repair removes a full-suite failure and preserves evidence isolation from release assets.
