### PR TITLE
feat: add deterministic conformance core

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ Confirm branch protection points at the `CI Gate` status and require approval fr
 
 Bootstrap records generated-file ownership in [the managed-file sidecar](docs/bootstrap/managed-file-ownership.md) and blocks direct edits before overwriting them.
 
+Run `bootstrap conform --manifest ./project.bootstrap.yaml --target .` for stable, machine-readable contract findings; see the [conformance core guide](docs/bootstrap/conformance.md).
+
 ## Project Identity
 
 - Product name: `Bootstrap`

--- a/docs/bootstrap/conformance.md
+++ b/docs/bootstrap/conformance.md
@@ -1,0 +1,11 @@
+# Conformance core
+
+`bootstrap conform` produces deterministic, versioned JSON and human output for
+the Public Repository Standard conformance core. Each result includes a stable
+rule ID, severity, evidence, and remediation. Blocking findings set exit code
+`1`; warnings remain distinct and return `0`.
+
+The first core validates repository class and product maturity, language-profile
+conflicts, typed exceptions, and the managed-file ownership sidecar. Additional
+security, provenance, GitHub-plan capability, and waiver rules can extend the
+same report schema without changing existing result semantics.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { Command } from "commander";
 
 import { runDoctor } from "./doctor.js";
+import { formatConformanceReport, runConformance } from "./conformance.js";
 import { reconcileFleet } from "./fleet.js";
 import { planGitHub, applyGitHub } from "./github/provision.js";
 import { planHome, applyHome } from "./home/sync.js";
@@ -239,6 +240,20 @@ async function main(): Promise<void> {
       process.stdout.write(
         `${checks.map((check) => `- [${check.status}] ${check.name}: ${check.detail}`).join("\n")}\n`
       );
+    });
+
+  program
+    .command("conform")
+    .description("Validate the deterministic Public Repository Standard conformance core.")
+    .option("--manifest <path>", "Path to manifest")
+    .option("--target <path>", "Target repository directory")
+    .option("--json", "Emit versioned JSON")
+    .action(async (options) => {
+      const manifest = await loadManifest(resolveManifestPath(options.manifest));
+      const targetDir = options.target ? path.resolve(options.target) : defaultTargetDir(manifest);
+      const report = await runConformance(manifest, targetDir);
+      process.stdout.write(`${options.json ? JSON.stringify(report, null, 2) : formatConformanceReport(report)}\n`);
+      process.exitCode = report.exitCode;
     });
 
   await program.parseAsync(process.argv);

