### PR TITLE
feat: enforce fork-safe PR governance

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -19,6 +19,9 @@ Refs #<issue-number>  <!-- use Closes/Fixes/Resolves only when this PR fully com
 - [ ] PR author enabled auto-merge where GitHub allows it, or GitHub plan-limit evidence/unavailable reason is recorded and the fallback merge-readiness policy applies
 - [ ] No real secrets, runtime auth, or machine-local env files are committed
 
+Material change: no
+ADR: docs/decisions/ADR-<number>-<slug>.md  <!-- required when Material change is yes; ADR status must be Accepted -->
+
 
 
 ## Merge Automation

--- a/.github/workflows/pr-fast-ci.yml
+++ b/.github/workflows/pr-fast-ci.yml
@@ -10,6 +10,7 @@ concurrency:
 
 permissions:
   contents: read
+  pull-requests: read
 
 env:
   NODE_VERSION: '20'
@@ -132,6 +133,26 @@ jobs:
       - name: Scan repository for secret patterns
         run: bash scripts/check-detect-secrets.sh --all-files
 
+  validate-pr-governance:
+    name: Validate PR Governance
+    runs-on: ['self-hosted', 'linux', 'shell-only', 'public']
+    timeout-minutes: 5
+    if: github.event.pull_request.draft == false
+    env:
+      PR_TITLE: ${{ github.event.pull_request.title }}
+      PR_BODY: ${{ github.event.pull_request.body }}
+      PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+      PR_FILES_URL: ${{ github.event.pull_request.url }}/files
+      PR_COMMITS_URL: ${{ github.event.pull_request.commits_url }}
+      PR_REVIEWS_URL: ${{ github.event.pull_request.url }}/reviews
+      GITHUB_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Validate title, DCO, size, ADR, and reviewer evidence
+        run: bash scripts/ci/check-pr-governance.sh
+
   ci-gate:
     name: CI Gate
     runs-on: ['self-hosted', 'linux', 'shell-only', 'public']
@@ -141,6 +162,7 @@ jobs:
       - fast-checks
       - validate-pr-description
       - validate-secrets
+      - validate-pr-governance
     steps:
       - name: Check required PR jobs
         env:
@@ -149,6 +171,7 @@ jobs:
             fast-checks=${{ needs.fast-checks.result }}
             validate-pr-description=${{ needs.validate-pr-description.result }}
             validate-secrets=${{ needs.validate-secrets.result }}
+            validate-pr-governance=${{ needs.validate-pr-governance.result }}
         run: |
           failed=0
           for entry in $RESULTS; do

