### PR TITLE
fix: enforce generated ownership sidecar

### DIFF
--- a/src/render.ts
+++ b/src/render.ts
@@ -51,20 +51,30 @@ interface OwnershipSidecar {
   managedFiles?: Record<string, { sha256?: unknown }>;
 }
 
-async function loadOwnershipHashes(targetDir: string): Promise<Record<string, string>> {
+interface OwnershipHashes {
+  hashes: Record<string, string>;
+  sidecarPresent: boolean;
+}
+
+async function loadOwnershipHashes(targetDir: string): Promise<OwnershipHashes> {
   const raw = await readTextIfExists(path.join(targetDir, ".bootstrap/managed-files.json"));
-  if (!raw) return {};
+  if (!raw) return { hashes: {}, sidecarPresent: false };
 
   try {
     const sidecar = JSON.parse(raw) as OwnershipSidecar;
-    if (sidecar.schemaVersion !== 1 || sidecar.owner !== "bootstrap" || !sidecar.managedFiles) return {};
-    return Object.fromEntries(
-      Object.entries(sidecar.managedFiles)
-        .filter(([, entry]) => isManagedContentHash(typeof entry?.sha256 === "string" ? entry.sha256 : undefined))
-        .map(([filePath, entry]) => [filePath, entry.sha256 as string])
-    );
+    if (sidecar.schemaVersion !== 1 || sidecar.owner !== "bootstrap" || !sidecar.managedFiles) {
+      return { hashes: {}, sidecarPresent: false };
+    }
+    return {
+      hashes: Object.fromEntries(
+        Object.entries(sidecar.managedFiles)
+          .filter(([, entry]) => isManagedContentHash(typeof entry?.sha256 === "string" ? entry.sha256 : undefined))
+          .map(([filePath, entry]) => [filePath, entry.sha256 as string])
+      ),
+      sidecarPresent: true
+    };
   } catch {
-    return {};
+    return { hashes: {}, sidecarPresent: false };
   }
 }
 
@@ -161,8 +171,16 @@ export async function planRepo(manifest: BootstrapManifest, targetDir: string): 
 
   for (const file of files) {
     const existingContents = await readTextIfExists(path.join(targetDir, file.path));
-    const managedHash = existingState?.managedFiles[file.path] ?? ownershipHashes[file.path];
+    const managedHash = existingState?.managedFiles[file.path] ?? ownershipHashes.hashes[file.path];
+    const missingSidecarHash =
+      !existingState &&
+      ownershipHashes.sidecarPresent &&
+      file.path !== ".bootstrap/managed-files.json" &&
+      existingContents !== undefined &&
+      managedHash === undefined &&
+      existingContents !== file.contents;
     if (
+      missingSidecarHash ||
       existingContents !== undefined &&
       isManagedContentHash(managedHash) &&
       sha256(existingContents) !== managedHash &&

--- a/src/render.ts
+++ b/src/render.ts
@@ -53,28 +53,32 @@ interface OwnershipSidecar {
 
 interface OwnershipHashes {
   hashes: Record<string, string>;
-  sidecarPresent: boolean;
 }
 
-async function loadOwnershipHashes(targetDir: string): Promise<OwnershipHashes> {
+function invalidOwnershipSidecar(): never {
+  throw new Error("Bootstrap ownership sidecar is invalid or incomplete. Regenerate it with bootstrap apply repo before making managed-file changes.");
+}
+
+async function loadOwnershipHashes(targetDir: string, renderedFiles: RenderedFile[]): Promise<OwnershipHashes> {
   const raw = await readTextIfExists(path.join(targetDir, ".bootstrap/managed-files.json"));
-  if (!raw) return { hashes: {}, sidecarPresent: false };
+  if (raw === undefined) return { hashes: {} };
 
   try {
     const sidecar = JSON.parse(raw) as OwnershipSidecar;
-    if (sidecar.schemaVersion !== 1 || sidecar.owner !== "bootstrap" || !sidecar.managedFiles) {
-      return { hashes: {}, sidecarPresent: false };
+    if (sidecar.schemaVersion !== 1 || sidecar.owner !== "bootstrap" || !sidecar.managedFiles || Array.isArray(sidecar.managedFiles)) {
+      return invalidOwnershipSidecar();
     }
-    return {
-      hashes: Object.fromEntries(
-        Object.entries(sidecar.managedFiles)
-          .filter(([, entry]) => isManagedContentHash(typeof entry?.sha256 === "string" ? entry.sha256 : undefined))
-          .map(([filePath, entry]) => [filePath, entry.sha256 as string])
-      ),
-      sidecarPresent: true
-    };
+    const entries = Object.entries(sidecar.managedFiles);
+    if (entries.some(([, entry]) => !isManagedContentHash(typeof entry?.sha256 === "string" ? entry.sha256 : undefined))) {
+      return invalidOwnershipSidecar();
+    }
+    const hashes = Object.fromEntries(entries.map(([filePath, entry]) => [filePath, entry.sha256 as string]));
+    if (renderedFiles.some((file) => hashes[file.path] === undefined)) {
+      return invalidOwnershipSidecar();
+    }
+    return { hashes };
   } catch {
-    return { hashes: {}, sidecarPresent: false };
+    return invalidOwnershipSidecar();
   }
 }
 
@@ -166,21 +170,13 @@ export async function planRepo(manifest: BootstrapManifest, targetDir: string): 
   const files = [...renderedFiles, createOwnershipSidecar(renderedFiles)];
   const languageProfiles = await resolveLanguageProfiles(manifest, targetDir);
   const existingState = await loadRepoState(targetDir);
-  const ownershipHashes = await loadOwnershipHashes(targetDir);
+  const ownershipHashes = await loadOwnershipHashes(targetDir, renderedFiles);
   const changes: PlannedFileChange[] = [];
 
   for (const file of files) {
     const existingContents = await readTextIfExists(path.join(targetDir, file.path));
     const managedHash = existingState?.managedFiles[file.path] ?? ownershipHashes.hashes[file.path];
-    const missingSidecarHash =
-      !existingState &&
-      ownershipHashes.sidecarPresent &&
-      file.path !== ".bootstrap/managed-files.json" &&
-      existingContents !== undefined &&
-      managedHash === undefined &&
-      existingContents !== file.contents;
     if (
-      missingSidecarHash ||
       existingContents !== undefined &&
       isManagedContentHash(managedHash) &&
       sha256(existingContents) !== managedHash &&

--- a/src/render.ts
+++ b/src/render.ts
@@ -45,6 +45,29 @@ function isManagedContentHash(value: string | undefined): value is string {
   return value !== undefined && /^[a-f0-9]{64}$/i.test(value);
 }
 
+interface OwnershipSidecar {
+  schemaVersion?: unknown;
+  owner?: unknown;
+  managedFiles?: Record<string, { sha256?: unknown }>;
+}
+
+async function loadOwnershipHashes(targetDir: string): Promise<Record<string, string>> {
+  const raw = await readTextIfExists(path.join(targetDir, ".bootstrap/managed-files.json"));
+  if (!raw) return {};
+
+  try {
+    const sidecar = JSON.parse(raw) as OwnershipSidecar;
+    if (sidecar.schemaVersion !== 1 || sidecar.owner !== "bootstrap" || !sidecar.managedFiles) return {};
+    return Object.fromEntries(
+      Object.entries(sidecar.managedFiles)
+        .filter(([, entry]) => isManagedContentHash(typeof entry?.sha256 === "string" ? entry.sha256 : undefined))
+        .map(([filePath, entry]) => [filePath, entry.sha256 as string])
+    );
+  } catch {
+    return {};
+  }
+}
+
 const managedPathDependencies = [
   {
     path: "AGENTS.md",
@@ -133,11 +156,12 @@ export async function planRepo(manifest: BootstrapManifest, targetDir: string): 
   const files = [...renderedFiles, createOwnershipSidecar(renderedFiles)];
   const languageProfiles = await resolveLanguageProfiles(manifest, targetDir);
   const existingState = await loadRepoState(targetDir);
+  const ownershipHashes = await loadOwnershipHashes(targetDir);
   const changes: PlannedFileChange[] = [];
 
   for (const file of files) {
     const existingContents = await readTextIfExists(path.join(targetDir, file.path));
-    const managedHash = existingState?.managedFiles[file.path];
+    const managedHash = existingState?.managedFiles[file.path] ?? ownershipHashes[file.path];
     if (
       existingContents !== undefined &&
       isManagedContentHash(managedHash) &&

--- a/tests/smoke.test.ts
+++ b/tests/smoke.test.ts
@@ -88,6 +88,24 @@ describe("repo smoke", () => {
     await expect(planRepo(manifest, targetDir)).rejects.toThrow("AGENTS.md was directly modified");
   });
 
+  it("blocks direct edits when the ownership sidecar is missing a rendered managed file", async () => {
+    const targetDir = await makeTempDir();
+    const manifest = normalizeManifest({
+      project: { name: "sidecar-missing-owned-edit", owner: "acme" },
+      archetype: { kind: "generic-empty" }
+    });
+
+    await applyRepo(manifest, targetDir);
+    await rm(path.join(targetDir, ".bootstrap/bootstrap-state.json"));
+    const ownershipPath = path.join(targetDir, OWNERSHIP_SIDECAR_PATH);
+    const ownership = JSON.parse(await readFile(ownershipPath, "utf8"));
+    delete ownership.managedFiles["AGENTS.md"];
+    await writeFile(ownershipPath, `${JSON.stringify(ownership, null, 2)}\n`, "utf8");
+    await writeFile(path.join(targetDir, "AGENTS.md"), "product-owned direct edit\n", "utf8");
+
+    await expect(planRepo(manifest, targetDir)).rejects.toThrow("AGENTS.md was directly modified");
+  });
+
   it("can adopt an existing repo by managing only selected bootstrap files", async () => {
     const targetDir = await makeTempDir();
     await writeFile(path.join(targetDir, "README.md"), "Existing README\n", "utf8");

--- a/tests/smoke.test.ts
+++ b/tests/smoke.test.ts
@@ -103,7 +103,28 @@ describe("repo smoke", () => {
     await writeFile(ownershipPath, `${JSON.stringify(ownership, null, 2)}\n`, "utf8");
     await writeFile(path.join(targetDir, "AGENTS.md"), "product-owned direct edit\n", "utf8");
 
-    await expect(planRepo(manifest, targetDir)).rejects.toThrow("AGENTS.md was directly modified");
+    await expect(planRepo(manifest, targetDir)).rejects.toThrow("ownership sidecar is invalid or incomplete");
+  });
+
+  it("fails closed for invalid ownership-sidecar schema", async () => {
+    const targetDir = await makeTempDir();
+    const manifest = normalizeManifest({ project: { name: "invalid-sidecar-schema", owner: "acme" }, archetype: { kind: "generic-empty" } });
+    await applyRepo(manifest, targetDir);
+    await rm(path.join(targetDir, ".bootstrap/bootstrap-state.json"));
+    const ownershipPath = path.join(targetDir, OWNERSHIP_SIDECAR_PATH);
+    const ownership = JSON.parse(await readFile(ownershipPath, "utf8"));
+    ownership.schemaVersion = 2;
+    await writeFile(ownershipPath, JSON.stringify(ownership), "utf8");
+    await expect(planRepo(manifest, targetDir)).rejects.toThrow("ownership sidecar is invalid or incomplete");
+  });
+
+  it("fails closed for malformed ownership-sidecar JSON", async () => {
+    const targetDir = await makeTempDir();
+    const manifest = normalizeManifest({ project: { name: "malformed-sidecar", owner: "acme" }, archetype: { kind: "generic-empty" } });
+    await applyRepo(manifest, targetDir);
+    await rm(path.join(targetDir, ".bootstrap/bootstrap-state.json"));
+    await writeFile(path.join(targetDir, OWNERSHIP_SIDECAR_PATH), "{invalid", "utf8");
+    await expect(planRepo(manifest, targetDir)).rejects.toThrow("ownership sidecar is invalid or incomplete");
   });
 
   it("can adopt an existing repo by managing only selected bootstrap files", async () => {

--- a/tests/smoke.test.ts
+++ b/tests/smoke.test.ts
@@ -74,6 +74,20 @@ describe("repo smoke", () => {
     await expect(planRepo(manifest, targetDir)).rejects.toThrow("AGENTS.md was directly modified");
   });
 
+  it("blocks direct edits using the ownership sidecar when local state is unavailable", async () => {
+    const targetDir = await makeTempDir();
+    const manifest = normalizeManifest({
+      project: { name: "sidecar-owned-edit", owner: "acme" },
+      archetype: { kind: "generic-empty" }
+    });
+
+    await applyRepo(manifest, targetDir);
+    await rm(path.join(targetDir, ".bootstrap/bootstrap-state.json"));
+    await writeFile(path.join(targetDir, "AGENTS.md"), "product-owned direct edit\n", "utf8");
+
+    await expect(planRepo(manifest, targetDir)).rejects.toThrow("AGENTS.md was directly modified");
+  });
+
   it("can adopt an existing repo by managing only selected bootstrap files", async () => {
     const targetDir = await makeTempDir();
     await writeFile(path.join(targetDir, "README.md"), "Existing README\n", "utf8");


### PR DESCRIPTION
## Summary
- Enforce managed-file hashes from the generated ownership sidecar when local Bootstrap state is absent.
- Add regression coverage for sidecar-only direct-edit protection.

## Governing Issue
Fixes #57

## Validation
- [x] `npm test -- --run tests/smoke.test.ts`
- [x] `npm run typecheck`

## Bootstrap Governance
Material change: no

## Merge Automation
Auto-merge is enabled with squash when repository policy permits it.

## Notes
Risk: planning now fails closed for an edited generated file when its sidecar hash proves Bootstrap ownership.