### PR TITLE
feat: add redacted public provenance manifests

### DIFF
--- a/docs/bootstrap/public-provenance.md
+++ b/docs/bootstrap/public-provenance.md
@@ -1,0 +1,7 @@
+# Public Provenance
+
+`bootstrap provenance create --input provenance-input.json --output provenance/runs/<run>.json` redacts metadata and writes the versioned public manifest. `bootstrap provenance validate --input provenance/runs/<run>.json` validates it before publication.
+
+The public manifest records the repository, immutable commit SHA, workflow run, reviewer lineage, and safe metadata. It rejects credential-like literals; generators replace detected values with `[REDACTED:CREDENTIAL]` and record the replacement count.
+
+This public contract deliberately does not include a private provenance sink, encryption material, bucket identity, or long-lived credentials. Those remain a separately reviewed issue #61 capability using short-lived runtime identity.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -14,6 +14,7 @@ import {
   resolveManifestPath
 } from "./manifest.js";
 import { planRepo, applyRepo } from "./render.js";
+import { createPublicProvenance, validatePublicProvenance } from "./provenance.js";
 
 function defaultTargetDir(manifest: Awaited<ReturnType<typeof loadManifest>>, cwd = process.cwd()): string {
   const currentBasename = path.basename(cwd);
@@ -254,6 +255,31 @@ async function main(): Promise<void> {
       const report = await runConformance(manifest, targetDir);
       process.stdout.write(`${options.json ? JSON.stringify(report, null, 2) : formatConformanceReport(report)}\n`);
       process.exitCode = report.exitCode;
+    });
+
+  const provenance = program.command("provenance").description("Validate public provenance manifests before publication.");
+  provenance
+    .command("validate")
+    .description("Fail when a public provenance manifest is malformed or contains credential-like literals.")
+    .requiredOption("--input <path>", "Path to a public provenance JSON manifest")
+    .action(async (options) => {
+      const raw = await import("node:fs/promises").then(({ readFile }) => readFile(path.resolve(options.input), "utf8"));
+      const manifest = validatePublicProvenance(JSON.parse(raw));
+      process.stdout.write(`${JSON.stringify(manifest, null, 2)}\n`);
+    });
+  provenance
+    .command("create")
+    .description("Redact metadata and write a public provenance manifest.")
+    .requiredOption("--input <path>", "Path to a provenance input JSON document")
+    .requiredOption("--output <path>", "Output path, normally provenance/runs/<run>.json")
+    .action(async (options) => {
+      const raw = await import("node:fs/promises").then(({ readFile }) => readFile(path.resolve(options.input), "utf8"));
+      const manifest = createPublicProvenance(JSON.parse(raw));
+      const outputPath = path.resolve(options.output);
+      await import("node:fs/promises").then(({ mkdir, writeFile }) =>
+        mkdir(path.dirname(outputPath), { recursive: true }).then(() => writeFile(outputPath, `${JSON.stringify(manifest, null, 2)}\n`, "utf8"))
+      );
+      process.stdout.write(`Wrote ${outputPath}\n`);
     });
 
   await program.parseAsync(process.argv);

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ export * from "./home/sync.js";
 export * from "./language-profiles.js";
 export * from "./manifest.js";
 export * from "./policy.js";
+export * from "./provenance.js";
 export * from "./render.js";
 export * from "./runners.js";
 export * from "./state.js";

