### PR TITLE
fix: pin reusable production workflows

### DIFF
--- a/.github/workflows/full-release-validation.yml
+++ b/.github/workflows/full-release-validation.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   validate:
-    uses: OMT-Global/bootstrap/.github/workflows/full-release-validation-reusable.yml@refs/heads/main
+    uses: OMT-Global/bootstrap/.github/workflows/full-release-validation-reusable.yml@d9c5bc7e50f4bcc97e4b4d3d2efc64e4ab3dca50
     with:
       target_ref: ${{ inputs.target_ref }}
       release_profile: ${{ inputs.release_profile }}

--- a/.github/workflows/release-postpublish.yml
+++ b/.github/workflows/release-postpublish.yml
@@ -20,7 +20,7 @@ on:
 
 jobs:
   postpublish:
-    uses: OMT-Global/bootstrap/.github/workflows/release-postpublish-reusable.yml@refs/heads/main
+    uses: OMT-Global/bootstrap/.github/workflows/release-postpublish-reusable.yml@d9c5bc7e50f4bcc97e4b4d3d2efc64e4ab3dca50
     with:
       tag: ${{ inputs.tag }}
       channel: ${{ inputs.channel }}

--- a/.github/workflows/release-preflight.yml
+++ b/.github/workflows/release-preflight.yml
@@ -24,7 +24,7 @@ on:
 
 jobs:
   preflight:
-    uses: OMT-Global/bootstrap/.github/workflows/release-preflight-reusable.yml@refs/heads/main
+    uses: OMT-Global/bootstrap/.github/workflows/release-preflight-reusable.yml@d9c5bc7e50f4bcc97e4b4d3d2efc64e4ab3dca50
     with:
       version: ${{ inputs.version }}
       channel: ${{ inputs.channel }}

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -28,7 +28,7 @@ on:
 
 jobs:
   publish:
-    uses: OMT-Global/bootstrap/.github/workflows/release-publish-reusable.yml@refs/heads/main
+    uses: OMT-Global/bootstrap/.github/workflows/release-publish-reusable.yml@d9c5bc7e50f4bcc97e4b4d3d2efc64e4ab3dca50
     with:
       tag: ${{ inputs.tag }}
       channel: ${{ inputs.channel }}

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Cut patch releases from `release/X.Y` branches when you maintain an older minor 
 
 ## AI Attestation
 
-This bootstrap also renders `.github/workflows/ai-attestation.yml` as a caller for the shared attestation workflow at `OMT-Global/bootstrap/.github/workflows/ai-attestation-reusable.yml@refs/heads/main`.
+This bootstrap also renders `.github/workflows/ai-attestation.yml` as a caller for the shared attestation workflow at `OMT-Global/bootstrap/.github/workflows/ai-attestation-reusable.yml@d9c5bc7e50f4bcc97e4b4d3d2efc64e4ab3dca50`.
 
 Override the default provider, model, and prompt hash with repo variables (`AI_ATTESTATION_PROVIDER`, `AI_ATTESTATION_MODEL`, `AI_ATTESTATION_PROMPT_HASH`) or update `project.bootstrap.yaml` before production rollout.
 

--- a/docs/bootstrap/onboarding.md
+++ b/docs/bootstrap/onboarding.md
@@ -63,7 +63,7 @@ Use this checklist after the first bootstrap render or whenever `project.bootstr
 
 ## AI Attestation
 
-- `.github/workflows/ai-attestation.yml` calls `OMT-Global/bootstrap/.github/workflows/ai-attestation-reusable.yml@refs/heads/main`.
+- `.github/workflows/ai-attestation.yml` calls `OMT-Global/bootstrap/.github/workflows/ai-attestation-reusable.yml@d9c5bc7e50f4bcc97e4b4d3d2efc64e4ab3dca50`.
 - Override default metadata with repo variables (`AI_ATTESTATION_PROVIDER`, `AI_ATTESTATION_MODEL`, `AI_ATTESTATION_PROMPT_HASH`) before treating the artifact metadata as authoritative.
 - Pin the reusable workflow to a tag or SHA once the control-plane contract is stable.
 

--- a/docs/bootstrap/release-train-contract.md
+++ b/docs/bootstrap/release-train-contract.md
@@ -18,7 +18,7 @@ release:
   enabled: true
   maturity: governed
   reusableWorkflowRepo: OMT-Global/bootstrap
-  reusableWorkflowRef: refs/heads/main
+  reusableWorkflowRef: d9c5bc7e50f4bcc97e4b4d3d2efc64e4ab3dca50
 ```
 
 Governed repos receive thin caller workflows for preflight, validation, publish, and postpublish verification. Package-specific behavior belongs in hook scripts under `scripts/release/`.

