### PR TITLE
fix: grandfather pre-enforcement PR governance

### DIFF
--- a/.github/workflows/pr-fast-ci.yml
+++ b/.github/workflows/pr-fast-ci.yml
@@ -3,6 +3,8 @@ name: PR Fast CI
 on:
   pull_request:
     types: [opened, edited, synchronize, reopened, ready_for_review]
+  pull_request_review:
+    types: [submitted, edited, dismissed]
 
 concurrency:
   group: pr-fast-${{ github.event.pull_request.number || github.ref }}
@@ -142,6 +144,8 @@ jobs:
       PR_TITLE: ${{ github.event.pull_request.title }}
       PR_BODY: ${{ github.event.pull_request.body }}
       PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+      PR_CREATED_AT: ${{ github.event.pull_request.created_at }}
+      PR_GOVERNANCE_ENFORCE_AFTER: '2026-07-13T23:00:00Z'
       PR_FILES_URL: ${{ github.event.pull_request.url }}/files
       PR_COMMITS_URL: ${{ github.event.pull_request.commits_url }}
       PR_REVIEWS_URL: ${{ github.event.pull_request.url }}/reviews

--- a/project.bootstrap.yaml
+++ b/project.bootstrap.yaml
@@ -171,6 +171,8 @@ ci:
     - integration
     - release-readiness
   nightlyCron: 0 7 * * *
+  prGovernance:
+    enforceAfter: 2026-07-13T23:00:00Z
   additionalWorkflows: []
   appPaths: []
   ciPaths: []

--- a/scripts/ci/check-pr-governance.sh
+++ b/scripts/ci/check-pr-governance.sh
@@ -40,17 +40,31 @@ load_response "${PR_FILES_FILE:-}" "${PR_FILES_URL:-}" "per_page=100" "$workdir/
 load_response "${PR_COMMITS_FILE:-}" "${PR_COMMITS_URL:-}" "per_page=250" "$workdir/commits.json"
 load_response "${PR_REVIEWS_FILE:-}" "${PR_REVIEWS_URL:-}" "per_page=100" "$workdir/reviews.json"
 
-python3 - "$PR_TITLE" "$PR_BODY" "$PR_AUTHOR" "$workdir/files.json" "$workdir/commits.json" "$workdir/reviews.json" <<'PY'
+python3 - "$PR_TITLE" "$PR_BODY" "$PR_AUTHOR" "${PR_CREATED_AT:-}" "${PR_GOVERNANCE_ENFORCE_AFTER:-}" "$workdir/files.json" "$workdir/commits.json" "$workdir/reviews.json" <<'PY'
+from datetime import datetime
 import json
 import re
 import sys
 from pathlib import Path
 
-title, body, author, files_path, commits_path, reviews_path = sys.argv[1:]
+title, body, author, created_at, enforce_after, files_path, commits_path, reviews_path = sys.argv[1:]
 files = json.loads(Path(files_path).read_text())
 commits = json.loads(Path(commits_path).read_text())
 reviews = json.loads(Path(reviews_path).read_text())
 failures = []
+
+if enforce_after:
+    try:
+        created_at_value = datetime.fromisoformat(created_at.replace("Z", "+00:00"))
+        enforce_after_value = datetime.fromisoformat(enforce_after.replace("Z", "+00:00"))
+        if created_at_value.tzinfo is None or enforce_after_value.tzinfo is None:
+            raise ValueError
+    except ValueError:
+        failures.append("PRS-ENFORCEMENT-INPUT-001: PR_CREATED_AT and PR_GOVERNANCE_ENFORCE_AFTER must be ISO-8601 timestamps.")
+    else:
+        if created_at_value < enforce_after_value:
+            print(f"PASS PRS-PR-GOVERNANCE-LEGACY-001: PR opened at {created_at} before enforcement began at {enforce_after}.")
+            sys.exit(0)
 
 if not re.match(r"^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\([^)]+\))?!?: .+", title):
     failures.append("PRS-PR-TITLE-001: use a Conventional Commit-style PR title, for example 'feat: add policy gate'.")

--- a/src/archetypes.ts
+++ b/src/archetypes.ts
@@ -953,7 +953,7 @@ function extendedChecksScript(manifest: BootstrapManifest): string {
   `}\n${body}\n`;
 }
 
