### PR TITLE
docs: require autoreview before pull requests

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,6 +9,8 @@ Refs #<issue-number>  <!-- use Closes/Fixes/Resolves only when this PR fully com
 ## Validation
 
 - [ ] Relevant local checks passed
+- [ ] Agent-authored changes passed `autoreview` against the intended PR diff with no accepted/actionable findings
+- Autoreview command and result:
 - [ ] Required PR checks are expected to satisfy `CI Gate`
 - [ ] Skipped checks are explained below
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,7 @@
 - CI baseline: fast PR checks stay cheap and shell-safe; extended validation runs on `main`, nightly, or manual dispatch.
 - Self-hosted runner policy: shell-safe jobs must use `[self-hosted, linux, shell-only, public]`; native repos must use self-hosted runners for required automation, with Docker, service-container, browser, or `container:` workloads routed to dedicated self-hosted capability pools.
 - Add or update tests for every interactive, branching, or operator-facing behavior change.
+- Before opening or updating a PR, use the `autoreview` skill to review the intended PR diff against its actual base. Verify every finding, fix accepted in-scope findings, and rerun affected tests and autoreview after changes. Proceed only when no accepted/actionable findings remain, and record the final command and result in the PR validation evidence. If the skill is unavailable or cannot complete, stop and report the blocker instead of bypassing the gate.
 - PRs must use the generated pull request template. The required PR gate validates summary, issue linkage, validation evidence, and risk notes.
 - Never commit real secrets, runtime auth, or machine-local env files. Use templates and GitHub environments instead.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,8 @@ Contributions should start from a GitHub issue that is assigned or explicitly en
 ## Validation
 
 - Run the relevant local checks before opening a PR.
+- For agent-authored changes, use the `autoreview` skill against the intended PR diff and actual base. Verify every finding, address accepted in-scope findings, and rerun affected checks and autoreview after edits until no accepted/actionable findings remain.
+- Record the final autoreview command and result in the PR. If the skill is unavailable or cannot complete, stop and report that blocker instead of opening or updating the PR.
 - For this bootstrap contract, the required PR check surface is `CI Gate`.
 - Document any skipped checks in the PR with a concrete reason.
 