--- a/docs/bootstrap/tier-a-ci-contract.md
+++ b/docs/bootstrap/tier-a-ci-contract.md
@@ -50,7 +50,7 @@ Example security caller:
 ```yaml
 jobs:
   security:
-    uses: OMT-Global/bootstrap/.github/workflows/security-pr.yml@refs/heads/main
+    uses: OMT-Global/bootstrap/.github/workflows/security-pr.yml@d9c5bc7e50f4bcc97e4b4d3d2efc64e4ab3dca50
     with:
       dependency-review: true
       run-osv: true
@@ -68,7 +68,7 @@ on:
 
 jobs:
   release:
-    uses: OMT-Global/bootstrap/.github/workflows/release.yml@refs/heads/main
+    uses: OMT-Global/bootstrap/.github/workflows/release.yml@d9c5bc7e50f4bcc97e4b4d3d2efc64e4ab3dca50
     secrets: inherit
     with:
       runs-on: '["ubuntu-latest"]'
@@ -110,7 +110,7 @@ env:
 
 jobs:
   attest:
-    uses: OMT-Global/bootstrap/.github/workflows/ai-attestation-reusable.yml@refs/heads/main
+    uses: OMT-Global/bootstrap/.github/workflows/ai-attestation-reusable.yml@d9c5bc7e50f4bcc97e4b4d3d2efc64e4ab3dca50
     with:
       artifact_name: ai-attestation
       retention_days: 90
@@ -119,7 +119,7 @@ jobs:
       prompt_hash: ${{ vars.AI_ATTESTATION_PROMPT_HASH || env.AI_ATTESTATION_PROMPT_HASH_DEFAULT }}
 ```
 
-Pin to a tag or SHA for production rollout. Use branch refs only while iterating on the contract, and override the attestation metadata defaults with repo variables before treating the signed payload as authoritative.
+Pin to an exact tag or SHA for every production rollout, and override the attestation metadata defaults with repo variables before treating the signed payload as authoritative.
 
 ## Publish Readiness
 

--- a/project.bootstrap.yaml
+++ b/project.bootstrap.yaml
@@ -203,7 +203,7 @@ ci:
     model: unknown
     promptHash: unknown
     reusableWorkflowRepo: OMT-Global/bootstrap
-    reusableWorkflowRef: refs/heads/main
+    reusableWorkflowRef: d9c5bc7e50f4bcc97e4b4d3d2efc64e4ab3dca50
 release:
   enabled: true
   maturity: governed
@@ -212,7 +212,7 @@ release:
   updateMajorTag: true
   updateMinorTag: true
   reusableWorkflowRepo: OMT-Global/bootstrap
-  reusableWorkflowRef: refs/heads/main
+  reusableWorkflowRef: d9c5bc7e50f4bcc97e4b4d3d2efc64e4ab3dca50
   changelog:
     enabled: true
     mode: github-generated-notes

--- a/scripts/ci/run-release-build.sh
+++ b/scripts/ci/run-release-build.sh
@@ -7,7 +7,7 @@ mkdir -p "${artifact_dir}"
 # Add repo-specific build steps above this line to populate ${artifact_dir}
 # with downloadable release assets before checksums are generated.
 
