### PR TITLE
fix: pin third-party GitHub Actions

### DIFF
--- a/.github/workflows/ai-attestation-reusable.yml
+++ b/.github/workflows/ai-attestation-reusable.yml
@@ -34,12 +34,12 @@ jobs:
     outputs:
       sha: ${{ steps.meta.outputs.sha }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 1
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@v4.1.2
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
       - name: Collect metadata and write attestation
         id: meta
@@ -82,7 +82,7 @@ jobs:
             "attest/${sha}.json"
 
       - name: Upload attestation artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: ${{ inputs.artifact_name }}-${{ steps.meta.outputs.sha }}
           path: attest/
@@ -93,10 +93,10 @@ jobs:
     needs: attest
     steps:
       - name: Install cosign
-        uses: sigstore/cosign-installer@v4.1.2
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
       - name: Download attestation artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: ${{ inputs.artifact_name }}-${{ needs.attest.outputs.sha }}
           path: attest

--- a/.github/workflows/extended-validation.yml
+++ b/.github/workflows/extended-validation.yml
@@ -31,7 +31,7 @@ jobs:
       ci: ${{ steps.preset.outputs.ci || steps.filter.outputs.ci || 'false' }}
       extended: ${{ steps.preset.outputs.extended || steps.filter.outputs.extended || 'false' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         if: github.event_name == 'push'
         with:
           fetch-depth: 0
@@ -46,7 +46,7 @@ jobs:
           extended=true
           EOF
 
-      - uses: dorny/paths-filter@v4
+      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4
         id: filter
         if: github.event_name == 'push'
         with:
@@ -84,7 +84,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.app == 'true' || needs.changes.outputs.ci == 'true'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Run fast checks
         run: bash scripts/ci/run-fast-checks.sh
@@ -96,7 +96,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.extended == 'true' || needs.changes.outputs.app == 'true'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Run extended validation
         run: bash scripts/ci/run-extended-validation.sh
@@ -106,7 +106,7 @@ jobs:
     runs-on: ['self-hosted', 'linux', 'shell-only', 'public']
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Scan repository for secret patterns
         run: bash scripts/check-detect-secrets.sh --all-files
 

--- a/.github/workflows/full-release-validation-reusable.yml
+++ b/.github/workflows/full-release-validation-reusable.yml
@@ -22,7 +22,7 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ inputs.target_ref }}
           fetch-depth: 0
@@ -49,7 +49,7 @@ jobs:
           cat >"$ARTIFACT_DIR/validation-evidence.json" <<JSON
           {"schema_version":1,"repo":"${GITHUB_REPOSITORY}","target_ref":"${TARGET_REF}","target_sha":"${target_sha}","validation_run_id":"${GITHUB_RUN_ID}","release_profile":"${RELEASE_PROFILE}","checks":{"validate_script":"${validate_status}","standard_checks":"${standard_status}"}}
           JSON
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: ${{ inputs.evidence_artifact_name }}-validation
           path: ${{ inputs.artifact_dir }}/validation-evidence.json

--- a/.github/workflows/pr-fast-ci.yml
+++ b/.github/workflows/pr-fast-ci.yml
@@ -28,7 +28,7 @@ jobs:
       app: ${{ steps.filter.outputs.app }}
       ci: ${{ steps.filter.outputs.ci }}
     steps:
-      - uses: dorny/paths-filter@v4
+      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4
         id: filter
         with:
           filters: |
@@ -64,7 +64,7 @@ jobs:
       github.event.pull_request.draft == false &&
       (needs.changes.outputs.app == 'true' || needs.changes.outputs.ci == 'true')
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
@@ -127,7 +127,7 @@ jobs:
     timeout-minutes: 10
     if: github.event.pull_request.draft == false
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Scan repository for secret patterns
@@ -147,11 +147,23 @@ jobs:
       PR_REVIEWS_URL: ${{ github.event.pull_request.url }}/reviews
       GITHUB_TOKEN: ${{ github.token }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Validate title, DCO, size, ADR, and reviewer evidence
         run: bash scripts/ci/check-pr-governance.sh
+
+  validate-action-pins:
+    name: Validate Action Pins
+    runs-on: ['self-hosted', 'linux', 'shell-only', 'public']
+    timeout-minutes: 5
+    if: github.event.pull_request.draft == false
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Require immutable third-party action pins
+        run: bash scripts/ci/check-action-pins.sh
 
   ci-gate:
     name: CI Gate
@@ -163,6 +175,7 @@ jobs:
       - validate-pr-description
       - validate-secrets
       - validate-pr-governance
+      - validate-action-pins
     steps:
       - name: Check required PR jobs
         env:
@@ -172,6 +185,7 @@ jobs:
             validate-pr-description=${{ needs.validate-pr-description.result }}
             validate-secrets=${{ needs.validate-secrets.result }}
             validate-pr-governance=${{ needs.validate-pr-governance.result }}
+            validate-action-pins=${{ needs.validate-action-pins.result }}
         run: |
           failed=0
           for entry in $RESULTS; do

--- a/.github/workflows/release-postpublish-reusable.yml
+++ b/.github/workflows/release-postpublish-reusable.yml
@@ -21,7 +21,7 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ inputs.tag }}
           fetch-depth: 0
