### PR TITLE
feat: plan governed fleet policy upgrades

### DIFF
--- a/docs/bootstrap/fleet-policy-upgrades.md
+++ b/docs/bootstrap/fleet-policy-upgrades.md
@@ -1,0 +1,7 @@
+# Fleet Policy Upgrades
+
+Use `bootstrap upgrade-plan --input inventory.json --json` to produce a non-mutating inventory before opening any upgrade PRs.
+
+Each inventory entry records repository, class, current and target exact SemVer policy versions, optional exception, and pilot outcome. Patch upgrades become eligible only after a passing first representative per class; failed pilots block the remaining class batch. Minor upgrades require independent review; major upgrades require notification and an accepted ADR.
+
+This planner deliberately does not create PRs or merge upgrades. Operators must attach policy diff, validation, exceptions, and provenance evidence to the governed PR after the dry run is approved.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -15,6 +15,7 @@ import {
 } from "./manifest.js";
 import { planRepo, applyRepo } from "./render.js";
 import { createPublicProvenance, validatePublicProvenance } from "./provenance.js";
+import { planFleetPolicyUpgrades, type FleetUpgradeCandidate } from "./upgrades.js";
 
 function defaultTargetDir(manifest: Awaited<ReturnType<typeof loadManifest>>, cwd = process.cwd()): string {
   const currentBasename = path.basename(cwd);
@@ -184,6 +185,21 @@ async function main(): Promise<void> {
       }
 
       process.stdout.write(`${formatFleetReport(report)}\n`);
+    });
+
+  program
+    .command("upgrade-plan")
+    .description("Dry-run version-aware fleet policy upgrade inventory; never opens pull requests or mutates repositories.")
+    .requiredOption("--input <path>", "JSON array of fleet upgrade candidates")
+    .option("--json", "Emit JSON")
+    .action(async (options) => {
+      const raw = await import("node:fs/promises").then(({ readFile }) => readFile(path.resolve(options.input), "utf8"));
+      const plan = planFleetPolicyUpgrades(JSON.parse(raw) as FleetUpgradeCandidate[]);
+      if (options.json) {
+        process.stdout.write(`${JSON.stringify(plan, null, 2)}\n`);
+        return;
+      }
+      process.stdout.write(`${plan.map((entry) => `- [${entry.status}] ${entry.repo} (${entry.repoClass}, ${entry.risk}, ${entry.role}): ${entry.reason}`).join("\n")}\n`);
     });
 
   const apply = program.command("apply").description("Apply one bootstrap target.");

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,3 +13,4 @@ export * from "./render.js";
 export * from "./runners.js";
 export * from "./state.js";
 export * from "./types.js";
+export * from "./upgrades.js";

--- a/src/upgrades.ts
+++ b/src/upgrades.ts
@@ -1,0 +1,58 @@
+export type UpgradeRisk = "patch" | "minor" | "major" | "invalid";
+export type PilotOutcome = "pending" | "passed" | "failed";
+
+export interface FleetUpgradeCandidate {
+  repo: string;
+  repoClass: string;
+  currentPolicy: string;
+  targetPolicy: string;
+  exceptionId?: string;
+  pilotOutcome?: PilotOutcome;
+}
+
+export interface FleetUpgradePlanEntry extends FleetUpgradeCandidate {
+  risk: UpgradeRisk;
+  role: "pilot" | "batch";
+  status: "eligible" | "review-required" | "blocked";
+  reason: string;
+}
+
+type Semver = { major: number; minor: number; patch: number };
+
+function parseVersion(value: string): Semver | undefined {
+  const match = /^v?(\d+)\.(\d+)\.(\d+)$/.exec(value);
+  return match
+    ? { major: Number(match[1]), minor: Number(match[2]), patch: Number(match[3]) }
+    : undefined;
+}
+
+export function classifyPolicyUpgrade(currentPolicy: string, targetPolicy: string): UpgradeRisk {
+  const current = parseVersion(currentPolicy);
+  const target = parseVersion(targetPolicy);
+  if (!current || !target || target.major < current.major || (target.major === current.major && target.minor < current.minor) || (target.major === current.major && target.minor === current.minor && target.patch < current.patch)) {
+    return "invalid";
+  }
+  if (target.major !== current.major) return "major";
+  if (target.minor !== current.minor) return "minor";
+  return "patch";
+}
+
+export function planFleetPolicyUpgrades(candidates: FleetUpgradeCandidate[]): FleetUpgradePlanEntry[] {
+  const pilots = new Map<string, PilotOutcome>();
+  return [...candidates]
+    .sort((left, right) => left.repoClass.localeCompare(right.repoClass) || left.repo.localeCompare(right.repo))
+    .map((candidate) => {
+      const risk = classifyPolicyUpgrade(candidate.currentPolicy, candidate.targetPolicy);
+      const knownPilot = pilots.get(candidate.repoClass);
+      const role = knownPilot === undefined ? "pilot" : "batch";
+      if (role === "pilot") pilots.set(candidate.repoClass, candidate.pilotOutcome ?? "pending");
+
+      if (risk === "invalid") return { ...candidate, risk, role, status: "blocked", reason: "Policy versions must be increasing exact SemVer values." };
+      if (knownPilot === "failed") return { ...candidate, risk, role, status: "blocked", reason: `The ${candidate.repoClass} pilot failed; stop this batch until remediation is recorded.` };
+      if (candidate.exceptionId) return { ...candidate, risk, role, status: "review-required", reason: `Exception ${candidate.exceptionId} requires human review before a fleet upgrade PR.` };
+      if (risk === "major") return { ...candidate, risk, role, status: "review-required", reason: "Major upgrades require notification and an accepted ADR before opening a PR." };
+      if (risk === "minor") return { ...candidate, risk, role, status: "review-required", reason: "Minor upgrades require independent review before merge." };
+      if (role === "pilot" && (candidate.pilotOutcome ?? "pending") !== "passed") return { ...candidate, risk, role, status: "review-required", reason: "Record a passing representative pilot before rolling this class forward." };
+      return { ...candidate, risk, role, status: "eligible", reason: "Patch upgrade is eligible after the representative class pilot passed." };
+    });
+}