--- a/src/conformance.ts
+++ b/src/conformance.ts
@@ -1,0 +1,129 @@
+import path from "node:path";
+
+import { z } from "zod";
+
+import { validatePolicyExceptions } from "./exceptions.js";
+import { readTextIfExists } from "./lib/fs.js";
+import { resolveLanguageProfiles } from "./language-profiles.js";
+import { planRepo } from "./render.js";
+import { OWNERSHIP_SIDECAR_PATH } from "./state.js";
+import type { BootstrapManifest } from "./types.js";
+
+export const CONFORMANCE_SCHEMA_VERSION = 1;
+
+const conformanceResultSchema = z.object({
+  ruleId: z.string().regex(/^PRS-[A-Z-]+-\d{3}$/),
+  severity: z.enum(["pass", "warning", "blocking"]),
+  evidence: z.array(z.string()),
+  remediation: z.string()
+});
+
+export const conformanceReportSchema = z.object({
+  schemaVersion: z.literal(CONFORMANCE_SCHEMA_VERSION),
+  results: z.array(conformanceResultSchema),
+  summary: z.object({ pass: z.number().int().nonnegative(), warning: z.number().int().nonnegative(), blocking: z.number().int().nonnegative() }),
+  exitCode: z.union([z.literal(0), z.literal(1)])
+});
+
+export type ConformanceResult = z.infer<typeof conformanceResultSchema>;
+export type ConformanceReport = z.infer<typeof conformanceReportSchema>;
+
+function result(
+  ruleId: string,
+  severity: ConformanceResult["severity"],
+  evidence: string[],
+  remediation: string
+): ConformanceResult {
+  return { ruleId, severity, evidence: [...evidence].sort(), remediation };
+}
+
+function summary(results: ConformanceResult[]): ConformanceReport["summary"] {
+  return {
+    pass: results.filter((entry) => entry.severity === "pass").length,
+    warning: results.filter((entry) => entry.severity === "warning").length,
+    blocking: results.filter((entry) => entry.severity === "blocking").length
+  };
+}
+
+export async function runConformance(manifest: BootstrapManifest, targetDir: string): Promise<ConformanceReport> {
+  const results: ConformanceResult[] = [];
+
+  results.push(
+    manifest.repo.class
+      ? result("PRS-CLASS-001", "pass", [manifest.repo.class], "Keep the canonical repository class current.")
+      : result("PRS-CLASS-001", "blocking", ["repo.class is absent"], "Declare a canonical repo.class or complete an explicit legacy migration.")
+  );
+  results.push(
+    manifest.project.maturity
+      ? result("PRS-MATURITY-001", "pass", [manifest.project.maturity], "Keep product maturity separate from release automation maturity.")
+      : result("PRS-MATURITY-001", "blocking", ["project.maturity is absent"], "Declare project.maturity from experimental through archived.")
+  );
+
+  const profiles = await resolveLanguageProfiles(manifest, targetDir);
+  if (profiles.conflicts.length === 0) {
+    results.push(
+      result(
+        "PRS-PROFILE-001",
+        "pass",
+        profiles.selected.length === 0 ? ["no repository language markers"] : profiles.selected,
+        "Keep selected language profiles aligned with the repository's toolchain markers."
+      )
+    );
+  } else {
+    for (const conflict of profiles.conflicts) {
+      results.push(result("PRS-PROFILE-001", "warning", [conflict.reason], "Align the archetype or resolve the detected language-profile conflict."));
+    }
+  }
+
+  for (const exception of validatePolicyExceptions(manifest.exceptions).results) {
+    results.push(
+      result(
+        exception.ruleId,
+        exception.status === "block" ? "blocking" : exception.status === "warn" ? "warning" : "pass",
+        [exception.detail],
+        exception.remediation ?? "Keep the approved exception current."
+      )
+    );
+  }
+
+  const ownershipPath = path.join(targetDir, OWNERSHIP_SIDECAR_PATH);
+  const ownershipRaw = await readTextIfExists(ownershipPath);
+  if (!ownershipRaw) {
+    results.push(result("PRS-OWNERSHIP-001", "blocking", [OWNERSHIP_SIDECAR_PATH], "Run bootstrap apply repo to create the managed-file ownership sidecar."));
+  } else {
+    try {
+      const ownership = JSON.parse(ownershipRaw) as { schemaVersion?: unknown; owner?: unknown; managedFiles?: unknown };
+      const valid = ownership.schemaVersion === 1 && ownership.owner === "bootstrap" && ownership.managedFiles && typeof ownership.managedFiles === "object";
+      results.push(
+        valid
+          ? result("PRS-OWNERSHIP-001", "pass", [OWNERSHIP_SIDECAR_PATH], "Keep the ownership sidecar under Bootstrap management.")
+          : result("PRS-OWNERSHIP-001", "blocking", [OWNERSHIP_SIDECAR_PATH], "Regenerate a valid Bootstrap ownership sidecar.")
+      );
+    } catch {
+      results.push(result("PRS-OWNERSHIP-001", "blocking", [OWNERSHIP_SIDECAR_PATH], "Regenerate the malformed Bootstrap ownership sidecar."));
+    }
+  }
+
+  try {
+    await planRepo(manifest, targetDir);
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    results.push(result("PRS-OWNERSHIP-001", "blocking", [detail], "Restore the managed file or use an explicit migration before applying Bootstrap changes."));
+  }
+
+  const sorted = results.sort((left, right) => left.ruleId.localeCompare(right.ruleId) || left.evidence.join("\n").localeCompare(right.evidence.join("\n")));
+  const report = {
+    schemaVersion: CONFORMANCE_SCHEMA_VERSION,
+    results: sorted,
+    summary: summary(sorted),
+    exitCode: sorted.some((entry) => entry.severity === "blocking") ? 1 : 0
+  } as const;
+  return conformanceReportSchema.parse(report);
+}
+
+export function formatConformanceReport(report: ConformanceReport): string {
+  return [
+    `Conformance: ${report.summary.blocking} blocking, ${report.summary.warning} warning, ${report.summary.pass} pass`,
+    ...report.results.map((entry) => `- [${entry.severity}] ${entry.ruleId}: ${entry.evidence.join("; ")} — ${entry.remediation}`)
+  ].join("\n");
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./doctor.js";
+export * from "./conformance.js";
 export * from "./exceptions.js";
 export * from "./fleet.js";
 export * from "./github/client.js";

--- a/tests/conformance.test.ts
+++ b/tests/conformance.test.ts
@@ -1,0 +1,54 @@
+import { mkdtemp, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+import { conformanceReportSchema, formatConformanceReport, runConformance } from "../src/conformance.js";
+import { normalizeManifest } from "../src/manifest.js";
+import { applyRepo } from "../src/render.js";
+
+async function fixtureDirectory(): Promise<string> {
+  return mkdtemp(path.join(os.tmpdir(), "bootstrap-conformance-"));
+}
+
+describe("runConformance", () => {
+  it("returns deterministic machine-validated blocking results for missing contract fields", async () => {
+    const directory = await fixtureDirectory();
+    const manifest = normalizeManifest({ project: { name: "missing-contract", owner: "acme" }, archetype: { kind: "generic-empty" } });
+
+    const report = await runConformance(manifest, directory);
+
+    expect(conformanceReportSchema.parse(report)).toEqual(report);
+    expect(report.exitCode).toBe(1);
+    expect(report.results.map((entry) => entry.ruleId)).toEqual([
+      "PRS-CLASS-001",
+      "PRS-MATURITY-001",
+      "PRS-OWNERSHIP-001",
+      "PRS-PROFILE-001"
+    ]);
+  });
+
+  it("passes the core for an applied canonical contract and keeps warning semantics distinct", async () => {
+    const directory = await fixtureDirectory();
+    await writeFile(path.join(directory, "pyproject.toml"), "[project]\nname = 'service'\n");
+    const manifest = normalizeManifest({
+      project: { name: "canonical-contract", owner: "acme", maturity: "stable" },
+      repo: { class: "service" },
+      archetype: { kind: "generic-empty" }
+    });
+    await applyRepo(manifest, directory);
+
+    const evaluatedManifest = normalizeManifest({
+      project: { name: "canonical-contract", owner: "acme", maturity: "stable" },
+      repo: { class: "service" },
+      archetype: { kind: "node-ts-service" }
+    });
+
+    const report = await runConformance(evaluatedManifest, directory);
+
+    expect(report.exitCode).toBe(0);
+    expect(report.summary.warning).toBe(1);
+    expect(report.results).toContainEqual(expect.objectContaining({ ruleId: "PRS-PROFILE-001", severity: "warning" }));
+    expect(formatConformanceReport(report)).toContain("Conformance: 0 blocking, 1 warning");
+  });
+});


### PR DESCRIPTION
## Summary

- Add deterministic Public Repository Standard conformance reports with stable rule IDs, severity, evidence, remediation, and versioned JSON.
- Introduce `bootstrap conform` with distinct warning/blocking exit semantics.
- Validate class, maturity, profiles, typed exceptions, and managed-file ownership in the first extensible core.

## Governing Issue

Refs #58. Stacked on #67 while the resolved policy contract awaits independent re-review.

## Validation

- [x] `npm test` (79 passing tests)
- [x] `npm run build`
- [x] `git diff --check`

## Bootstrap Governance

- [x] Changes are scoped to the conformance engine core for #58.
- [x] Human and machine-readable output semantics are documented.
- [x] No real secrets, runtime auth, or machine-local env files are committed.

## Merge Automation

- Auto-merge is unavailable while this PR targets the unmerged #67 branch; it will be armed after #67 lands and the PR is rebased to `main`.

## Notes

- GitHub-plan capability, security, provenance, and waiver rules are intentionally additive follow-up checks under the same schema.