--- a/docs/bootstrap/onboarding.md
+++ b/docs/bootstrap/onboarding.md
@@ -13,6 +13,7 @@ Use this checklist after the first bootstrap render or whenever `project.bootstr
 - Confirm branch protection or rulesets on `main` require one approval, code owner review, and approval from someone other than the most recent pusher.
 - Confirm branch protection points at the `CI Gate` status.
 - Confirm `CONTRIBUTING.md` and `.github/PULL_REQUEST_TEMPLATE.md` are present as the required contributor and PR guidance surfaces.
+- Confirm `AGENTS.md` requires the `autoreview` skill against the intended PR diff before an agent opens or updates a PR, and that the PR template records the final command and result.
 - Confirm the pull request template is present and PR Fast CI validates the required PR description sections before CI Gate can pass.
 - Confirm PR Fast CI uses the fork-safe `pull_request` event with only read permissions. It must validate Conventional titles, contributed-commit DCO trailers, changed-line accounting, and material-change ADR/reviewer evidence without accessing repository secrets.
 - Confirm every third-party `uses:` entry is a 40-character commit SHA followed by readable tag metadata. The `Validate Action Pins` check fails closed on mutable references and silently ignores local or Bootstrap-owned reusable workflows.

--- a/profiles/home/codex/AGENTS.md
+++ b/profiles/home/codex/AGENTS.md
@@ -4,3 +4,4 @@
 - Treat `project.bootstrap.yaml` as the control plane for new-repo setup.
 - Do not copy auth state, sessions, caches, or machine-local secrets into portable Codex profiles.
 - Prefer `plan` before `apply` when provisioning GitHub policy or home profile changes.
+- Before opening or updating a PR, use the `autoreview` skill against the intended PR diff and actual base. Verify findings, fix accepted in-scope findings, rerun affected tests and autoreview after edits, and proceed only when no accepted/actionable findings remain. Record the final command and result in the PR; if autoreview is unavailable or cannot complete, stop and report the blocker.

--- a/src/archetypes.ts
+++ b/src/archetypes.ts
@@ -196,6 +196,7 @@ function repoAgents(manifest: BootstrapManifest): string {
     - CI baseline: fast PR checks stay cheap and shell-safe; extended validation runs on \`main\`, nightly, or manual dispatch.
     - Self-hosted runner policy: shell-safe jobs must use \`[self-hosted, linux, shell-only, ${manifest.project.visibility === "public" ? "public" : "private"}]\`; native repos must use self-hosted runners for required automation, with Docker, service-container, browser, or \`container:\` workloads routed to dedicated self-hosted capability pools.
     - Add or update tests for every interactive, branching, or operator-facing behavior change.
+    - Before opening or updating a PR, use the \`autoreview\` skill to review the intended PR diff against its actual base. Verify every finding, fix accepted in-scope findings, and rerun affected tests and autoreview after changes. Proceed only when no accepted/actionable findings remain, and record the final command and result in the PR validation evidence. If the skill is unavailable or cannot complete, stop and report the blocker instead of bypassing the gate.
     - PRs must use the generated pull request template. The required PR gate validates summary, issue linkage, validation evidence, and risk notes.
     - Never commit real secrets, runtime auth, or machine-local env files. Use templates and GitHub environments instead.
 
@@ -364,6 +365,8 @@ function contributingDoc(manifest: BootstrapManifest): string {
     ## Validation
 
     - Run the relevant local checks before opening a PR.
+    - For agent-authored changes, use the \`autoreview\` skill against the intended PR diff and actual base. Verify every finding, address accepted in-scope findings, and rerun affected checks and autoreview after edits until no accepted/actionable findings remain.
+    - Record the final autoreview command and result in the PR. If the skill is unavailable or cannot complete, stop and report that blocker instead of opening or updating the PR.
     - For this bootstrap contract, the required PR check surface is ${requiredStatusChecksDisplay(manifest)}.
     - Document any skipped checks in the PR with a concrete reason.
 
@@ -412,6 +415,8 @@ function pullRequestTemplate(manifest: BootstrapManifest): string {
     ## Validation
 
     - [ ] Relevant local checks passed
+    - [ ] Agent-authored changes passed \`autoreview\` against the intended PR diff with no accepted/actionable findings
+    - Autoreview command and result:
     - [ ] Required PR checks are expected to satisfy ${requiredStatusChecksDisplay(manifest)}
     - [ ] Skipped checks are explained below
 
@@ -2757,6 +2762,7 @@ ${indentBlock(projectIdentityLines(manifest), 4)}
     - Confirm branch protection or rulesets on \`${manifest.project.defaultBranch}\` require one approval, code owner review, and approval from someone other than the most recent pusher.
     - ${requiredStatusCheckConfirmation(manifest)}
     - Confirm \`CONTRIBUTING.md\` and \`.github/PULL_REQUEST_TEMPLATE.md\` are present as the required contributor and PR guidance surfaces.
+    - Confirm \`AGENTS.md\` requires the \`autoreview\` skill against the intended PR diff before an agent opens or updates a PR, and that the PR template records the final command and result.
     - Confirm the pull request template is present and PR Fast CI validates the required PR description sections before ${primaryRequiredStatusCheck(manifest)} can pass.
     - ${autoMergeOnboardingConfirmation()}
     - Fallback merge readiness requires passing or intentionally skipped required checks, satisfied approvals, resolved conversations, no blocking review state, and a manual maintainer merge.

--- a/tests/home-sync.test.ts
+++ b/tests/home-sync.test.ts
@@ -40,6 +40,7 @@ describe("home sync", () => {
     expect(applied.some((action) => action.path.startsWith(".claude/"))).toBe(false);
 
     const codexAgents = await readFile(path.join(homeDir, ".codex/AGENTS.md"), "utf8");
+    expect(codexAgents).toContain("Before opening or updating a PR, use the `autoreview` skill");
     expect(codexAgents).toContain("Codex Home Profile");
     await expect(access(path.join(homeDir, ".bootstrap/home-state.json"))).resolves.toBeUndefined();
 

--- a/tests/render.test.ts
+++ b/tests/render.test.ts
@@ -282,7 +282,7 @@ describe("renderManagedFiles", () => {
     expect(claudeWorkflow?.contents).toContain("anthropics/claude-code-action@e90deca47693f9457b72f2b53c17d7c445a87342 # v1");
   });
 
-  it("documents required PR template enforcement in generated agent instructions", () => {
+  it("documents required PR template and autoreview enforcement in generated guidance", () => {
     const manifest = normalizeManifest({
       project: {
         name: "template-required",
@@ -295,8 +295,17 @@ describe("renderManagedFiles", () => {
 
     const files = renderManagedFiles(manifest);
     const agents = files.find((file) => file.path === "AGENTS.md");
+    const contributing = files.find((file) => file.path === "CONTRIBUTING.md");
+    const prTemplate = files.find((file) => file.path === ".github/PULL_REQUEST_TEMPLATE.md");
+    const onboarding = files.find((file) => file.path === "docs/bootstrap/onboarding.md");
     const prWorkflow = files.find((file) => file.path === ".github/workflows/pr-fast-ci.yml");
 
+    expect(agents?.contents).toContain("Before opening or updating a PR, use the `autoreview` skill");
+    expect(agents?.contents).toContain("stop and report the blocker instead of bypassing the gate");
+    expect(contributing?.contents).toContain("For agent-authored changes, use the `autoreview` skill");
+    expect(prTemplate?.contents).toContain("Agent-authored changes passed `autoreview`");
+    expect(prTemplate?.contents).toContain("Autoreview command and result:");
+    expect(onboarding?.contents).toContain("`AGENTS.md` requires the `autoreview` skill");
     expect(agents?.contents).toContain("PRs must use the generated pull request template");
     expect(prWorkflow?.contents).toContain("- validate-pr-description");
     expect(prWorkflow?.contents).toContain("validate-pr-description=${{ needs.validate-pr-description.result }}");


### PR DESCRIPTION
## Summary

- Require agents to run `autoreview` against the intended PR diff and actual base before opening or updating a pull request.
- Fail closed when autoreview is unavailable; address accepted in-scope findings and rerun checks after review-driven edits.
- Keep generated agent guidance, contributor guidance, the PR template, onboarding, and the portable Codex profile aligned.

Risk is low: generated process guidance and its tests only; no runtime behavior or networked CI reviewer is added.

## Governing Issue

Closes #84

## Material Change

Material change: no

## Validation

- [x] `npm test -- --run tests/render.test.ts tests/home-sync.test.ts`
- [x] `npm run typecheck`
- [x] `git diff --check origin/main...HEAD`

## Bootstrap Governance

- [x] Changes are scoped to the linked issue
- [x] Contributor/PR guidance is reflected in `CONTRIBUTING.md`, `.github/PULL_REQUEST_TEMPLATE.md`, and `docs/bootstrap/onboarding.md`
- [x] No real secrets, runtime auth, or machine-local env files are committed

## Merge Automation

- [x] Auto-merge is enabled where GitHub allows it; otherwise the fallback merge-readiness policy applies.

## Notes

- Branch history was rewritten as one Hephaestus-authored, Signed-off-by commit to satisfy DCO without impersonating the original author.