### PR TITLE
feat: validate typed policy exceptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Confirm branch protection points at the `CI Gate` status and require approval fr
 
 For the Flow v1 repository-class transition, see [the explicit class-migration guide](docs/bootstrap/repository-class-migration.md).
 Use [language-profile detection](docs/bootstrap/language-profiles.md) to review target toolchain evidence before applying a plan.
+Use [typed policy exceptions](docs/bootstrap/policy-exceptions.md) to make temporary deviations visible and enforce their expiry.
 
 
 ## Release Standard

--- a/docs/bootstrap/policy-exceptions.md
+++ b/docs/bootstrap/policy-exceptions.md
@@ -1,0 +1,22 @@
+# Policy exceptions
+
+Declare every policy exception in `project.bootstrap.yaml` with an ID, policy,
+scope, rationale, approver, and governing issue. Temporary exceptions require
+an ISO `expiresAt` date; expired exceptions block validation. Exceptions expiring
+within 14 days produce a `PRS-NOTIFY-001` notification intent and do not stop
+work solely because they were reported.
+
+Permanent exceptions require explicit approval and an `adr` reference. The
+`bootstrap doctor` output reports deterministic `PRS-EXCEPTION-001` results so
+automation can consume the same outcome as operators.
+
+```yaml
+exceptions:
+  - id: temporary-runner-deviation
+    policy: runner-policy
+    scope: .github/workflows/release.yml
+    rationale: Platform migration in progress
+    approvedBy: release-maintainers
+    issue: https://github.com/OMT-Global/bootstrap/issues/55
+    expiresAt: 2026-09-01
+```

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -1,5 +1,6 @@
 import os from "node:os";
 
+import { validatePolicyExceptions } from "./exceptions.js";
 import { execRunner, type CommandRunner } from "./lib/process.js";
 import { resolveRunsOn } from "./runners.js";
 import type { BootstrapManifest } from "./types.js";