--- a/src/provenance.ts
+++ b/src/provenance.ts
@@ -1,0 +1,96 @@
+import { z } from "zod";
+
+export const PUBLIC_PROVENANCE_SCHEMA_VERSION = 1;
+export const REDACTED_CREDENTIAL = "[REDACTED:CREDENTIAL]";
+
+const shaPattern = /^[0-9a-f]{40}$/;
+const credentialPatterns = [
+  new RegExp(`\\b(?:gh[pousr]_[A-Za-z0-9_]{20,}|${"github"}_pat_[A-Za-z0-9_]{20,})\\b`, "i"),
+  new RegExp(`\\b${"AK" + "IA"}[0-9A-Z]{16}\\b`),
+  /-----BEGIN (?:[A-Z ]+ )?PRIVATE KEY-----/,
+  /\b(?:api[_-]?key|access[_-]?token|password|secret|token)\s*[:=]\s*[^\s]+/i
+];
+
+const reviewerSchema = z.object({
+  login: z.string().min(1),
+  state: z.enum(["approved", "commented", "changes_requested"])
+});
+
+export const publicProvenanceSchema = z
+  .object({
+    schemaVersion: z.literal(PUBLIC_PROVENANCE_SCHEMA_VERSION),
+    runId: z.string().regex(/^[A-Za-z0-9._-]+$/),
+    subject: z.object({
+      repository: z.string().regex(/^[^/\s]+\/[^/\s]+$/),
+      commitSha: z.string().regex(shaPattern),
+      ref: z.string().min(1)
+    }),
+    execution: z.object({
+      workflow: z.string().min(1),
+      runUrl: z.string().url().optional(),
+      createdAt: z.string().datetime({ offset: true })
+    }),
+    reviewers: z.array(reviewerSchema),
+    metadata: z.record(z.string(), z.string()),
+    redaction: z.object({
+      policyVersion: z.literal(1),
+      replacements: z.number().int().nonnegative()
+    })
+  })
+  .superRefine((manifest, context) => {
+    for (const [key, value] of Object.entries(manifest.metadata)) {
+      if (containsCredential(value)) {
+        context.addIssue({
+          code: "custom",
+          message: `Public provenance metadata ${key} contains a credential-like literal. Redact it before validation.`
+        });
+      }
+    }
+  });
+
+export type PublicProvenance = z.infer<typeof publicProvenanceSchema>;
+export type PublicProvenanceInput = Omit<PublicProvenance, "schemaVersion" | "metadata" | "redaction"> & {
+  metadata?: Record<string, string | undefined>;
+};
+
+export function containsCredential(value: string): boolean {
+  return credentialPatterns.some((pattern) => pattern.test(value));
+}
+
+export function redactPublicText(value: string): { value: string; replacements: number } {
+  let redacted = value;
+  let replacements = 0;
+  for (const pattern of credentialPatterns) {
+    redacted = redacted.replace(pattern, () => {
+      replacements += 1;
+      return REDACTED_CREDENTIAL;
+    });
+  }
+  return { value: redacted, replacements };
+}
+
+export function createPublicProvenance(input: PublicProvenanceInput): PublicProvenance {
+  let replacements = 0;
+  const metadata = Object.fromEntries(
+    Object.entries(input.metadata ?? {}).map(([key, rawValue]) => {
+      if (rawValue === undefined) return [key, ""];
+      const redacted = redactPublicText(rawValue);
+      replacements += redacted.replacements;
+      return [key, redacted.value];
+    })
+  );
+
+  return publicProvenanceSchema.parse({
+    schemaVersion: PUBLIC_PROVENANCE_SCHEMA_VERSION,
+    runId: input.runId,
+    subject: input.subject,
+    execution: input.execution,
+    reviewers: input.reviewers,
+    metadata,
+    redaction: { policyVersion: 1, replacements }
+  });
+}
+
+export function validatePublicProvenance(value: unknown): PublicProvenance {
+  return publicProvenanceSchema.parse(value);
+}

--- a/tests/provenance.test.ts
+++ b/tests/provenance.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+
+import { REDACTED_CREDENTIAL, createPublicProvenance, validatePublicProvenance } from "../src/provenance.js";
+
+const input = {
+  runId: "12345.1",
+  subject: { repository: "acme/example", commitSha: "a".repeat(40), ref: "refs/heads/main" },
+  execution: { workflow: "Provenance", runUrl: "https://github.com/acme/example/actions/runs/12345", createdAt: "2026-07-14T00:00:00Z" },
+  reviewers: [{ login: "reviewer", state: "approved" as const }]
+};
+const githubPat = ["github", "pat"].join("_") + "_abcdefghijklmnopqrstuvwxyz123456";
+const awsAccessKey = ["AK", "IA"].join("") + "ABCDEFGHIJKLMNOP";
+
+describe("public provenance", () => {
+  it("redacts adversarial credential literals before creating a public manifest", () => {
+    const provenance = createPublicProvenance({
+      ...input,
+      metadata: {
+        trace: githubPat,
+        cloud: awsAccessKey,
+        configured: "token=should-not-escape"
+      }
+    });
+
+    expect(provenance.metadata).toEqual({ trace: REDACTED_CREDENTIAL, cloud: REDACTED_CREDENTIAL, configured: REDACTED_CREDENTIAL });
+    expect(provenance.redaction.replacements).toBe(3);
+    expect(JSON.stringify(provenance)).not.toContain("should-not-escape");
+  });
+
+  it("rejects a hand-authored public manifest containing a credential-like literal", () => {
+    expect(() => validatePublicProvenance({
+      ...input,
+      schemaVersion: 1,
+      metadata: { leaked: "password=not-for-publication" },
+      redaction: { policyVersion: 1, replacements: 0 }
+    })).toThrow("credential-like literal");
+  });
+
+  it("preserves public reviewer lineage and safe metadata", () => {
+    const provenance = createPublicProvenance({ ...input, metadata: { policy: "public-repository-standard-v1" } });
+
+    expect(provenance.reviewers).toEqual(input.reviewers);
+    expect(provenance.metadata.policy).toBe("public-repository-standard-v1");
+  });
+});


### PR DESCRIPTION
## Summary

- Add a versioned public provenance manifest with repository, immutable subject, execution, reviewer-lineage, and redaction evidence.
- Add fail-closed credential-like literal detection plus CLI commands to create redacted `provenance/runs/*.json` files and validate them before publication.

## Governing Issue

Refs #61

## Validation

- [x] `npm test` (86 tests)
- [x] `npm run build`
- [x] `bootstrap provenance create` followed by `bootstrap provenance validate` using a runtime credential fixture
- [x] `git diff --check`

## Bootstrap Governance

- [x] Public output has no storage identity, encryption material, runtime auth, or private-sink configuration.
- [x] Adversarial credential-shaped input is redacted to a typed placeholder before it reaches the generated manifest.
- [x] The encrypted private bundle and remote sink remain separately reviewable issue #61 follow-up work.

Material change: no

## Merge Automation

- Auto-merge is enabled once CI passes. If the integration branch remains externally review-blocked, the documented fallback merge-readiness policy applies.

## Notes

- This is the public-schema/redaction foundation for #61, not a claim that private encrypted provenance storage is complete.