@@ -46,7 +46,7 @@ jobs:
             exit 1
           fi
           printf '{"schema_version":1,"repo":"%s","tag":"%s","channel":"%s","release_issue":"%s","postpublish_run_id":"%s","release_assets":%s}\n' "$GITHUB_REPOSITORY" "$TAG" "$CHANNEL" "$RELEASE_ISSUE" "$GITHUB_RUN_ID" "$asset_count" >"$ARTIFACT_DIR/postpublish-evidence.json"
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: ${{ inputs.evidence_artifact_name }}-postpublish
           path: ${{ inputs.artifact_dir }}/postpublish-evidence.json

--- a/.github/workflows/release-preflight-reusable.yml
+++ b/.github/workflows/release-preflight-reusable.yml
@@ -30,7 +30,7 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ inputs.target_ref }}
           fetch-depth: 0
@@ -76,13 +76,13 @@ jobs:
           {"schema_version":1,"repo":"${GITHUB_REPOSITORY}","version":"${VERSION}","channel":"${CHANNEL}","target_ref":"${TARGET_REF}","target_sha":"${target_sha}","release_issue":"${RELEASE_ISSUE}","preflight_run_id":"${GITHUB_RUN_ID}","checks":{"prep":"${prep_status}","preflight":"${preflight_status}","build":"${build_status}"}}
           JSON
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: release-package
           path: ${{ inputs.artifact_dir }}/
           retention-days: ${{ inputs.evidence_retention_days }}
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: ${{ inputs.evidence_artifact_name }}
           path: |

--- a/.github/workflows/release-publish-reusable.yml
+++ b/.github/workflows/release-publish-reusable.yml
@@ -39,7 +39,7 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ inputs.tag }}
           fetch-depth: 0
@@ -152,7 +152,7 @@ jobs:
             exit 1
           fi
           printf '{"schema_version":1,"repo":"%s","tag":"%s","tag_sha":"%s","publish_run_id":"%s"}\n' "$GITHUB_REPOSITORY" "$TAG" "$tag_sha" "$GITHUB_RUN_ID" >"$ARTIFACT_DIR/postpublish-evidence.json"
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: ${{ inputs.evidence_artifact_name }}-publish
           path: ${{ inputs.artifact_dir }}/postpublish-evidence.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,7 +100,7 @@ jobs:
       DOCKYARD_SPARKLE_SIGN_UPDATE: ${{ secrets.DOCKYARD_SPARKLE_SIGN_UPDATE }}
       SPARKLE_FRAMEWORK_PATH: ${{ secrets.SPARKLE_FRAMEWORK_PATH }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
       - name: Derive release metadata

--- a/.github/workflows/security-pr.yml
+++ b/.github/workflows/security-pr.yml
@@ -43,8 +43,8 @@ jobs:
       contents: read
       pull-requests: read
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/dependency-review-action@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4
         with:
           fail-on-severity: high
 
@@ -61,8 +61,8 @@ jobs:
       contents: read
       security-events: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: github/codeql-action/init@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4
         with:
           languages: ${{ inputs.codeql-languages }}
       - name: Repo build hook
@@ -72,7 +72,7 @@ jobs:
           else
             echo "No scripts/ci/run-security-build.sh hook; continuing without a custom build."
           fi
-      - uses: github/codeql-action/analyze@v4
+      - uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4
 
   osv:
     name: osv
@@ -86,7 +86,7 @@ jobs:
       contents: read
       security-events: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Repo OSV hook
         run: |
           if [[ -x scripts/ci/run-osv.sh ]]; then
@@ -108,7 +108,7 @@ jobs:
       contents: read
       security-events: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Repo Semgrep hook
         env:
           SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}