--- a/docs/bootstrap/onboarding.md
+++ b/docs/bootstrap/onboarding.md
@@ -14,6 +14,7 @@ Use this checklist after the first bootstrap render or whenever `project.bootstr
 - Confirm branch protection points at the `CI Gate` status.
 - Confirm `CONTRIBUTING.md` and `.github/PULL_REQUEST_TEMPLATE.md` are present as the required contributor and PR guidance surfaces.
 - Confirm the pull request template is present and PR Fast CI validates the required PR description sections before CI Gate can pass.
+- Confirm PR Fast CI uses the fork-safe `pull_request` event with only read permissions. It must validate Conventional titles, contributed-commit DCO trailers, changed-line accounting, and material-change ADR/reviewer evidence without accessing repository secrets.
 - Confirm `delete branch on merge` and `allow auto-merge` are enabled when the GitHub plan supports them; otherwise record the plan-limit evidence and use the fallback merge-readiness policy.
 - Fallback merge readiness requires passing or intentionally skipped required checks, satisfied approvals, resolved conversations, no blocking review state, and a manual maintainer merge.
 

--- a/scripts/ci/check-pr-governance.sh
+++ b/scripts/ci/check-pr-governance.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+required=(PR_TITLE PR_BODY PR_AUTHOR)
+for name in "${required[@]}"; do
+  if [[ -z "${!name:-}" ]]; then
+    echo "Missing required PR governance input: $name" >&2
+    exit 2
+  fi
+done
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "$workdir"' EXIT
+
+fetch() {
+  local url="$1"
+  local destination="$2"
+  curl --fail --silent --show-error --location --retry 2 \
+    --header "Accept: application/vnd.github+json" \
+    --header "Authorization: Bearer $GITHUB_TOKEN" \
+    "$url" >"$destination"
+}
+
+load_response() {
+  local fixture="$1"
+  local url="$2"
+  local suffix="$3"
+  local destination="$4"
+  if [[ -n "$fixture" ]]; then
+    cp "$fixture" "$destination"
+  elif [[ -n "$url" && -n "${GITHUB_TOKEN:-}" ]]; then
+    fetch "$url?$suffix" "$destination"
+  else
+    echo "Provide a fixture file or API URL plus GITHUB_TOKEN for $destination" >&2
+    exit 2
+  fi
+}
+
+load_response "${PR_FILES_FILE:-}" "${PR_FILES_URL:-}" "per_page=100" "$workdir/files.json"
+load_response "${PR_COMMITS_FILE:-}" "${PR_COMMITS_URL:-}" "per_page=250" "$workdir/commits.json"
+load_response "${PR_REVIEWS_FILE:-}" "${PR_REVIEWS_URL:-}" "per_page=100" "$workdir/reviews.json"
+
+python3 - "$PR_TITLE" "$PR_BODY" "$PR_AUTHOR" "$workdir/files.json" "$workdir/commits.json" "$workdir/reviews.json" <<'PY'
+import json
+import re
+import sys
+from pathlib import Path
+
+title, body, author, files_path, commits_path, reviews_path = sys.argv[1:]
+files = json.loads(Path(files_path).read_text())
+commits = json.loads(Path(commits_path).read_text())
+reviews = json.loads(Path(reviews_path).read_text())
+failures = []
+
+if not re.match(r"^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\([^)]+\))?!?: .+", title):
+    failures.append("PRS-PR-TITLE-001: use a Conventional Commit-style PR title, for example 'feat: add policy gate'.")
+
+excluded = []
+counted_lines = 0
+for changed in files:
+    name = changed.get("filename", "unknown")
+    if name.startswith(("docs/", "test/", "tests/")) or name.endswith((".md", ".lock")) or name in {"package-lock.json", "pnpm-lock.yaml", "yarn.lock"}:
+        excluded.append(name)
+    else:
+        counted_lines += int(changed.get("additions", 0)) + int(changed.get("deletions", 0))
+print(f"INFO PRS-PR-SIZE-001: {counted_lines} counted changed lines; excluded {len(excluded)} documentation, test, and lockfile paths.")
+if excluded:
+    print("INFO PRS-PR-SIZE-001 excluded: " + ", ".join(sorted(excluded)))
+if counted_lines > 800:
+    failures.append(f"PRS-PR-SIZE-001: {counted_lines} counted changed lines exceeds the 800-line review threshold; split the change before requesting review.")
+
+missing_dco = []
+for commit in commits:
+    login = (commit.get("author") or {}).get("login", "")
+    account_type = (commit.get("author") or {}).get("type", "")
+    if account_type == "Bot" or login.endswith("[bot]"):
+        continue
+    message = (commit.get("commit") or {}).get("message", "")
+    if not re.search(r"(?im)^signed-off-by:\s+.+ <[^>]+>$", message):
+        missing_dco.append(commit.get("sha", "unknown")[:12])
+if missing_dco:
+    failures.append("PRS-DCO-001: contributed commits without a Signed-off-by trailer: " + ", ".join(missing_dco))
+
+declaration = re.search(r"(?im)^material change:\s*(yes|no)\s*$", body)
+if not declaration:
+    failures.append("PRS-MATERIAL-001: declare 'Material change: yes' or 'Material change: no' in the PR body.")
+elif declaration.group(1).lower() == "yes":
+    adr = re.search(r"(?im)^adr:\s*(docs/decisions/[^\s]+\.md)\s*$", body)
+    if not adr:
+        failures.append("PRS-ADR-001: material changes require an ADR line pointing at an accepted docs/decisions/*.md file.")
+    else:
+        adr_path = Path(adr.group(1))
+        if not adr_path.is_file() or not re.search(r"(?im)^status:\s*accepted\s*$", adr_path.read_text()):
+            failures.append(f"PRS-ADR-001: {adr_path} must exist in this PR and declare 'Status: Accepted'.")
+
+    independent_approvers = {
+        (review.get("user") or {}).get("login", "")
+        for review in reviews
+        if review.get("state", "").upper() == "APPROVED"
+        and (review.get("user") or {}).get("login", "") != author
+        and (review.get("user") or {}).get("type", "") != "Bot"
+    }
+    if not independent_approvers:
+        failures.append("PRS-INDEPENDENT-REVIEW-001: material changes require an approving reviewer other than the PR author.")
+
+if failures:
+    print("\n".join("FAIL " + failure for failure in failures), file=sys.stderr)
+    sys.exit(1)
+print("PASS PRS-PR-GOVERNANCE-001: title, DCO, change accounting, and material evidence are valid.")
+PY

--- a/src/archetypes.ts
+++ b/src/archetypes.ts
@@ -422,6 +422,9 @@ function pullRequestTemplate(manifest: BootstrapManifest): string {
     - [ ] PR author enabled auto-merge where GitHub allows it, or GitHub plan-limit evidence/unavailable reason is recorded and the fallback merge-readiness policy applies
     - [ ] No real secrets, runtime auth, or machine-local env files are committed
 
+    Material change: no
+    ADR: docs/decisions/ADR-<number>-<slug>.md  <!-- required when Material change is yes; ADR status must be Accepted -->
+
 ${indentBlock(flowPullRequestSection(manifest), 4)}
 
     ## Merge Automation
@@ -948,6 +951,121 @@ function extendedChecksScript(manifest: BootstrapManifest): string {
     set -euo pipefail
 
   `}\n${body}\n`;
+}
+
+function prGovernanceScript(): string {
+  return dedent`
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    required=(PR_TITLE PR_BODY PR_AUTHOR)
+    for name in "\${required[@]}"; do
+      if [[ -z "\${!name:-}" ]]; then
+        echo "Missing required PR governance input: $name" >&2
+        exit 2
+      fi
+    done
+
+    workdir="$(mktemp -d)"
+    trap 'rm -rf "$workdir"' EXIT
+
+    fetch() {
+      local url="$1"
+      local destination="$2"
+      curl --fail --silent --show-error --location --retry 2 \\
+        --header "Accept: application/vnd.github+json" \\
+        --header "Authorization: Bearer $GITHUB_TOKEN" \\
+        "$url" >"$destination"
+    }
+
+    load_response() {
+      local fixture="$1"
+      local url="$2"
+      local suffix="$3"
+      local destination="$4"
+      if [[ -n "$fixture" ]]; then
+        cp "$fixture" "$destination"
+      elif [[ -n "$url" && -n "\${GITHUB_TOKEN:-}" ]]; then
+        fetch "$url?$suffix" "$destination"
+      else
+        echo "Provide a fixture file or API URL plus GITHUB_TOKEN for $destination" >&2
+        exit 2
+      fi
+    }
+
+    load_response "\${PR_FILES_FILE:-}" "\${PR_FILES_URL:-}" "per_page=100" "$workdir/files.json"
+    load_response "\${PR_COMMITS_FILE:-}" "\${PR_COMMITS_URL:-}" "per_page=250" "$workdir/commits.json"
+    load_response "\${PR_REVIEWS_FILE:-}" "\${PR_REVIEWS_URL:-}" "per_page=100" "$workdir/reviews.json"
+
+    python3 - "$PR_TITLE" "$PR_BODY" "$PR_AUTHOR" "$workdir/files.json" "$workdir/commits.json" "$workdir/reviews.json" <<'PY'
+    import json
+    import re
+    import sys
+    from pathlib import Path
+
+    title, body, author, files_path, commits_path, reviews_path = sys.argv[1:]
+    files = json.loads(Path(files_path).read_text())
+    commits = json.loads(Path(commits_path).read_text())
+    reviews = json.loads(Path(reviews_path).read_text())
+    failures = []
+
+    if not re.match(r"^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\\([^)]+\\))?!?: .+", title):
+        failures.append("PRS-PR-TITLE-001: use a Conventional Commit-style PR title, for example 'feat: add policy gate'.")
+
+    excluded = []
+    counted_lines = 0
+    for changed in files:
+        name = changed.get("filename", "unknown")
+        if name.startswith(("docs/", "test/", "tests/")) or name.endswith((".md", ".lock")) or name in {"package-lock.json", "pnpm-lock.yaml", "yarn.lock"}:
+            excluded.append(name)
+        else:
+            counted_lines += int(changed.get("additions", 0)) + int(changed.get("deletions", 0))
+    print(f"INFO PRS-PR-SIZE-001: {counted_lines} counted changed lines; excluded {len(excluded)} documentation, test, and lockfile paths.")
+    if excluded:
+        print("INFO PRS-PR-SIZE-001 excluded: " + ", ".join(sorted(excluded)))
+    if counted_lines > 800:
+        failures.append(f"PRS-PR-SIZE-001: {counted_lines} counted changed lines exceeds the 800-line review threshold; split the change before requesting review.")
+
+    missing_dco = []
+    for commit in commits:
+        login = (commit.get("author") or {}).get("login", "")
+        account_type = (commit.get("author") or {}).get("type", "")
+        if account_type == "Bot" or login.endswith("[bot]"):
+            continue
+        message = (commit.get("commit") or {}).get("message", "")
+        if not re.search(r"(?im)^signed-off-by:\\s+.+ <[^>]+>$", message):
+            missing_dco.append(commit.get("sha", "unknown")[:12])
+    if missing_dco:
+        failures.append("PRS-DCO-001: contributed commits without a Signed-off-by trailer: " + ", ".join(missing_dco))
+
+    declaration = re.search(r"(?im)^material change:\\s*(yes|no)\\s*$", body)
+    if not declaration:
+        failures.append("PRS-MATERIAL-001: declare 'Material change: yes' or 'Material change: no' in the PR body.")
+    elif declaration.group(1).lower() == "yes":
+        adr = re.search(r"(?im)^adr:\\s*(docs/decisions/[^\\s]+\\.md)\\s*$", body)
+        if not adr:
+            failures.append("PRS-ADR-001: material changes require an ADR line pointing at an accepted docs/decisions/*.md file.")
+        else:
+            adr_path = Path(adr.group(1))
+            if not adr_path.is_file() or not re.search(r"(?im)^status:\\s*accepted\\s*$", adr_path.read_text()):
+                failures.append(f"PRS-ADR-001: {adr_path} must exist in this PR and declare 'Status: Accepted'.")
+
+        independent_approvers = {
+            (review.get("user") or {}).get("login", "")
+            for review in reviews
+            if review.get("state", "").upper() == "APPROVED"
+            and (review.get("user") or {}).get("login", "") != author
+            and (review.get("user") or {}).get("type", "") != "Bot"
+        }
+        if not independent_approvers:
+            failures.append("PRS-INDEPENDENT-REVIEW-001: material changes require an approving reviewer other than the PR author.")
+
+    if failures:
+        print("\\n".join("FAIL " + failure for failure in failures), file=sys.stderr)
+        sys.exit(1)
+    print("PASS PRS-PR-GOVERNANCE-001: title, DCO, change accounting, and material evidence are valid.")
+    PY
+  `;
 }
 
 function releaseVerificationScript(manifest: BootstrapManifest): string {
@@ -2259,6 +2377,7 @@ function prWorkflow(manifest: BootstrapManifest): string {
 
     permissions:
       contents: read
+      pull-requests: read
 
     env:
       NODE_VERSION: '${manifest.ci.nodeVersion}'
@@ -2363,6 +2482,26 @@ ${indentBlock(setupSteps(manifest), 6)}
           - name: Scan repository for secret patterns
             run: bash scripts/check-detect-secrets.sh --all-files
 
+      validate-pr-governance:
+        name: Validate PR Governance
+        runs-on: ${shellRunner}
+        timeout-minutes: 5
+        if: github.event.pull_request.draft == false
+        env:
+          PR_TITLE: \${{ github.event.pull_request.title }}
+          PR_BODY: \${{ github.event.pull_request.body }}
+          PR_AUTHOR: \${{ github.event.pull_request.user.login }}
+          PR_FILES_URL: \${{ github.event.pull_request.url }}/files
+          PR_COMMITS_URL: \${{ github.event.pull_request.commits_url }}
+          PR_REVIEWS_URL: \${{ github.event.pull_request.url }}/reviews
+          GITHUB_TOKEN: \${{ github.token }}
+        steps:
+          - uses: actions/checkout@v4
+            with:
+              ref: \${{ github.event.pull_request.head.sha }}
+          - name: Validate title, DCO, size, ADR, and reviewer evidence
+            run: bash scripts/ci/check-pr-governance.sh
+
       ci-gate:
         name: ${primaryRequiredStatusCheck(manifest)}
         runs-on: ${shellRunner}
@@ -2372,6 +2511,7 @@ ${indentBlock(setupSteps(manifest), 6)}
           - fast-checks
           - validate-pr-description
           - validate-secrets
+          - validate-pr-governance
         steps:
           - name: Check required PR jobs
             env:
@@ -2380,6 +2520,7 @@ ${indentBlock(setupSteps(manifest), 6)}
                 fast-checks=\${{ needs.fast-checks.result }}
                 validate-pr-description=\${{ needs.validate-pr-description.result }}
                 validate-secrets=\${{ needs.validate-secrets.result }}
+                validate-pr-governance=\${{ needs.validate-pr-governance.result }}
             run: |
               failed=0
               for entry in $RESULTS; do
@@ -3189,6 +3330,12 @@ export function renderManagedFiles(manifest: BootstrapManifest): RenderedFile[] 
       path: "scripts/ci/run-extended-validation.sh",
       reason: "Extended CI entrypoint",
       contents: extendedChecksScript(manifest),
+      executable: true
+    },
+    {
+      path: "scripts/ci/check-pr-governance.sh",
+      reason: "Fork-safe pull request governance validation",
+      contents: `${prGovernanceScript()}\n`,
       executable: true
     },
     ...(manifest.release.enabled

--- a/tests/__snapshots__/render.test.ts.snap
+++ b/tests/__snapshots__/render.test.ts.snap
@@ -72,6 +72,10 @@ exports[`renderManagedFiles > renders a stable managed file set for generic-empt
   },
   {
     "executable": true,
+    "path": "scripts/ci/check-pr-governance.sh",
+  },
+  {
+    "executable": true,
     "path": "scripts/ci/run-release-verification.sh",
   },
   {
@@ -182,6 +186,10 @@ exports[`renderManagedFiles > renders a stable managed file set for nextjs-web 1
   {
     "executable": true,
     "path": "scripts/ci/run-extended-validation.sh",
+  },
+  {
+    "executable": true,
+    "path": "scripts/ci/check-pr-governance.sh",
   },
   {
     "executable": true,
@@ -306,6 +314,10 @@ exports[`renderManagedFiles > renders a stable managed file set for node-ts-serv
   },
   {
     "executable": true,
+    "path": "scripts/ci/check-pr-governance.sh",
+  },
+  {
+    "executable": true,
     "path": "scripts/ci/run-release-verification.sh",
   },
   {
@@ -416,6 +428,10 @@ exports[`renderManagedFiles > renders a stable managed file set for python-servi
   {
     "executable": true,
     "path": "scripts/ci/run-extended-validation.sh",
+  },
+  {
+    "executable": true,
+    "path": "scripts/ci/check-pr-governance.sh",
   },
   {
     "executable": true,

--- a/tests/pr-governance.test.ts
+++ b/tests/pr-governance.test.ts
@@ -1,0 +1,91 @@
+import { spawn } from "node:child_process";
+import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+type Fixture = { files: unknown[]; commits: unknown[]; reviews: unknown[] };
+
+async function runGovernance(fixture: Fixture, overrides: Record<string, string> = {}) {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "bootstrap-pr-governance-"));
+  const paths = {
+    files: path.join(directory, "files.json"),
+    commits: path.join(directory, "commits.json"),
+    reviews: path.join(directory, "reviews.json")
+  };
+  await Promise.all([
+    writeFile(paths.files, JSON.stringify(fixture.files)),
+    writeFile(paths.commits, JSON.stringify(fixture.commits)),
+    writeFile(paths.reviews, JSON.stringify(fixture.reviews))
+  ]);
+  const result = await new Promise<{ code: number; output: string }>((resolve, reject) => {
+    const child = spawn("bash", [path.resolve("scripts/ci/check-pr-governance.sh")], {
+      cwd: directory,
+      env: {
+        ...process.env,
+        PR_TITLE: "feat: validate fixtures",
+        PR_BODY: "Material change: no",
+        PR_AUTHOR: "author",
+        PR_FILES_FILE: paths.files,
+        PR_COMMITS_FILE: paths.commits,
+        PR_REVIEWS_FILE: paths.reviews,
+        ...overrides
+      }
+    });
+    let output = "";
+    child.stdout.on("data", (chunk) => (output += chunk));
+    child.stderr.on("data", (chunk) => (output += chunk));
+    child.on("error", reject);
+    child.on("close", (code) => resolve({ code: code ?? 1, output }));
+  });
+  return { ...result, directory };
+}
+
+describe("check-pr-governance", () => {
+  it("reports synthetic title, DCO, and changed-line failures with its exclusions", async () => {
+    const result = await runGovernance({
+      files: [{ filename: "src/large.ts", additions: 801, deletions: 0 }, { filename: "docs/guide.md", additions: 50, deletions: 0 }],
+      commits: [{ sha: "1234567890abcdef", author: { login: "human", type: "User" }, commit: { message: "feat: no signoff" } }],
+      reviews: []
+    }, { PR_TITLE: "missing conventional title" });
+
+    expect(result.code).toBe(1);
+    expect(result.output).toContain("PRS-PR-TITLE-001");
+    expect(result.output).toContain("PRS-DCO-001");
+    expect(result.output).toContain("PRS-PR-SIZE-001");
+    expect(result.output).toContain("docs/guide.md");
+  });
+
+  it("accepts a material change with an accepted ADR and independent reviewer", async () => {
+    const result = await runGovernance({
+      files: [{ filename: "src/policy.ts", additions: 10, deletions: 2 }],
+      commits: [{ sha: "abcdef1234567890", author: { login: "human", type: "User" }, commit: { message: "feat: policy\n\nSigned-off-by: Human <human@example.com>" } }],
+      reviews: [{ state: "APPROVED", user: { login: "reviewer", type: "User" } }]
+    }, { PR_BODY: "Material change: yes\nADR: docs/decisions/ADR-0001-test.md" });
+    await mkdir(path.join(result.directory, "docs", "decisions"), { recursive: true });
+    await writeFile(path.join(result.directory, "docs", "decisions", "ADR-0001-test.md"), "# Decision\n\nStatus: Accepted\n");
+
+    const rerun = await new Promise<{ code: number; output: string }>((resolve, reject) => {
+      const child = spawn("bash", [path.resolve("scripts/ci/check-pr-governance.sh")], {
+        cwd: result.directory,
+        env: {
+          ...process.env,
+          PR_TITLE: "feat: apply policy",
+          PR_BODY: "Material change: yes\nADR: docs/decisions/ADR-0001-test.md",
+          PR_AUTHOR: "author",
+          PR_FILES_FILE: path.join(result.directory, "files.json"),
+          PR_COMMITS_FILE: path.join(result.directory, "commits.json"),
+          PR_REVIEWS_FILE: path.join(result.directory, "reviews.json")
+        }
+      });
+      let output = "";
+      child.stdout.on("data", (chunk) => (output += chunk));
+      child.stderr.on("data", (chunk) => (output += chunk));
+      child.on("error", reject);
+      child.on("close", (code) => resolve({ code: code ?? 1, output }));
+    });
+
+    expect(rerun.code).toBe(0);
+    expect(rerun.output).toContain("PASS PRS-PR-GOVERNANCE-001");
+  });
+});

--- a/tests/render.test.ts
+++ b/tests/render.test.ts
@@ -55,6 +55,10 @@ describe("renderManagedFiles", () => {
       expect(prWorkflow?.contents).toContain("https://github\\.com/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+/issues/");
       expect(prWorkflow?.contents).toContain("auto_merge_evidence=");
       expect(prWorkflow?.contents).toContain('<<<"$auto_merge_evidence"');
+      expect(prWorkflow?.contents).toContain("validate-pr-governance:");
+      expect(prWorkflow?.contents).toContain("pull-requests: read");
+      expect(prWorkflow?.contents).toContain("PR_COMMITS_URL:");
+      expect(files.find((file) => file.path === "scripts/ci/check-pr-governance.sh")?.contents).toContain("PRS-DCO-001");
 
       const prTemplate = files.find((file) => file.path === ".github/PULL_REQUEST_TEMPLATE.md");
       const dependabot = files.find((file) => file.path === ".github/dependabot.yml");
@@ -64,6 +68,7 @@ describe("renderManagedFiles", () => {
       expect(prTemplate?.contents).toContain("## Bootstrap Governance");
       expect(prTemplate?.contents).toContain("fallback merge-readiness policy applies");
       expect(prTemplate?.contents).toContain("## Notes");
+      expect(prTemplate?.contents).toContain("Material change: no");
       expect(dependabot?.contents).toContain('package-ecosystem: "npm"');
       expect(dependabot?.contents).toContain('package-ecosystem: "github-actions"');
       expect(dependabot?.contents).toContain("npm-minor-patch");


### PR DESCRIPTION
## Summary

- Add a fork-safe, read-only PR governance gate for Conventional titles, contributed-commit DCO trailers, changed-line accounting, and material ADR/reviewer evidence.
- Project the gate through Bootstrap and dogfood it in this repository with synthetic passing and failing fixtures.

## Governing Issue

Refs #59

## Validation

- [x] `npm test` (81 tests)
- [x] `npm run build`
- [x] `git diff --check`

## Bootstrap Governance

- [x] The generated workflow uses the `pull_request` event and read-only `contents` / `pull-requests` permissions; it does not access repository secrets.
- [x] The template and onboarding guide explain the required material-change declaration and accepted ADR evidence.
- [x] No real secrets, runtime auth, or machine-local environment files are included.

Material change: no

## Merge Automation

- Auto-merge is enabled once CI passes. If the integration branch remains externally review-blocked, the documented fallback merge-readiness policy applies.

## Notes

- This is the PR-gate slice of #59. The scheduled issue-aging workflow remains report-only follow-up work.