-mapfile -t artifacts < <(find "${artifact_dir}" -maxdepth 1 -type f ! -name SHA256SUMS | sort)
+mapfile -t artifacts < <(find "${artifact_dir}" -maxdepth 1 -type f ! -name SHA256SUMS ! -name release-evidence.json ! -name validation-evidence.json | sort)
 if [[ ${#artifacts[@]} -eq 0 ]]; then
   echo "No release artifacts were produced in ${artifact_dir}."
   echo "This repo ships no downloadable assets; add build steps to scripts/ci/run-release-build.sh when it does."

--- a/src/archetypes.ts
+++ b/src/archetypes.ts
@@ -1075,7 +1075,7 @@ function releaseBuildScript(manifest: BootstrapManifest): string {
     # Add repo-specific build steps above this line to populate \${artifact_dir}
     # with downloadable release assets before checksums are generated.
 
-    mapfile -t artifacts < <(find "\${artifact_dir}" -maxdepth 1 -type f ! -name SHA256SUMS | sort)
+    mapfile -t artifacts < <(find "\${artifact_dir}" -maxdepth 1 -type f ! -name SHA256SUMS ! -name release-evidence.json ! -name validation-evidence.json | sort)
     if [[ \${#artifacts[@]} -eq 0 ]]; then
       echo "No release artifacts were produced in \${artifact_dir}."
       echo "This repo ships no downloadable assets; add build steps to scripts/ci/run-release-build.sh when it does."
@@ -2154,7 +2154,7 @@ function releaseTrainDoc(): string {
   `;
 }
 
-function releaseTrainContractDoc(): string {
+function releaseTrainContractDoc(manifest: BootstrapManifest): string {
   return dedent`
     # Governed Release Train Contract
 
@@ -2175,8 +2175,8 @@ function releaseTrainContractDoc(): string {
     release:
       enabled: true
       maturity: governed
-      reusableWorkflowRepo: OMT-Global/bootstrap
-      reusableWorkflowRef: refs/heads/main
+      reusableWorkflowRepo: ${manifest.release.reusableWorkflowRepo}
+      reusableWorkflowRef: ${manifest.release.reusableWorkflowRef}
     \`\`\`
 
     Governed repos receive thin caller workflows for preflight, validation, publish, and postpublish verification. Package-specific behavior belongs in hook scripts under \`scripts/release/\`.
@@ -3290,7 +3290,7 @@ export function renderManagedFiles(manifest: BootstrapManifest): RenderedFile[] 
           {
             path: "docs/bootstrap/release-train-contract.md",
             reason: "Governed release train contract",
-            contents: `${releaseTrainContractDoc()}\n`
+            contents: `${releaseTrainContractDoc(manifest)}\n`
           },
           {
             path: "docs/bootstrap/release-evidence-schema.md",

--- a/tests/render.test.ts
+++ b/tests/render.test.ts
@@ -404,6 +404,7 @@ describe("renderManagedFiles", () => {
       (file) => file.path === ".github/workflows/release-publish-reusable.yml"
     );
     const releaseTrain = files.find((file) => file.path === "docs/release-train.md");
+    const releaseTrainContract = files.find((file) => file.path === "docs/bootstrap/release-train-contract.md");
     const issueTemplate = files.find((file) => file.path === ".github/ISSUE_TEMPLATE/release_train.yml");
 
     expect(paths).not.toContain(".github/workflows/release-tag.yml");
@@ -418,6 +419,7 @@ describe("renderManagedFiles", () => {
       "uses: OMT-Global/bootstrap/.github/workflows/release-preflight-reusable.yml@refs/tags/bootstrap-v1"
     );
     expect(publish?.contents).toContain("require_release_issue: true");
+    expect(releaseTrainContract?.contents).toContain("reusableWorkflowRef: refs/tags/bootstrap-v1");
     expect(publish?.contents).toContain("require_signed_tag: false");
     expect(reusablePublish?.contents).toContain("gh run download");
     expect(reusablePublish?.contents).toContain("PREFLIGHT_ARTIFACT_DIR");


### PR DESCRIPTION
## Summary

- Pin Bootstrap’s governed release callers to the immutable commit that contains their reusable workflows.
- Keep release evidence files out of generated release-asset checksums.
- Carry the configured immutable reference into generated release guidance and Tier A examples.

## Governing Issue

Refs #64.

## Validation

- [x] `npm run check` (62 tests passed)
- [x] `bootstrap plan --manifest ./project.bootstrap.yaml --target . --json`
- [x] Verified every pinned reusable workflow exists at `d9c5bc7e50f4bcc97e4b4d3d2efc64e4ab3dca50`.

## Bootstrap Governance

- [x] The pin is a 40-character immutable commit SHA; no production caller targets a mutable branch.
- [x] The generated workflow and documentation changes are sourced from `project.bootstrap.yaml`.
- [x] No real secrets, runtime auth, or machine-local env files are committed.

Material change: no

## Merge Automation

- [x] Auto-merge is enabled with squash merge; independent review and required checks remain enforced.

## Notes

- This repairs the non-publishing release preflight blocker found while preparing issue #27; it does not create a release or move tags.
