### PR TITLE
feat: record managed-file ownership

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ Confirm branch protection points at the `CI Gate` status and require approval fr
 - `.github/PULL_REQUEST_TEMPLATE.md` is the canonical pull request format for summaries, governing issue links, validation notes, and merge-readiness checks.
 - Existing bootstrapped repos can retrofit these surfaces with `bootstrap apply repo --manifest ./project.bootstrap.yaml`; repos with restricted `repo.managedPaths` should include both paths before applying.
 
+Bootstrap records generated-file ownership in [the managed-file sidecar](docs/bootstrap/managed-file-ownership.md) and blocks direct edits before overwriting them.
+
 ## Project Identity
 
 - Product name: `Bootstrap`

--- a/docs/bootstrap/managed-file-ownership.md
+++ b/docs/bootstrap/managed-file-ownership.md
@@ -1,0 +1,11 @@
+# Managed-file ownership
+
+Every repository render writes `.bootstrap/managed-files.json`. The sidecar
+identifies Bootstrap as the owner, records the template version and regeneration
+command, and stores a SHA-256 digest for every managed artifact.
+
+`bootstrap plan` and `bootstrap apply repo` reject a direct edit to a file that
+Bootstrap previously managed. Restore the generated version, remove the file
+from `repo.managedPaths`, or perform an explicit migration before changing the
+managed set. This keeps product-owned files outside Bootstrap's authority and
+prevents silent overwrites.

--- a/src/render.ts
+++ b/src/render.ts
@@ -1,9 +1,10 @@
 import path from "node:path";
 
 import { renderManagedFiles } from "./archetypes.js";
+import { sha256 } from "./lib/hash.js";
 import { readTextIfExists, removeFileIfExists, writeTextFile } from "./lib/fs.js";
 import { resolveLanguageProfiles, type LanguageProfileResolution } from "./language-profiles.js";