--- a/docs/bootstrap/onboarding.md
+++ b/docs/bootstrap/onboarding.md
@@ -15,6 +15,7 @@ Use this checklist after the first bootstrap render or whenever `project.bootstr
 - Confirm `CONTRIBUTING.md` and `.github/PULL_REQUEST_TEMPLATE.md` are present as the required contributor and PR guidance surfaces.
 - Confirm the pull request template is present and PR Fast CI validates the required PR description sections before CI Gate can pass.
 - Confirm PR Fast CI uses the fork-safe `pull_request` event with only read permissions. It must validate Conventional titles, contributed-commit DCO trailers, changed-line accounting, and material-change ADR/reviewer evidence without accessing repository secrets.
+- Confirm every third-party `uses:` entry is a 40-character commit SHA followed by readable tag metadata. The `Validate Action Pins` check fails closed on mutable references and silently ignores local or Bootstrap-owned reusable workflows.
 - Confirm `delete branch on merge` and `allow auto-merge` are enabled when the GitHub plan supports them; otherwise record the plan-limit evidence and use the fallback merge-readiness policy.
 - Fallback merge readiness requires passing or intentionally skipped required checks, satisfied approvals, resolved conversations, no blocking review state, and a manual maintainer merge.
 

--- a/scripts/ci/check-action-pins.sh
+++ b/scripts/ci/check-action-pins.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+python3 - "${1:-.github/workflows}" <<'PY'
+import re
+import sys
+from pathlib import Path
+
+workflow_root = Path(sys.argv[1])
+uses_pattern = re.compile(r"^\s*(?:-\s+)?uses:\s*([^\s#]+)@([^\s#]+)(?:\s+#\s*(.+))?\s*$")
+sha_pattern = re.compile(r"^[0-9a-f]{40}$")
+failures = []
+checked = 0
+
+for workflow in sorted([*workflow_root.rglob("*.yml"), *workflow_root.rglob("*.yaml")]):
+    for line_number, line in enumerate(workflow.read_text().splitlines(), start=1):
+        match = uses_pattern.match(line)
+        if not match:
+            continue
+        action, ref, metadata = match.groups()
+        if action.startswith("./") or action.startswith("OMT-Global/bootstrap/"):
+            continue
+        checked += 1
+        location = f"{workflow}:{line_number}"
+        if not sha_pattern.fullmatch(ref):
+            failures.append(f"SA-ACTION-PIN-001 {location}: {action}@{ref} is not an immutable 40-character commit SHA.")
+        elif not metadata:
+            failures.append(f"SA-ACTION-PIN-002 {location}: {action} is pinned but lacks readable tag or release metadata after '#'.")
+
+if failures:
+    print("\n".join(failures), file=sys.stderr)
+    raise SystemExit(1)
+
+print(f"PASS SA-ACTION-PIN-000: validated {checked} third-party action pin(s) under {workflow_root}.")
+PY

--- a/src/archetypes.ts
+++ b/src/archetypes.ts
@@ -1068,6 +1068,46 @@ function prGovernanceScript(): string {
   `;
 }
 