@@ -43,6 +44,22 @@ export async function runDoctor(
     name: "gh CLI",
     status: ghAvailable ? "ok" : "fail",
     detail: ghAvailable ? "gh is available." : "gh is missing from PATH."
+  });
+
+  const exceptionReport = validatePolicyExceptions(manifest.exceptions);
+  const exceptionStatus = exceptionReport.blocking
+    ? "fail"
+    : exceptionReport.results.some((result) => result.status === "warn")
+      ? "warn"
+      : "ok";
+  const exceptionDetails = exceptionReport.results.filter((result) => result.status !== "pass");
+  checks.push({
+    name: "Policy exceptions",
+    status: exceptionStatus,
+    detail:
+      exceptionDetails.length === 0
+        ? "No blocking or expiring policy exceptions."
+        : exceptionDetails.map((result) => `${result.ruleId}: ${result.detail}`).join(" ")
   });
 
   if (ghAvailable) {

--- a/src/exceptions.ts
+++ b/src/exceptions.ts
@@ -1,0 +1,129 @@
+import type { PolicyException } from "./types.js";
+
+export type ExceptionResultStatus = "pass" | "warn" | "block";
+
+export interface ExceptionValidationResult {
+  ruleId: "PRS-EXCEPTION-001";
+  exceptionId: string;
+  status: ExceptionResultStatus;
+  detail: string;
+  remediation?: string;
+}
+
+export interface ExceptionNotificationIntent {
+  ruleId: "PRS-NOTIFY-001";
+  exceptionId: string;
+  event: "exception-expiring";
+  destinations: ["governing-issue-or-pull-request", "configured-notification-mechanism"];
+  continueAfterNotification: true;
+}
+
+export interface ExceptionValidationReport {
+  results: ExceptionValidationResult[];
+  notifications: ExceptionNotificationIntent[];
+  blocking: boolean;
+}
+
+const EXPIRY_WARNING_DAYS = 14;
+
+function utcMidnight(value: Date): number {
+  return Date.UTC(value.getUTCFullYear(), value.getUTCMonth(), value.getUTCDate());
+}
+
+function parseDate(value: string): Date | undefined {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) return undefined;
+  const parsed = new Date(`${value}T00:00:00.000Z`);
+  return Number.isNaN(parsed.valueOf()) ? undefined : parsed;
+}
+
+export function validatePolicyExceptions(
+  exceptions: PolicyException[],
+  now = new Date()
+): ExceptionValidationReport {
+  const results: ExceptionValidationResult[] = [];
+  const notifications: ExceptionNotificationIntent[] = [];
+
+  for (const exception of [...exceptions].sort((left, right) => left.id.localeCompare(right.id))) {
+    if (exception.permanent) {
+      if (!exception.adr) {
+        results.push({
+          ruleId: "PRS-EXCEPTION-001",
+          exceptionId: exception.id,
+          status: "block",
+          detail: `Permanent exception ${exception.id} has no ADR.`,
+          remediation: "Add the accepted ADR that documents the permanent exception."
+        });
+      } else {
+        results.push({
+          ruleId: "PRS-EXCEPTION-001",
+          exceptionId: exception.id,
+          status: "pass",
+          detail: `Permanent exception ${exception.id} has explicit approval and ADR ${exception.adr}.`
+        });
+      }
+      continue;
+    }
+
+    if (!exception.expiresAt) {
+      results.push({
+        ruleId: "PRS-EXCEPTION-001",
+        exceptionId: exception.id,
+        status: "block",
+        detail: `Temporary exception ${exception.id} has no expiry date.`,
+        remediation: "Set exceptions[].expiresAt to an ISO date or mark the exception permanent with an ADR."
+      });
+      continue;
+    }
+
+    const expiry = parseDate(exception.expiresAt);
+    if (!expiry) {
+      results.push({
+        ruleId: "PRS-EXCEPTION-001",
+        exceptionId: exception.id,
+        status: "block",
+        detail: `Exception ${exception.id} has an invalid expiry date ${exception.expiresAt}.`,
+        remediation: "Use an ISO date in YYYY-MM-DD format."
+      });
+      continue;
+    }
+
+    const remainingDays = Math.floor((utcMidnight(expiry) - utcMidnight(now)) / 86_400_000);
+    if (remainingDays < 0) {
+      results.push({
+        ruleId: "PRS-EXCEPTION-001",
+        exceptionId: exception.id,
+        status: "block",
+        detail: `Temporary exception ${exception.id} expired on ${exception.expiresAt}.`,
+        remediation: "Renew the exception with approval or remove the deviation."
+      });
+      continue;
+    }
+
+    if (remainingDays <= EXPIRY_WARNING_DAYS) {
+      results.push({
+        ruleId: "PRS-EXCEPTION-001",
+        exceptionId: exception.id,
+        status: "warn",
+        detail: `Temporary exception ${exception.id} expires in ${remainingDays} day(s) on ${exception.expiresAt}.`,
+        remediation: "Renew with approval before the exception expires or remove the deviation."
+      });
+      notifications.push({
+        ruleId: "PRS-NOTIFY-001",
+        exceptionId: exception.id,
+        event: "exception-expiring",
+        destinations: ["governing-issue-or-pull-request", "configured-notification-mechanism"],
+        continueAfterNotification: true
+      });
+      continue;
+    }
+
+    results.push({
+      ruleId: "PRS-EXCEPTION-001",
+      exceptionId: exception.id,
+      status: "pass",
+      detail: `Temporary exception ${exception.id} is valid through ${exception.expiresAt}.`
+    });
+  }
+
+  return { results, notifications, blocking: results.some((result) => result.status === "block") };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./doctor.js";
+export * from "./exceptions.js";
 export * from "./fleet.js";
 export * from "./github/client.js";
 export * from "./github/provision.js";

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -196,6 +196,18 @@ const policySchema = z.object({
   })
 });
 