-import { createRepoState, loadRepoState, writeRepoState } from "./state.js";
+import { createOwnershipSidecar, createRepoState, loadRepoState, writeRepoState } from "./state.js";
 import type { BootstrapManifest, PlannedFileChange, RenderedFile } from "./types.js";
 
 export interface RepoPlan {
@@ -38,6 +39,10 @@ function globToRegExp(pattern: string): RegExp {
 
 function matchesManagedPath(filePath: string, pattern: string): boolean {
   return globToRegExp(pattern).test(filePath.replace(/\\/g, "/"));
+}
+
+function isManagedContentHash(value: string | undefined): value is string {
+  return value !== undefined && /^[a-f0-9]{64}$/i.test(value);
 }
 
 const managedPathDependencies = [
@@ -124,13 +129,25 @@ function validateManagedPathDependencies(files: RenderedFile[]): void {
 }
 
 export async function planRepo(manifest: BootstrapManifest, targetDir: string): Promise<RepoPlan> {
-  const files = selectManagedFiles(manifest, renderManagedFiles(manifest));
+  const renderedFiles = selectManagedFiles(manifest, renderManagedFiles(manifest));
+  const files = [...renderedFiles, createOwnershipSidecar(renderedFiles)];
   const languageProfiles = await resolveLanguageProfiles(manifest, targetDir);
   const existingState = await loadRepoState(targetDir);
   const changes: PlannedFileChange[] = [];
 
   for (const file of files) {
     const existingContents = await readTextIfExists(path.join(targetDir, file.path));
+    const managedHash = existingState?.managedFiles[file.path];
+    if (
+      existingContents !== undefined &&
+      isManagedContentHash(managedHash) &&
+      sha256(existingContents) !== managedHash &&
+      existingContents !== file.contents
+    ) {
+      throw new Error(
+        `Managed file ${file.path} was directly modified. Restore it, remove it from managed paths, or use an explicit migration before applying Bootstrap changes.`
+      );
+    }
     const type =
       existingContents === undefined
         ? "create"
@@ -149,6 +166,16 @@ export async function planRepo(manifest: BootstrapManifest, targetDir: string): 
     const plannedPaths = new Set(files.map((file) => file.path));
     for (const stalePath of Object.keys(existingState.managedFiles)) {
       if (!plannedPaths.has(stalePath)) {
+        const existingContents = await readTextIfExists(path.join(targetDir, stalePath));
+        if (
+          existingContents !== undefined &&
+          isManagedContentHash(existingState.managedFiles[stalePath]) &&
+          sha256(existingContents) !== existingState.managedFiles[stalePath]
+        ) {
+          throw new Error(
+            `Managed file ${stalePath} was directly modified. Restore it or use an explicit migration before Bootstrap removes it.`
+          );
+        }
         changes.push({
           path: stalePath,
           type: "delete",

--- a/src/state.ts
+++ b/src/state.ts
@@ -11,6 +11,7 @@ export const HOME_STATE_PATH = ".bootstrap/home-state.json";
 export const LEGACY_HOME_STATE_PATH = ".new-project-bootstrap/home-state.json";
 export const REPO_STATE_FILENAME = "bootstrap-state.json";
 export const LEGACY_REPO_STATE_FILENAME = "new-project-bootstrap-state.json";
+export const OWNERSHIP_SIDECAR_PATH = ".bootstrap/managed-files.json";
 
 async function resolveGitDir(targetDir: string): Promise<string | undefined> {
   const gitPath = path.join(targetDir, ".git");
@@ -73,5 +74,30 @@ export function createRepoState(manifest: BootstrapManifest, files: RenderedFile
     manifestHash: sha256(JSON.stringify(manifest)),
     templateVersion: TEMPLATE_VERSION,
     managedFiles: Object.fromEntries(files.map((file) => [file.path, sha256(file.contents)]))
+  };
+}
+
+export function createOwnershipSidecar(files: RenderedFile[]): RenderedFile {
+  const managedFiles = Object.fromEntries(
+    files
+      .filter((file) => file.path !== OWNERSHIP_SIDECAR_PATH)
+      .sort((left, right) => left.path.localeCompare(right.path))
+      .map((file) => [file.path, { sha256: sha256(file.contents), source: "bootstrap" }])
+  );
+
+  return {
+    path: OWNERSHIP_SIDECAR_PATH,
+    contents: `${JSON.stringify(
+      {
+        schemaVersion: 1,
+        owner: "bootstrap",
+        templateVersion: TEMPLATE_VERSION,
+        regenerationCommand: "bootstrap apply repo --manifest ./project.bootstrap.yaml",
+        managedFiles
+      },
+      null,
+      2
+    )}\n`,
+    reason: "Managed-file ownership sidecar"
   };
 }

--- a/tests/smoke.test.ts
+++ b/tests/smoke.test.ts
@@ -8,6 +8,7 @@ import { afterEach, describe, expect, it } from "vitest";
 
 import { normalizeManifest } from "../src/manifest.js";
 import { applyRepo, planRepo } from "../src/render.js";
+import { OWNERSHIP_SIDECAR_PATH } from "../src/state.js";
 
 const tempDirs: string[] = [];
 const execFileAsync = promisify(execFile);
@@ -51,6 +52,26 @@ describe("repo smoke", () => {
 
     const secondPlan = await planRepo(manifest, targetDir);
     expect(secondPlan.changes.every((change) => change.type === "unchanged")).toBe(true);
+    const ownership = JSON.parse(await readFile(path.join(targetDir, OWNERSHIP_SIDECAR_PATH), "utf8"));
+    expect(ownership).toMatchObject({
+      schemaVersion: 1,
+      owner: "bootstrap",
+      regenerationCommand: "bootstrap apply repo --manifest ./project.bootstrap.yaml"
+    });
+    expect(ownership.managedFiles["AGENTS.md"]).toMatchObject({ source: "bootstrap" });
+  });
+
+  it("blocks direct edits to previously managed files instead of overwriting them", async () => {
+    const targetDir = await makeTempDir();
+    const manifest = normalizeManifest({
+      project: { name: "owned-edit", owner: "acme" },
+      archetype: { kind: "generic-empty" }
+    });
+
+    await applyRepo(manifest, targetDir);
+    await writeFile(path.join(targetDir, "AGENTS.md"), "product-owned direct edit\n", "utf8");
+
+    await expect(planRepo(manifest, targetDir)).rejects.toThrow("AGENTS.md was directly modified");
   });
 
   it("can adopt an existing repo by managing only selected bootstrap files", async () => {


### PR DESCRIPTION
## Summary

- Render a portable `.bootstrap/managed-files.json` ownership sidecar for every managed artifact.
- Record source, digest, template version, and the regeneration command deterministically.
- Block direct edits before Bootstrap overwrites or removes a file, while retaining explicit legacy-state migrations.

## Governing Issue

Refs #57. Stacked on #67 while the resolved policy contract awaits independent re-review.

## Validation

- [x] `npm test` (77 passing tests)
- [x] `npm run build`
- [x] `git diff --check`

## Bootstrap Governance

- [x] Changes are scoped to ownership metadata and direct-edit protection for #57.
- [x] The sidecar contract and migration boundary are documented.
- [x] No real secrets, runtime auth, or machine-local env files are committed.

## Merge Automation

- Auto-merge is unavailable while this PR targets the unmerged #67 branch; it will be armed after #67 lands and the PR is rebased to `main`.

## Notes

- The direct-edit block protects SHA-backed managed state; older non-digest legacy state remains removable through the existing explicit migration path.