+function actionPinScript(): string {
+  return dedent`
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    python3 - "\${1:-.github/workflows}" <<'PY'
+    import re
+    import sys
+    from pathlib import Path
+
+    workflow_root = Path(sys.argv[1])
+    uses_pattern = re.compile(r"^\\s*(?:-\\s+)?uses:\\s*([^\\s#]+)@([^\\s#]+)(?:\\s+#\\s*(.+))?\\s*$")
+    sha_pattern = re.compile(r"^[0-9a-f]{40}$")
+    failures = []
+    checked = 0
+
+    for workflow in sorted([*workflow_root.rglob("*.yml"), *workflow_root.rglob("*.yaml")]):
+        for line_number, line in enumerate(workflow.read_text().splitlines(), start=1):
+            match = uses_pattern.match(line)
+            if not match:
+                continue
+            action, ref, metadata = match.groups()
+            if action.startswith("./") or action.startswith("OMT-Global/bootstrap/"):
+                continue
+            checked += 1
+            location = f"{workflow}:{line_number}"
+            if not sha_pattern.fullmatch(ref):
+                failures.append(f"SA-ACTION-PIN-001 {location}: {action}@{ref} is not an immutable 40-character commit SHA.")
+            elif not metadata:
+                failures.append(f"SA-ACTION-PIN-002 {location}: {action} is pinned but lacks readable tag or release metadata after '#'.")
+
+    if failures:
+        print("\\n".join(failures), file=sys.stderr)
+        raise SystemExit(1)
+
+    print(f"PASS SA-ACTION-PIN-000: validated {checked} third-party action pin(s) under {workflow_root}.")
+    PY
+  `;
+}
+
 function releaseVerificationScript(manifest: BootstrapManifest): string {
   if (manifest.ci.customScripts.releaseVerification) {
     return `${dedent`
@@ -1405,7 +1445,7 @@ function setupSteps(manifest: BootstrapManifest): string {
 
   if (manifest.archetype.kind === "nextjs-web" || manifest.archetype.kind === "node-ts-service") {
     lines.push(
-      `- uses: actions/setup-node@v4`,
+      `- uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4`,
       `  with:`,
       `    node-version: \${{ env.NODE_VERSION }}`,
       `    cache: ${manifest.archetype.packageManager}`,
@@ -1421,7 +1461,7 @@ function setupSteps(manifest: BootstrapManifest): string {
 
   if (manifest.archetype.kind === "python-service") {
     lines.push(
-      `- uses: actions/setup-python@v5`,
+      `- uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5`,
       `  with:`,
       `    python-version: \${{ env.PYTHON_VERSION }}`
     );
@@ -1743,7 +1783,7 @@ function releasePreflightReusableWorkflow(): string {
           run:
             shell: bash
         steps:
-          - uses: actions/checkout@v4
+          - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
             with:
               ref: \${{ inputs.target_ref }}
               fetch-depth: 0
@@ -1789,13 +1829,13 @@ function releasePreflightReusableWorkflow(): string {
               {"schema_version":1,"repo":"\${GITHUB_REPOSITORY}","version":"\${VERSION}","channel":"\${CHANNEL}","target_ref":"\${TARGET_REF}","target_sha":"\${target_sha}","release_issue":"\${RELEASE_ISSUE}","preflight_run_id":"\${GITHUB_RUN_ID}","checks":{"prep":"\${prep_status}","preflight":"\${preflight_status}","build":"\${build_status}"}}
               JSON
 
-          - uses: actions/upload-artifact@v4
+          - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
             with:
               name: release-package
               path: \${{ inputs.artifact_dir }}/
               retention-days: \${{ inputs.evidence_retention_days }}
 
-          - uses: actions/upload-artifact@v4
+          - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
             with:
               name: \${{ inputs.evidence_artifact_name }}
               path: |
@@ -1832,7 +1872,7 @@ function fullReleaseValidationReusableWorkflow(): string {
           run:
             shell: bash
         steps:
-          - uses: actions/checkout@v4
+          - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
             with:
               ref: \${{ inputs.target_ref }}
               fetch-depth: 0
@@ -1859,7 +1899,7 @@ function fullReleaseValidationReusableWorkflow(): string {
               cat >"$ARTIFACT_DIR/validation-evidence.json" <<JSON
               {"schema_version":1,"repo":"\${GITHUB_REPOSITORY}","target_ref":"\${TARGET_REF}","target_sha":"\${target_sha}","validation_run_id":"\${GITHUB_RUN_ID}","release_profile":"\${RELEASE_PROFILE}","checks":{"validate_script":"\${validate_status}","standard_checks":"\${standard_status}"}}
               JSON
-          - uses: actions/upload-artifact@v4
+          - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
             with:
               name: \${{ inputs.evidence_artifact_name }}-validation
               path: \${{ inputs.artifact_dir }}/validation-evidence.json
@@ -1910,7 +1950,7 @@ function releasePublishReusableWorkflow(): string {
           run:
             shell: bash
         steps:
-          - uses: actions/checkout@v4
+          - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
             with:
               ref: \${{ inputs.tag }}
               fetch-depth: 0
@@ -2025,7 +2065,7 @@ function releasePublishReusableWorkflow(): string {
                 exit 1
               fi
               printf '{"schema_version":1,"repo":"%s","tag":"%s","tag_sha":"%s","publish_run_id":"%s"}\\n' "$GITHUB_REPOSITORY" "$TAG" "$tag_sha" "$GITHUB_RUN_ID" >"$ARTIFACT_DIR/postpublish-evidence.json"
-          - uses: actions/upload-artifact@v4
+          - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
             with:
               name: \${{ inputs.evidence_artifact_name }}-publish
               path: \${{ inputs.artifact_dir }}/postpublish-evidence.json
@@ -2057,7 +2097,7 @@ function releasePostpublishReusableWorkflow(): string {
           run:
             shell: bash
         steps:
-          - uses: actions/checkout@v4
+          - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
             with:
               ref: \${{ inputs.tag }}
               fetch-depth: 0
@@ -2082,7 +2122,7 @@ function releasePostpublishReusableWorkflow(): string {
                 exit 1
               fi
               printf '{"schema_version":1,"repo":"%s","tag":"%s","channel":"%s","release_issue":"%s","postpublish_run_id":"%s","release_assets":%s}\\n' "$GITHUB_REPOSITORY" "$TAG" "$CHANNEL" "$RELEASE_ISSUE" "$GITHUB_RUN_ID" "$asset_count" >"$ARTIFACT_DIR/postpublish-evidence.json"
-          - uses: actions/upload-artifact@v4
+          - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
             with:
               name: \${{ inputs.evidence_artifact_name }}-postpublish
               path: \${{ inputs.artifact_dir }}/postpublish-evidence.json
@@ -2395,7 +2435,7 @@ function prWorkflow(manifest: BootstrapManifest): string {
           app: \${{ steps.filter.outputs.app }}
           ci: \${{ steps.filter.outputs.ci }}
         steps:
-          - uses: dorny/paths-filter@v4
+          - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4
             id: filter
             with:
               filters: |
@@ -2413,7 +2453,7 @@ ${yamlList(paths.ci, 18)}
           github.event.pull_request.draft == false &&
           (needs.changes.outputs.app == 'true' || needs.changes.outputs.ci == 'true')
         steps:
-          - uses: actions/checkout@v4
+          - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
             with:
               ref: \${{ github.event.pull_request.head.sha }}
 ${indentBlock(setupSteps(manifest), 6)}
@@ -2476,7 +2516,7 @@ ${indentBlock(setupSteps(manifest), 6)}
         timeout-minutes: 10
         if: github.event.pull_request.draft == false
         steps:
-          - uses: actions/checkout@v4
+          - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
             with:
               ref: \${{ github.event.pull_request.head.sha }}
           - name: Scan repository for secret patterns
@@ -2496,11 +2536,23 @@ ${indentBlock(setupSteps(manifest), 6)}
           PR_REVIEWS_URL: \${{ github.event.pull_request.url }}/reviews
           GITHUB_TOKEN: \${{ github.token }}
         steps:
-          - uses: actions/checkout@v4
+          - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
             with:
               ref: \${{ github.event.pull_request.head.sha }}
           - name: Validate title, DCO, size, ADR, and reviewer evidence
             run: bash scripts/ci/check-pr-governance.sh
+
+      validate-action-pins:
+        name: Validate Action Pins
+        runs-on: ${shellRunner}
+        timeout-minutes: 5
+        if: github.event.pull_request.draft == false
+        steps:
+          - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+            with:
+              ref: \${{ github.event.pull_request.head.sha }}
+          - name: Require immutable third-party action pins
+            run: bash scripts/ci/check-action-pins.sh
 
       ci-gate:
         name: ${primaryRequiredStatusCheck(manifest)}
@@ -2512,6 +2564,7 @@ ${indentBlock(setupSteps(manifest), 6)}
           - validate-pr-description
           - validate-secrets
           - validate-pr-governance
+          - validate-action-pins
         steps:
           - name: Check required PR jobs
             env:
@@ -2521,6 +2574,7 @@ ${indentBlock(setupSteps(manifest), 6)}
                 validate-pr-description=\${{ needs.validate-pr-description.result }}
                 validate-secrets=\${{ needs.validate-secrets.result }}
                 validate-pr-governance=\${{ needs.validate-pr-governance.result }}
+                validate-action-pins=\${{ needs.validate-action-pins.result }}
             run: |
               failed=0
               for entry in $RESULTS; do
@@ -2575,7 +2629,7 @@ function extendedWorkflow(manifest: BootstrapManifest): string {
           ci: \${{ steps.preset.outputs.ci || steps.filter.outputs.ci || 'false' }}
           extended: \${{ steps.preset.outputs.extended || steps.filter.outputs.extended || 'false' }}
         steps:
-          - uses: actions/checkout@v4
+          - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
             if: github.event_name == 'push'
             with:
               fetch-depth: 0
@@ -2590,7 +2644,7 @@ function extendedWorkflow(manifest: BootstrapManifest): string {
               extended=true
               EOF
 
-          - uses: dorny/paths-filter@v4
+          - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4
             id: filter
             if: github.event_name == 'push'
             with:
@@ -2609,7 +2663,7 @@ ${yamlList(paths.extended, 18)}
         needs: changes
         if: needs.changes.outputs.app == 'true' || needs.changes.outputs.ci == 'true'
         steps:
-          - uses: actions/checkout@v4
+          - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 ${indentBlock(setupSteps(manifest), 6)}
           - name: Run fast checks
             run: bash scripts/ci/run-fast-checks.sh
@@ -2621,7 +2675,7 @@ ${indentBlock(setupSteps(manifest), 6)}
         needs: changes
         if: needs.changes.outputs.extended == 'true' || needs.changes.outputs.app == 'true'
         steps:
-          - uses: actions/checkout@v4
+          - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 ${indentBlock(setupSteps(manifest), 6)}
           - name: Run extended validation
             run: bash scripts/ci/run-extended-validation.sh
@@ -2631,7 +2685,7 @@ ${indentBlock(setupSteps(manifest), 6)}
         runs-on: ${shellRunner}
         timeout-minutes: 10
         steps:
-          - uses: actions/checkout@v4
+          - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
           - name: Scan repository for secret patterns
             run: bash scripts/check-detect-secrets.sh --all-files
 
@@ -3046,9 +3100,9 @@ function claudeWorkflow(manifest: BootstrapManifest): string {
         runs-on: ubuntu-latest
         timeout-minutes: 30
         steps:
-          - uses: actions/checkout@v4
+          - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
           - name: Run Claude Code
-            uses: anthropics/claude-code-action@v1
+            uses: anthropics/claude-code-action@e90deca47693f9457b72f2b53c17d7c445a87342 # v1
             with:
               anthropic_api_key: \${{ secrets.ANTHROPIC_API_KEY }}
               prompt: |
@@ -3336,6 +3390,12 @@ export function renderManagedFiles(manifest: BootstrapManifest): RenderedFile[] 
       path: "scripts/ci/check-pr-governance.sh",
       reason: "Fork-safe pull request governance validation",
       contents: `${prGovernanceScript()}\n`,
+      executable: true
+    },
+    {
+      path: "scripts/ci/check-action-pins.sh",
+      reason: "Immutable third-party action pin validation",
+      contents: `${actionPinScript()}\n`,
       executable: true
     },
     ...(manifest.release.enabled

--- a/tests/__snapshots__/render.test.ts.snap
+++ b/tests/__snapshots__/render.test.ts.snap
@@ -76,6 +76,10 @@ exports[`renderManagedFiles > renders a stable managed file set for generic-empt
   },
   {
     "executable": true,
+    "path": "scripts/ci/check-action-pins.sh",
+  },
+  {
+    "executable": true,
     "path": "scripts/ci/run-release-verification.sh",
   },
   {
@@ -190,6 +194,10 @@ exports[`renderManagedFiles > renders a stable managed file set for nextjs-web 1
   {
     "executable": true,
     "path": "scripts/ci/check-pr-governance.sh",
+  },
+  {
+    "executable": true,
+    "path": "scripts/ci/check-action-pins.sh",
   },
   {
     "executable": true,
@@ -318,6 +326,10 @@ exports[`renderManagedFiles > renders a stable managed file set for node-ts-serv
   },
   {
     "executable": true,
+    "path": "scripts/ci/check-action-pins.sh",
+  },
+  {
+    "executable": true,
     "path": "scripts/ci/run-release-verification.sh",
   },
   {
@@ -432,6 +444,10 @@ exports[`renderManagedFiles > renders a stable managed file set for python-servi
   {
     "executable": true,
     "path": "scripts/ci/check-pr-governance.sh",
+  },
+  {
+    "executable": true,
+    "path": "scripts/ci/check-action-pins.sh",
   },
   {
     "executable": true,

--- a/tests/action-pins.test.ts
+++ b/tests/action-pins.test.ts
@@ -1,0 +1,37 @@
+import { spawn } from "node:child_process";
+import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+async function runPinCheck(workflow: string) {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "bootstrap-action-pins-"));
+  const workflows = path.join(directory, ".github", "workflows");
+  await mkdir(workflows, { recursive: true });
+  await writeFile(path.join(workflows, "fixture.yml"), workflow);
+  return new Promise<{ code: number; output: string }>((resolve, reject) => {
+    const child = spawn("bash", [path.resolve("scripts/ci/check-action-pins.sh"), workflows]);
+    let output = "";
+    child.stdout.on("data", (chunk) => (output += chunk));
+    child.stderr.on("data", (chunk) => (output += chunk));
+    child.on("error", reject);
+    child.on("close", (code) => resolve({ code: code ?? 1, output }));
+  });
+}
+
+describe("check-action-pins", () => {
+  it("rejects mutable third-party references and pins without update metadata", async () => {
+    const result = await runPinCheck(`jobs:\n  check:\n    steps:\n      - uses: actions/checkout@v4\n      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706\n`);
+
+    expect(result.code).toBe(1);
+    expect(result.output).toContain("SA-ACTION-PIN-001");
+    expect(result.output).toContain("SA-ACTION-PIN-002");
+  });
+
+  it("accepts immutable pins with readable metadata and Bootstrap-owned reusable workflows", async () => {
+    const result = await runPinCheck(`jobs:\n  check:\n    steps:\n      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4\n  reuse:\n    uses: OMT-Global/bootstrap/.github/workflows/security-pr.yml@refs/heads/main\n`);
+
+    expect(result.code).toBe(0);
+    expect(result.output).toContain("validated 1 third-party action pin");
+  });
+});

--- a/tests/render.test.ts
+++ b/tests/render.test.ts
@@ -42,9 +42,9 @@ describe("renderManagedFiles", () => {
       const prWorkflow = files.find((file) => file.path === ".github/workflows/pr-fast-ci.yml");
       const extendedValidationWorkflow = files.find((file) => file.path === ".github/workflows/extended-validation.yml");
       expect(prWorkflow?.contents).toContain("name: CI Gate");
-      expect(prWorkflow?.contents).toContain("dorny/paths-filter@v4");
+      expect(prWorkflow?.contents).toContain("dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4");
       expect(prWorkflow?.contents).not.toContain("dorny/paths-filter@v3");
-      expect(extendedValidationWorkflow?.contents).toContain("dorny/paths-filter@v4");
+      expect(extendedValidationWorkflow?.contents).toContain("dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4");
       expect(extendedValidationWorkflow?.contents).not.toContain("dorny/paths-filter@v3");
       expect(prWorkflow?.contents).toContain("types: [opened, edited, synchronize, reopened, ready_for_review]");
       expect(prWorkflow?.contents).toContain("['self-hosted', 'linux'");
@@ -59,6 +59,8 @@ describe("renderManagedFiles", () => {
       expect(prWorkflow?.contents).toContain("pull-requests: read");
       expect(prWorkflow?.contents).toContain("PR_COMMITS_URL:");
       expect(files.find((file) => file.path === "scripts/ci/check-pr-governance.sh")?.contents).toContain("PRS-DCO-001");
+      expect(prWorkflow?.contents).toContain("validate-action-pins:");
+      expect(files.find((file) => file.path === "scripts/ci/check-action-pins.sh")?.contents).toContain("SA-ACTION-PIN-001");
 
       const prTemplate = files.find((file) => file.path === ".github/PULL_REQUEST_TEMPLATE.md");
       const dependabot = files.find((file) => file.path === ".github/dependabot.yml");
@@ -272,10 +274,10 @@ describe("renderManagedFiles", () => {
     expect(renderedManifest?.contents).toContain("version: 2");
     expect(renderedManifest?.contents).toContain("capabilities:");
     expect(renderedManifest?.contents).not.toContain("\nrelease:\n");
-    expect(prWorkflow?.contents).toContain("dorny/paths-filter@v4");
+    expect(prWorkflow?.contents).toContain("dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4");
     expect(prWorkflow?.contents).not.toContain("dorny/paths-filter@v3");
     expect(claudeWorkflow?.contents).toContain("name: Claude Code");
-    expect(claudeWorkflow?.contents).toContain("anthropics/claude-code-action@v1");
+    expect(claudeWorkflow?.contents).toContain("anthropics/claude-code-action@e90deca47693f9457b72f2b53c17d7c445a87342 # v1");
   });
 
   it("documents required PR template enforcement in generated agent instructions", () => {

--- a/tests/reusable-workflows.test.ts
+++ b/tests/reusable-workflows.test.ts
@@ -97,7 +97,7 @@ describe("reusable workflows", () => {
     expect((preflight.on as any).workflow_call.inputs.version.required).toBe(true);
     expect((validation.on as any).workflow_call.inputs.evidence_artifact_name.default).toBe("release-evidence");
     expect((validation.on as any).workflow_call.inputs.release_package_artifact_name).toBeUndefined();
-    expect((validation.jobs as any).validate.steps.some((step: any) => step.uses === "actions/upload-artifact@v4" && step.with?.name === "${{ inputs.evidence_artifact_name }}-validation")).toBe(true);
+    expect((validation.jobs as any).validate.steps.some((step: any) => step.uses === "actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02" && step.with?.name === "${{ inputs.evidence_artifact_name }}-validation")).toBe(true);
     expect((preflight.jobs as any).preflight).toBeTruthy();
     expect(validation.name).toBe("Reusable Full Release Validation");
     expect((validation.jobs as any).validate).toBeTruthy();


### PR DESCRIPTION
## Summary

- Pin Bootstrap’s third-party GitHub Actions to immutable commits and retain their released tag as inline update metadata.
- Add a fail-closed CI scanner plus generated-workflow projection and adversarial mutable/missing-metadata fixtures.

## Governing Issue

Refs #60

## Validation

- [x] `npm test` (83 tests)
- [x] `npm run build`
- [x] `bash scripts/ci/check-action-pins.sh` (32 third-party action pins)
- [x] `git diff --check`

## Bootstrap Governance

- [x] The scanner runs in the existing fork-safe `pull_request` workflow and requires only repository contents already checked out for CI.
- [x] Bootstrap projects the same pin policy into generated PR and release workflows.
- [x] No real secrets, runtime auth, or machine-local environment files are included.

Material change: no

## Merge Automation

- Auto-merge is enabled once CI passes. If the integration branch remains externally review-blocked, the documented fallback merge-readiness policy applies.

## Notes

- This is the immutable third-party action-pin slice of #60. SBOM/reporting and plan-capability projection remain separate security slices.
