### PR TITLE
feat: validate immutable production workflow refs

### DIFF
--- a/src/policy.ts
+++ b/src/policy.ts
@@ -36,8 +36,14 @@ function stableJson(value: unknown): string {
   return JSON.stringify(value);
 }
 
-function isImmutablePolicyRef(ref: string): boolean {
+export function isImmutablePolicyRef(ref: string): boolean {
   return /^refs\/tags\/v\d+\.\d+\.\d+$/.test(ref) || /^[0-9a-f]{40}$/i.test(ref);
+}
+
+export function requireImmutableProductionWorkflowRef(ref: string, surface = "Production workflow"): void {
+  if (!isImmutablePolicyRef(ref)) {
+    throw new Error(`${surface} ref must be an exact vX.Y.Z tag or immutable 40-character SHA; ${JSON.stringify(ref)} is mutable.`);
+  }
 }
 
 export function flowPolicyDigest(bundle: unknown): string {

--- a/tests/policy.test.ts
+++ b/tests/policy.test.ts
@@ -4,7 +4,7 @@ import os from "node:os";
 import path from "node:path";
 
 import { normalizeManifest } from "../src/manifest.js";
-import { flowPolicyDigest, loadResolvedFlowPolicy, resolveFlowPolicy } from "../src/policy.js";
+import { flowPolicyDigest, loadResolvedFlowPolicy, requireImmutableProductionWorkflowRef, resolveFlowPolicy } from "../src/policy.js";
 
 const bundle = { standard: "public-repository-standard" as const, version: "1.0.0", publisher: { identitySource: "publisherKey" } };
 const manifest = normalizeManifest({ project: { name: "example", owner: "acme" }, archetype: { kind: "generic-empty" } });
@@ -36,5 +36,14 @@ describe("resolveFlowPolicy", () => {
     expect(() => resolveFlowPolicy(manifest, bundle, { ref: "refs/heads/main", sha256: flowPolicyDigest(bundle) })).toThrow("exact release tag");
     expect(() => resolveFlowPolicy(manifest, bundle, { ref: "refs/tags/v1.0.0", sha256: "0".repeat(64) })).toThrow("digest does not match");
     expect(() => resolveFlowPolicy(manifest, { standard: "other", version: "1.0.0" }, { ref: "0123456789012345678901234567890123456789", sha256: flowPolicyDigest({ standard: "other", version: "1.0.0" }) })).toThrow("compatible");
+  });
+});
+
+describe("requireImmutableProductionWorkflowRef", () => {
+  it("rejects branch and floating tag references while accepting exact tags and SHAs", () => {
+    expect(() => requireImmutableProductionWorkflowRef("refs/heads/main", "Release workflow")).toThrow("mutable");
+    expect(() => requireImmutableProductionWorkflowRef("refs/tags/v1", "Release workflow")).toThrow("mutable");
+    expect(() => requireImmutableProductionWorkflowRef("refs/tags/v1.2.3", "Release workflow")).not.toThrow();
+    expect(() => requireImmutableProductionWorkflowRef("a".repeat(40), "Release workflow")).not.toThrow();
   });
 });


### PR DESCRIPTION
## Summary

- Add a fail-closed validator for production reusable-workflow policy references.
- Reject mutable branches and floating tags; accept only exact `vX.Y.Z` tags or immutable 40-character SHAs.

## Governing Issue

Refs #64

## Validation

- [x] `npm test` (90 tests)
- [x] `npm run build`
- [x] `git diff --check`

## Bootstrap Governance

- [x] The guard is reusable by release projection and conformance without selecting a production tag implicitly.
- [x] The actual Bootstrap production tag/pin remains an explicit maintainer release decision.

Material change: no

## Merge Automation

- Auto-merge is enabled once CI passes. If the integration branch remains externally review-blocked, the fallback merge-readiness policy applies.

## Notes

- This is the immutable-ref enforcement primitive for #64; it does not publish a release.