+const exceptionSchema = z.object({
+  id: z.string().min(1),
+  policy: z.string().min(1),
+  scope: z.string().min(1),
+  rationale: z.string().min(1),
+  approvedBy: z.string().min(1),
+  issue: z.string().min(1),
+  permanent: z.boolean().optional(),
+  expiresAt: z.string().min(1).optional(),
+  adr: z.string().min(1).optional()
+});
+
 const dependabotEcosystemSchema = z.object({
   packageEcosystem: z.enum(["npm", "github-actions", "docker"]),
   directory: z.string().min(1).optional(),
@@ -390,6 +402,7 @@ const manifestSchema = z.object({
     .optional(),
   capabilities: capabilitiesSchema.optional(),
   policy: policySchema.optional(),
+  exceptions: z.array(exceptionSchema).optional(),
   environments: z
     .object({
       dev: environmentSchema.optional(),
@@ -400,7 +413,7 @@ const manifestSchema = z.object({
 }).passthrough();
 
 const KNOWN_MANIFEST_SETTINGS = new Set([
-  "version", "project", "repo", "archetype", "github", "ci", "release", "agents", "capabilities", "policy", "environments"
+  "version", "project", "repo", "archetype", "github", "ci", "release", "agents", "capabilities", "policy", "exceptions", "environments"
 ]);
 
 function slugify(value: string): string {
@@ -856,6 +869,17 @@ export function normalizeManifest(raw: z.input<typeof manifestSchema>): Bootstra
     ...(parsed.policy
       ? { policy: { flow: { ...parsed.policy.flow, sha256: parsed.policy.flow.sha256.toLowerCase() } } }
       : {}),
+    exceptions: (parsed.exceptions ?? []).map((exception) => ({
+      id: exception.id,
+      policy: exception.policy,
+      scope: exception.scope,
+      rationale: exception.rationale,
+      approvedBy: exception.approvedBy,
+      issue: exception.issue,
+      permanent: exception.permanent ?? false,
+      ...(exception.expiresAt ? { expiresAt: exception.expiresAt } : {}),
+      ...(exception.adr ? { adr: exception.adr } : {})
+    })),
     environments: {
       dev: applyEnvironmentDefaults(defaultEnvironment(environments.dev), reviewers, defaultBranch, "dev"),
       stage: applyEnvironmentDefaults(

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,6 +15,18 @@ export type LegacyRepoClass = "application" | "tooling";
 export type ProductMaturity = "experimental" | "alpha" | "beta" | "stable" | "maintenance" | "archived";
 export type CiPolicy = "standard" | "standard-public" | "experimental" | "strict";
 
+export interface PolicyException {
+  id: string;
+  policy: string;
+  scope: string;
+  rationale: string;
+  approvedBy: string;
+  issue: string;
+  permanent: boolean;
+  expiresAt?: string;
+  adr?: string;
+}
+
 export interface CodeownerRule {
   pattern: string;
   owners: string[];
@@ -280,6 +292,7 @@ export interface BootstrapManifest {
       bundlePath: string;
     };
   };
+  exceptions: PolicyException[];
   environments: {
     dev: EnvironmentConfig;
     stage: EnvironmentConfig;

--- a/tests/doctor.test.ts
+++ b/tests/doctor.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+
+import { runDoctor } from "../src/doctor.js";
+import { normalizeManifest } from "../src/manifest.js";
+import type { CommandRunner } from "../src/lib/process.js";
+
+const unavailableRunner: CommandRunner = async () => ({ stdout: "", stderr: "not installed", exitCode: 1 });
+
+describe("runDoctor", () => {
+  it("surfaces blocking exception validation with its stable rule ID", async () => {
+    const manifest = normalizeManifest({
+      project: { name: "doctor-exceptions", owner: "acme" },
+      archetype: { kind: "generic-empty" },
+      exceptions: [{ id: "temporary", policy: "release", scope: "repo", rationale: "migration", approvedBy: "alice", issue: "#55" }]
+    } as never);
+
+    const checks = await runDoctor(manifest, { runner: unavailableRunner, homeDir: "/tmp/home" });
+
+    expect(checks).toContainEqual(
+      expect.objectContaining({ name: "Policy exceptions", status: "fail", detail: expect.stringContaining("PRS-EXCEPTION-001") })
+    );
+  });
+});

--- a/tests/exceptions.test.ts
+++ b/tests/exceptions.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizeManifest } from "../src/manifest.js";
+import { validatePolicyExceptions } from "../src/exceptions.js";
+
+const now = new Date("2026-07-13T12:00:00.000Z");
+
+describe("validatePolicyExceptions", () => {
+  it("blocks expired or incomplete temporary exceptions with stable rule IDs", () => {
+    const report = validatePolicyExceptions(
+      [
+        { id: "missing-expiry", policy: "release", scope: "repo", rationale: "migration", approvedBy: "alice", issue: "#55", permanent: false },
+        { id: "expired", policy: "security", scope: "workflow", rationale: "migration", approvedBy: "alice", issue: "#55", permanent: false, expiresAt: "2026-07-12" }
+      ],
+      now
+    );
+
+    expect(report.blocking).toBe(true);
+    expect(report.results).toMatchObject([
+      { ruleId: "PRS-EXCEPTION-001", exceptionId: "expired", status: "block" },
+      { ruleId: "PRS-EXCEPTION-001", exceptionId: "missing-expiry", status: "block" }
+    ]);
+  });
+
+  it("requires an ADR for permanent exceptions and emits expiring notification intents without blocking", () => {
+    const report = validatePolicyExceptions(
+      [
+        { id: "permanent", policy: "release", scope: "repo", rationale: "required", approvedBy: "alice", issue: "#55", permanent: true },
+        { id: "expiring", policy: "ci", scope: "workflow", rationale: "migration", approvedBy: "alice", issue: "#55", permanent: false, expiresAt: "2026-07-20" }
+      ],
+      now
+    );
+
+    expect(report.blocking).toBe(true);
+    expect(report.notifications).toEqual([
+      {
+        ruleId: "PRS-NOTIFY-001",
+        exceptionId: "expiring",
+        event: "exception-expiring",
+        destinations: ["governing-issue-or-pull-request", "configured-notification-mechanism"],
+        continueAfterNotification: true
+      }
+    ]);
+  });
+
+  it("normalizes declared exceptions for deterministic validation", () => {
+    const manifest = normalizeManifest({
+      project: { name: "exceptions", owner: "acme" },
+      archetype: { kind: "generic-empty" },
+      exceptions: [{ id: "approved", policy: "security", scope: "repo", rationale: "temporary migration", approvedBy: "alice", issue: "#55", expiresAt: "2026-08-01" }]
+    } as never);
+
+    expect(manifest.exceptions).toEqual([
+      { id: "approved", policy: "security", scope: "repo", rationale: "temporary migration", approvedBy: "alice", issue: "#55", permanent: false, expiresAt: "2026-08-01" }
+    ]);
+    expect(validatePolicyExceptions(manifest.exceptions, now).blocking).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- Add typed manifest exceptions with required policy, scope, rationale, approval, and governing-issue fields.
- Validate temporary expiry, permanent ADR requirements, and deterministic `PRS-EXCEPTION-001` results.
- Emit `PRS-NOTIFY-001` expiring-exception notification intents and surface the outcome through `bootstrap doctor`.

## Governing Issue

Refs #55. Stacked on #67 while the resolved policy contract awaits independent re-review.

## Validation

- [x] `npm test` (76 passing tests)
- [x] `npm run build`
- [x] `git diff --check`

## Bootstrap Governance

- [x] Changes are scoped to typed exception validation and report-first notification intents for #55.
- [x] The manifest contract and operator behavior are documented.
- [x] No real secrets, runtime auth, or machine-local env files are committed.

## Merge Automation

- Auto-merge is unavailable while this PR targets the unmerged #67 branch; it will be armed after #67 lands and the PR is rebased to `main`.

## Notes

- Remote notification delivery remains a follow-up; this slice provides deterministic, safe notification intents without requiring external credentials.
