### PR TITLE
feat: project public security policy

### DIFF
--- a/src/archetypes.ts
+++ b/src/archetypes.ts
@@ -2898,7 +2898,19 @@ function repoDocEnabled(
   key: "readme" | "contributing" | "security",
   fallback: boolean
 ): boolean {
-  return manifest.repo.docs?.[key] ?? fallback;
+  if (manifest.repo.docs?.[key] !== undefined) {
+    return manifest.repo.docs[key];
+  }
+
+  // Public repositories need a discoverable vulnerability-reporting route even
+  // when the manifest predates the v2 docs block. The generated policy uses
+  // GitHub's private advisory flow and does not add a contact address. An
+  // explicit `repo.docs.security: false` remains the migration opt-out.
+  if (key === "security") {
+    return manifest.project.visibility === "public";
+  }
+
+  return fallback;
 }
 
 function envExampleEnabled(manifest: BootstrapManifest): boolean {

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -579,7 +579,7 @@ function normalizeRepo(repo: z.input<typeof manifestSchema>["repo"]): BootstrapM
           docs: {
             readme: repo.docs.readme ?? true,
             contributing: repo.docs.contributing ?? true,
-            security: repo.docs.security ?? false
+            ...(repo.docs.security !== undefined ? { security: repo.docs.security } : {})
           }
         }
       : {}),

--- a/src/types.ts
+++ b/src/types.ts
@@ -55,7 +55,7 @@ export interface RepoConfig {
   docs?: {
     readme: boolean;
     contributing: boolean;
-    security: boolean;
+    security?: boolean;
   };
   templates?: {
     pullRequest: "standard" | "none";

--- a/tests/render.test.ts
+++ b/tests/render.test.ts
@@ -190,6 +190,21 @@ describe("renderManagedFiles", () => {
   });
 
 
+  it("projects SECURITY.md for public repositories unless explicitly disabled", () => {
+    const publicManifest = normalizeManifest({
+      project: { name: "public-policy", owner: "acme", visibility: "public" },
+      archetype: { kind: "generic-empty" }
+    });
+    expect(renderManagedFiles(publicManifest).some((file) => file.path === "SECURITY.md")).toBe(true);
+
+    const optedOutManifest = normalizeManifest({
+      project: { name: "public-policy", owner: "acme", visibility: "public" },
+      repo: { docs: { security: false } },
+      archetype: { kind: "generic-empty" }
+    });
+    expect(renderManagedFiles(optedOutManifest).some((file) => file.path === "SECURITY.md")).toBe(false);
+  });
+
   it("renders version 2 docs, templates, environment, and workflow switches", () => {
     const manifest = normalizeManifest({
       version: 2,

--- a/tests/render.test.ts
+++ b/tests/render.test.ts
@@ -205,6 +205,17 @@ describe("renderManagedFiles", () => {
     expect(renderManagedFiles(optedOutManifest).some((file) => file.path === "SECURITY.md")).toBe(false);
   });
 
+  it("projects SECURITY.md when public repository docs omit security", () => {
+    const manifest = normalizeManifest({
+      project: { name: "partial-docs-policy", owner: "acme", visibility: "public" },
+      repo: { docs: { readme: true } },
+      archetype: { kind: "generic-empty" }
+    });
+
+    expect(manifest.repo.docs).toEqual({ readme: true, contributing: true });
+    expect(renderManagedFiles(manifest).some((file) => file.path === "SECURITY.md")).toBe(true);
+  });
+
   it("renders version 2 docs, templates, environment, and workflow switches", () => {
     const manifest = normalizeManifest({
       version: 2,


### PR DESCRIPTION
## Summary

- Project SECURITY.md by default for public repositories.
- Preserve repo.docs.security: false as an explicit migration opt-out.

## Governing Issue

Refs #57

## Validation

- [x] npm test (92 tests passed)
- [x] npm run typecheck
- [x] npm run build
- [x] git diff --check

## Bootstrap Governance

- [x] Scope is limited to the public security-policy projection needed by Flow #13.
- [x] No product repository was applied or modified.
- [x] No real secrets, runtime auth, or machine-local env files are committed.

Material change: no
ADR: n/a

## Merge Automation

Auto-merge is enabled with squash.

## Notes

- Flow remains blocked on its planned v2 manifest migration and human-owned license/conduct decisions; this PR supplies only the non-sensitive security-policy projection.