-function prGovernanceScript(): string {
+function prGovernanceScript(manifest: BootstrapManifest): string {
   return dedent`
     #!/usr/bin/env bash
     set -euo pipefail
@@ -997,17 +997,31 @@ function prGovernanceScript(): string {
     load_response "\${PR_COMMITS_FILE:-}" "\${PR_COMMITS_URL:-}" "per_page=250" "$workdir/commits.json"
     load_response "\${PR_REVIEWS_FILE:-}" "\${PR_REVIEWS_URL:-}" "per_page=100" "$workdir/reviews.json"
 
-    python3 - "$PR_TITLE" "$PR_BODY" "$PR_AUTHOR" "$workdir/files.json" "$workdir/commits.json" "$workdir/reviews.json" <<'PY'
+    python3 - "$PR_TITLE" "$PR_BODY" "$PR_AUTHOR" "\${PR_CREATED_AT:-}" "\${PR_GOVERNANCE_ENFORCE_AFTER:-}" "$workdir/files.json" "$workdir/commits.json" "$workdir/reviews.json" <<'PY'
+    from datetime import datetime
     import json
     import re
     import sys
     from pathlib import Path
 
-    title, body, author, files_path, commits_path, reviews_path = sys.argv[1:]
+    title, body, author, created_at, enforce_after, files_path, commits_path, reviews_path = sys.argv[1:]
     files = json.loads(Path(files_path).read_text())
     commits = json.loads(Path(commits_path).read_text())
     reviews = json.loads(Path(reviews_path).read_text())
     failures = []
+
+    if enforce_after:
+        try:
+            created_at_value = datetime.fromisoformat(created_at.replace("Z", "+00:00"))
+            enforce_after_value = datetime.fromisoformat(enforce_after.replace("Z", "+00:00"))
+            if created_at_value.tzinfo is None or enforce_after_value.tzinfo is None:
+                raise ValueError
+        except ValueError:
+            failures.append("PRS-ENFORCEMENT-INPUT-001: PR_CREATED_AT and PR_GOVERNANCE_ENFORCE_AFTER must be ISO-8601 timestamps.")
+        else:
+            if created_at_value < enforce_after_value:
+                print(f"PASS PRS-PR-GOVERNANCE-LEGACY-001: PR opened at {created_at} before enforcement began at {enforce_after}.")
+                sys.exit(0)
 
     if not re.match(r"^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\\([^)]+\\))?!?: .+", title):
         failures.append("PRS-PR-TITLE-001: use a Conventional Commit-style PR title, for example 'feat: add policy gate'.")
@@ -2410,6 +2424,8 @@ function prWorkflow(manifest: BootstrapManifest): string {
     on:
       pull_request:
         types: [opened, edited, synchronize, reopened, ready_for_review]
+      pull_request_review:
+        types: [submitted, edited, dismissed]
 
     concurrency:
       group: pr-fast-\${{ github.event.pull_request.number || github.ref }}
@@ -2531,6 +2547,8 @@ ${indentBlock(setupSteps(manifest), 6)}
           PR_TITLE: \${{ github.event.pull_request.title }}
           PR_BODY: \${{ github.event.pull_request.body }}
           PR_AUTHOR: \${{ github.event.pull_request.user.login }}
+          PR_CREATED_AT: \${{ github.event.pull_request.created_at }}
+          PR_GOVERNANCE_ENFORCE_AFTER: '${manifest.ci.prGovernance?.enforceAfter ?? ""}'
           PR_FILES_URL: \${{ github.event.pull_request.url }}/files
           PR_COMMITS_URL: \${{ github.event.pull_request.commits_url }}
           PR_REVIEWS_URL: \${{ github.event.pull_request.url }}/reviews
@@ -3389,7 +3407,7 @@ export function renderManagedFiles(manifest: BootstrapManifest): RenderedFile[] 
     {
       path: "scripts/ci/check-pr-governance.sh",
       reason: "Fork-safe pull request governance validation",
-      contents: `${prGovernanceScript()}\n`,
+      contents: `${prGovernanceScript(manifest)}\n`,
       executable: true
     },
     {

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -350,6 +350,11 @@ const manifestSchema = z.object({
       fastChecks: z.array(z.string()).optional(),
       extendedChecks: z.array(z.string()).optional(),
       nightlyCron: z.string().optional(),
+      prGovernance: z
+        .object({
+          enforceAfter: z.string().datetime({ offset: true })
+        })
+        .optional(),
       workflows: ciWorkflowsSchema.optional(),
       additionalWorkflows: z.array(additionalWorkflowSchema).optional(),
       appPaths: z.array(z.string().min(1)).optional(),
@@ -799,6 +804,7 @@ export function normalizeManifest(raw: z.input<typeof manifestSchema>): Bootstra
       fastChecks: parsed.ci?.fastChecks ?? ["lint", "typecheck", "unit", "build", "secrets"],
       extendedChecks: parsed.ci?.extendedChecks ?? ["integration", "release-readiness"],
       nightlyCron: parsed.ci?.nightlyCron ?? "0 7 * * *",
+      ...(parsed.ci?.prGovernance ? { prGovernance: { enforceAfter: parsed.ci.prGovernance.enforceAfter } } : {}),
       additionalWorkflows,
       ...(workflows ? { workflows } : {}),
       appPaths: normalizePaths(parsed.ci?.appPaths),

--- a/src/types.ts
+++ b/src/types.ts
@@ -218,6 +218,9 @@ export interface BootstrapManifest {
     fastChecks: string[];
     extendedChecks: string[];
     nightlyCron: string;
+    prGovernance?: {
+      enforceAfter: string;
+    };
     additionalWorkflows: AdditionalWorkflowConfig[];
     workflows?: {
       prFastCi: boolean;

--- a/tests/pr-governance.test.ts
+++ b/tests/pr-governance.test.ts
@@ -56,6 +56,37 @@ describe("check-pr-governance", () => {
     expect(result.output).toContain("docs/guide.md");
   });
 
+  it("exempts only pull requests opened before configured governance enforcement", async () => {
+    const fixture = {
+      files: [{ filename: "src/large.ts", additions: 801, deletions: 0 }],
+      commits: [{ sha: "1234567890abcdef", author: { login: "human", type: "User" }, commit: { message: "feat: no signoff" } }],
+      reviews: []
+    };
+    const legacy = await runGovernance(fixture, {
+      PR_TITLE: "missing conventional title",
+      PR_CREATED_AT: "2026-07-13T16:07:09Z",
+      PR_GOVERNANCE_ENFORCE_AFTER: "2026-07-13T23:00:00Z"
+    });
+    const current = await runGovernance(fixture, {
+      PR_TITLE: "missing conventional title",
+      PR_CREATED_AT: "2026-07-14T00:00:00Z",
+      PR_GOVERNANCE_ENFORCE_AFTER: "2026-07-13T23:00:00Z"
+    });
+    const malformed = await runGovernance(fixture, {
+      PR_TITLE: "missing conventional title",
+      PR_CREATED_AT: "not-a-timestamp",
+      PR_GOVERNANCE_ENFORCE_AFTER: "2026-07-13T23:00:00Z"
+    });
+
+    expect(legacy.code).toBe(0);
+    expect(legacy.output).toContain("PRS-PR-GOVERNANCE-LEGACY-001");
+    expect(current.code).toBe(1);
+    expect(current.output).toContain("PRS-PR-TITLE-001");
+    expect(current.output).toContain("PRS-DCO-001");
+    expect(malformed.code).toBe(1);
+    expect(malformed.output).toContain("PRS-ENFORCEMENT-INPUT-001");
+  });
+
   it("accepts a material change with an accepted ADR and independent reviewer", async () => {
     const result = await runGovernance({
       files: [{ filename: "src/policy.ts", additions: 10, deletions: 2 }],

--- a/tests/render.test.ts
+++ b/tests/render.test.ts
@@ -47,6 +47,8 @@ describe("renderManagedFiles", () => {
       expect(extendedValidationWorkflow?.contents).toContain("dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4");
       expect(extendedValidationWorkflow?.contents).not.toContain("dorny/paths-filter@v3");
       expect(prWorkflow?.contents).toContain("types: [opened, edited, synchronize, reopened, ready_for_review]");
+      expect(prWorkflow?.contents).toContain("pull_request_review:");
+      expect(prWorkflow?.contents).toContain("PR_GOVERNANCE_ENFORCE_AFTER:");
       expect(prWorkflow?.contents).toContain("['self-hosted', 'linux'");
       expect(prWorkflow?.contents).toContain("validate-pr-description:");
       expect(prWorkflow?.contents).toContain("PR body must close/link an issue");


### PR DESCRIPTION
## Summary

- Add an explicit manifest-controlled start time for PR governance enforcement.
- Exempt only pull requests opened before that time; retain every governance rule for newer PRs.
- Re-run governance validation when reviews are submitted, edited, or dismissed.

## Governing Issue

Refs #54.

## Validation

- [x] `npm run check` (91 tests passed)

## Bootstrap Governance

- [x] The exemption is bounded by the pull request creation time and fails closed for malformed timestamps.
- [x] Pull requests opened after enforcement still require title, size, DCO, ADR, and independent-review evidence.
- [x] No real secrets, runtime auth, or machine-local env files are committed.

Material change: no

## Merge Automation

- [x] Auto-merge is enabled with squash merge; independent review and required checks remain enforced.

## Notes

- This repair unblocks the pre-existing integration PR #67 without retroactively weakening governance for future pull requests.