--- a/tests/upgrades.test.ts
+++ b/tests/upgrades.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+
+import { classifyPolicyUpgrade, planFleetPolicyUpgrades } from "../src/upgrades.js";
+
+describe("fleet policy upgrades", () => {
+  it("classifies patch, minor, major, and invalid policy versions", () => {
+    expect(classifyPolicyUpgrade("1.2.3", "1.2.4")).toBe("patch");
+    expect(classifyPolicyUpgrade("1.2.3", "1.3.0")).toBe("minor");
+    expect(classifyPolicyUpgrade("1.2.3", "2.0.0")).toBe("major");
+    expect(classifyPolicyUpgrade("1.2.3", "1.2.2")).toBe("invalid");
+  });
+
+  it("requires a first-class pilot and stops later candidates after a failed pilot", () => {
+    const plan = planFleetPolicyUpgrades([
+      { repo: "acme/service-a", repoClass: "service", currentPolicy: "1.0.0", targetPolicy: "1.0.1", pilotOutcome: "failed" },
+      { repo: "acme/service-b", repoClass: "service", currentPolicy: "1.0.0", targetPolicy: "1.0.1" },
+      { repo: "acme/cli-a", repoClass: "cli", currentPolicy: "1.0.0", targetPolicy: "1.0.1", pilotOutcome: "passed" },
+      { repo: "acme/cli-b", repoClass: "cli", currentPolicy: "1.0.0", targetPolicy: "1.0.1" }
+    ]);
+
+    expect(plan.find((entry) => entry.repo === "acme/cli-a")).toMatchObject({ role: "pilot", status: "eligible" });
+    expect(plan.find((entry) => entry.repo === "acme/cli-b")).toMatchObject({ role: "batch", status: "eligible" });
+    expect(plan.find((entry) => entry.repo === "acme/service-a")).toMatchObject({ role: "pilot", status: "review-required" });
+    expect(plan.find((entry) => entry.repo === "acme/service-b")).toMatchObject({ role: "batch", status: "blocked" });
+  });
+
+  it("routes minor, major, and exception upgrades to human review", () => {
+    const plan = planFleetPolicyUpgrades([
+      { repo: "acme/minor", repoClass: "cli", currentPolicy: "1.0.0", targetPolicy: "1.1.0", pilotOutcome: "passed" },
+      { repo: "acme/major", repoClass: "service", currentPolicy: "1.0.0", targetPolicy: "2.0.0", pilotOutcome: "passed" },
+      { repo: "acme/excepted", repoClass: "library", currentPolicy: "1.0.0", targetPolicy: "1.0.1", exceptionId: "EX-1", pilotOutcome: "passed" }
+    ]);
+
+    expect(plan.map((entry) => entry.status)).toEqual(["review-required", "review-required", "review-required"]);
+  });
+});


### PR DESCRIPTION
## Summary

- Add a dry-run fleet policy upgrade planner with exact SemVer risk classification.
- Gate patch rollout on a representative class pilot, stop batches after failures, and route minor, major, and exception upgrades to human review.

## Governing Issue

Refs #62

## Validation

- [x] `npm test` (89 tests)
- [x] `npm run build`
- [x] `git diff --check`

## Bootstrap Governance

- [x] `bootstrap upgrade-plan` is read-only and never creates pull requests or mutates repositories.
- [x] Output makes pilot, exception, review, and ADR requirements explicit before an operator begins rollout.

Material change: no

## Merge Automation

- Auto-merge is enabled once CI passes. If the integration branch remains externally review-blocked, the fallback merge-readiness policy applies.

## Notes

- This is the dry-run batching foundation for #62; PR creation and provenance attachment remain later guarded steps.
