### PR TITLE
test: restore conformance warning fixture

### DIFF
--- a/docs/bootstrap/policy-exceptions.md
+++ b/docs/bootstrap/policy-exceptions.md
@@ -24,15 +24,26 @@ exceptions:
 ## Material-action notifications and hard stops
 
 Configure the second required notification destination by naming the
-environment variable that will contain its webhook URL. Store only the variable
+environment variable that contains its webhook URL. Store only the variable
 name in the manifest; the URL and any secret-bearing routing token remain in
-the execution environment. Webhook transmission remains disabled and fails
-closed until the secure transport follow-up is merged.
+the execution environment. The executor must also set the fixed
+`BOOTSTRAP_NOTIFICATION_WEBHOOK_ALLOWED_HOSTS` variable to a comma-separated
+allowlist of exact webhook hostnames. The manifest cannot select or replace
+this allowlist.
 
 ```yaml
 notifications:
   webhookUrlEnv: BOOTSTRAP_NOTIFICATION_WEBHOOK_URL
 ```
+
+```sh
+export BOOTSTRAP_NOTIFICATION_WEBHOOK_ALLOWED_HOSTS=hooks.example.com
+```
+
+Delivery accepts only HTTPS on port 443, resolves every allowlisted hostname
+before connecting, and rejects loopback, link-local, private, multicast, and
+reserved addresses. The built-in transport pins a validated public address for
+the TLS connection so a second DNS lookup cannot rebind the destination.
 
 Describe one material action in a JSON file. The governing target accepts a
 local issue or pull request such as `#55`, an `owner/repo#55` shorthand, or a
@@ -64,9 +75,8 @@ bootstrap notifications exceptions --manifest project.bootstrap.yaml --deliver
 
 All notification commands support `--json` and return stable `PRS-NOTIFY-001` and
 `PRS-HARDSTOP-001` results. Delivery writes the redacted notification to the
-governing GitHub issue or pull request. The configured webhook destination
-remains blocking until the secure transport follow-up is merged, so ordinary
-material actions cannot continue on partial delivery.
+governing GitHub issue or pull request and to the configured HTTPS webhook. A
+failed destination blocks continuation.
 
 For a defined hard stop, add its category plus explicit human approval
 evidence. Planning and delivery remain blocking until both fields are present:

--- a/docs/bootstrap/policy-exceptions.md
+++ b/docs/bootstrap/policy-exceptions.md
@@ -26,12 +26,24 @@ exceptions:
 Configure the second required notification destination by naming the
 environment variable that contains its webhook URL. Store only the variable
 name in the manifest; the URL and any secret-bearing routing token remain in
-the execution environment.
+the execution environment. The executor must also set the fixed
+`BOOTSTRAP_NOTIFICATION_WEBHOOK_ALLOWED_HOSTS` variable to a comma-separated
+allowlist of exact webhook hostnames. The manifest cannot select or replace
+this allowlist.
 
 ```yaml
 notifications:
   webhookUrlEnv: BOOTSTRAP_NOTIFICATION_WEBHOOK_URL
 ```
+
+```sh
+export BOOTSTRAP_NOTIFICATION_WEBHOOK_ALLOWED_HOSTS=hooks.example.com
+```
+
+Delivery accepts only HTTPS on port 443, resolves every allowlisted hostname
+before connecting, and rejects loopback, link-local, private, multicast, and
+reserved addresses. The built-in transport pins a validated public address for
+the TLS connection so a second DNS lookup cannot rebind the destination.
 
 Describe one material action in a JSON file. The governing target accepts a
 local issue or pull request such as `#55`, an `owner/repo#55` shorthand, or a

--- a/docs/bootstrap/policy-exceptions.md
+++ b/docs/bootstrap/policy-exceptions.md
@@ -24,26 +24,15 @@ exceptions:
 ## Material-action notifications and hard stops
 
 Configure the second required notification destination by naming the
-environment variable that contains its webhook URL. Store only the variable
+environment variable that will contain its webhook URL. Store only the variable
 name in the manifest; the URL and any secret-bearing routing token remain in
-the execution environment. The executor must also set the fixed
-`BOOTSTRAP_NOTIFICATION_WEBHOOK_ALLOWED_HOSTS` variable to a comma-separated
-allowlist of exact webhook hostnames. The manifest cannot select or replace
-this allowlist.
+the execution environment. Webhook transmission remains disabled and fails
+closed until the secure transport follow-up is merged.
 
 ```yaml
 notifications:
   webhookUrlEnv: BOOTSTRAP_NOTIFICATION_WEBHOOK_URL
 ```
-
-```sh
-export BOOTSTRAP_NOTIFICATION_WEBHOOK_ALLOWED_HOSTS=hooks.example.com
-```
-
-Delivery accepts only HTTPS on port 443, resolves every allowlisted hostname
-before connecting, and rejects loopback, link-local, private, multicast, and
-reserved addresses. The built-in transport pins a validated public address for
-the TLS connection so a second DNS lookup cannot rebind the destination.
 
 Describe one material action in a JSON file. The governing target accepts a
 local issue or pull request such as `#55`, an `owner/repo#55` shorthand, or a
@@ -75,8 +64,9 @@ bootstrap notifications exceptions --manifest project.bootstrap.yaml --deliver
 
 All notification commands support `--json` and return stable `PRS-NOTIFY-001` and
 `PRS-HARDSTOP-001` results. Delivery writes the redacted notification to the
-governing GitHub issue or pull request and to the configured HTTPS webhook. A
-failed destination blocks continuation.
+governing GitHub issue or pull request. The configured webhook destination
+remains blocking until the secure transport follow-up is merged, so ordinary
+material actions cannot continue on partial delivery.
 
 For a defined hard stop, add its category plus explicit human approval
 evidence. Planning and delivery remain blocking until both fields are present:

--- a/docs/bootstrap/policy-exceptions.md
+++ b/docs/bootstrap/policy-exceptions.md
@@ -20,3 +20,82 @@ exceptions:
     issue: https://github.com/OMT-Global/bootstrap/issues/55
     expiresAt: 2026-09-01
 ```
+
+## Material-action notifications and hard stops
+
+Configure the second required notification destination by naming the
+environment variable that contains its webhook URL. Store only the variable
+name in the manifest; the URL and any secret-bearing routing token remain in
+the execution environment.
+
+```yaml
+notifications:
+  webhookUrlEnv: BOOTSTRAP_NOTIFICATION_WEBHOOK_URL
+```
+
+Describe one material action in a JSON file. The governing target accepts a
+local issue or pull request such as `#55`, an `owner/repo#55` shorthand, or a
+full GitHub issue or pull-request URL.
+
+```json
+{
+  "id": "release-policy-2026-07-16",
+  "action": "repository-settings-change",
+  "summary": "Enable private vulnerability reporting.",
+  "governingTarget": "#55"
+}
+```
+
+Plan before delivery:
+
+```sh
+bootstrap notifications plan --manifest project.bootstrap.yaml --input material-action.json
+bootstrap notifications deliver --manifest project.bootstrap.yaml --input material-action.json
+```
+
+Bootstrap also converts the manifest's expiring-exception intents directly.
+This is plan-only unless `--deliver` is explicit:
+
+```sh
+bootstrap notifications exceptions --manifest project.bootstrap.yaml
+bootstrap notifications exceptions --manifest project.bootstrap.yaml --deliver
+```
+
+All notification commands support `--json` and return stable `PRS-NOTIFY-001` and
+`PRS-HARDSTOP-001` results. Delivery writes the redacted notification to the
+governing GitHub issue or pull request and to the configured HTTPS webhook. A
+failed destination blocks continuation.
+
+For a defined hard stop, add its category plus explicit human approval
+evidence. Planning and delivery remain blocking until both fields are present:
+
+```json
+{
+  "id": "license-change-2026-07-16",
+  "action": "license-change",
+  "summary": "Apply the approved repository license change.",
+  "governingTarget": "https://github.com/acme/example/issues/55",
+  "approval": {
+    "evidence": "https://github.com/acme/example/issues/55#issuecomment-1"
+  }
+}
+```
+
+The evidence comment must be on the governing issue or pull request, authored
+by a configured `github.reviewers` maintainer, and contain this exact marker:
+
+```text
+APPROVE PRS-HARDSTOP-001 action=license-change-2026-07-16 category=license-change digest=0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+```
+
+The action category is the canonical Flow hard-stop category; there is no
+separate caller-controlled hard-stop flag. Planning records that verification
+is required and returns the canonical `approvalDigest`; copy that exact digest
+into the approval marker. The digest binds the action ID, category, summary,
+and governing target so approval cannot be replayed after any of those fields
+change. Delivery fetches and verifies the GitHub comment before returning an
+approved result.
+
+Notification delivery still occurs for a blocked hard stop so the governing
+record captures the request. Work continues only when both required
+destinations succeed and the hard stop has explicit approval evidence.

--- a/docs/bootstrap/repository-class-migration.md
+++ b/docs/bootstrap/repository-class-migration.md
@@ -23,3 +23,26 @@ to `infrastructure` instead.
 `project.maturity` describes the product lifecycle (`experimental` through
 `archived`). It is intentionally independent from `release.maturity`, which
 selects the release-automation profile.
+
+## Publisher defaults and class deviations
+
+The resolved publisher key defaults to `project.owner`. A publisher can set a
+different stable key and an explicit spending approval threshold with a
+non-negative amount and three-letter ISO currency code:
+
+```yaml
+publisher:
+  key: acme-public
+  spendingApprovalThreshold:
+    amount: 500
+    currency: USD
+```
+
+Bootstrap does not invent a monetary threshold when the publisher omits one.
+Callers must treat that state as an unresolved human decision rather than as
+permission to spend.
+
+A repository that cannot yet declare one of the seven canonical classes must
+carry a currently valid policy exception with `policy:
+repository-classification` and `scope: repo.class`. Missing, expired, or
+otherwise invalid exceptions remain blocking conformance violations.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -16,6 +16,14 @@ import {
 import { planRepo, applyRepo } from "./render.js";
 import { createPublicProvenance, validatePublicProvenance } from "./provenance.js";
 import { planFleetPolicyUpgrades, type FleetUpgradeCandidate } from "./upgrades.js";
+import {
+  deliverExceptionNotifications,
+  deliverMaterialAction,
+  formatExceptionNotificationReport,
+  formatMaterialActionReport,
+  planExceptionNotifications,
+  planMaterialAction
+} from "./notifications.js";
 
 function defaultTargetDir(manifest: Awaited<ReturnType<typeof loadManifest>>, cwd = process.cwd()): string {
   const currentBasename = path.basename(cwd);
@@ -73,6 +81,11 @@ function formatFleetReport(report: Awaited<ReturnType<typeof reconcileFleet>>): 
       return `- ${details.join(" - ")}`;
     })
   ].join("\n");
+}
+
+async function readJsonInput(inputPath: string): Promise<unknown> {
+  const raw = await import("node:fs/promises").then(({ readFile }) => readFile(path.resolve(inputPath), "utf8"));
+  return JSON.parse(raw) as unknown;
 }
 
 async function main(): Promise<void> {
@@ -270,6 +283,53 @@ async function main(): Promise<void> {
       const targetDir = options.target ? path.resolve(options.target) : defaultTargetDir(manifest);
       const report = await runConformance(manifest, targetDir);
       process.stdout.write(`${options.json ? JSON.stringify(report, null, 2) : formatConformanceReport(report)}\n`);
+      process.exitCode = report.exitCode;
+    });
+
+  const notifications = program
+    .command("notifications")
+    .description("Plan or deliver material-action notifications and enforce defined human hard stops.");
+
+  notifications
+    .command("plan")
+    .description("Validate a material action and print its non-mutating notification plan.")
+    .requiredOption("--input <path>", "Path to a material-action JSON document")
+    .option("--manifest <path>", "Path to manifest")
+    .option("--json", "Emit versioned JSON")
+    .action(async (options) => {
+      const manifest = await loadManifest(resolveManifestPath(options.manifest));
+      const report = planMaterialAction(manifest, await readJsonInput(options.input));
+      process.stdout.write(`${options.json ? JSON.stringify(report, null, 2) : formatMaterialActionReport(report)}\n`);
+      process.exitCode = report.exitCode;
+    });
+
+  notifications
+    .command("deliver")
+    .description("Write a material-action notification to its governing GitHub target and configured webhook.")
+    .requiredOption("--input <path>", "Path to a material-action JSON document")
+    .option("--manifest <path>", "Path to manifest")
+    .option("--json", "Emit versioned JSON")
+    .action(async (options) => {
+      const manifest = await loadManifest(resolveManifestPath(options.manifest));
+      const report = await deliverMaterialAction(manifest, await readJsonInput(options.input));
+      process.stdout.write(`${options.json ? JSON.stringify(report, null, 2) : formatMaterialActionReport(report)}\n`);
+      process.exitCode = report.exitCode;
+    });
+
+  notifications
+    .command("exceptions")
+    .description("Plan expiring-exception notifications, or deliver them with --deliver.")
+    .option("--manifest <path>", "Path to manifest")
+    .option("--deliver", "Write notifications to the governing GitHub targets and configured webhook")
+    .option("--json", "Emit versioned JSON")
+    .action(async (options) => {
+      const manifest = await loadManifest(resolveManifestPath(options.manifest));
+      const report = options.deliver
+        ? await deliverExceptionNotifications(manifest)
+        : planExceptionNotifications(manifest);
+      process.stdout.write(
+        `${options.json ? JSON.stringify(report, null, 2) : formatExceptionNotificationReport(report)}\n`
+      );
       process.exitCode = report.exitCode;
     });
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -305,7 +305,7 @@ async function main(): Promise<void> {
 
   notifications
     .command("deliver")
-    .description("Write a material-action notification to its governing GitHub target and configured webhook.")
+    .description("Write a material-action notification to its governing GitHub target; configured webhook delivery is currently disabled.")
     .requiredOption("--input <path>", "Path to a material-action JSON document")
     .option("--manifest <path>", "Path to manifest")
     .option("--json", "Emit versioned JSON")
@@ -320,7 +320,7 @@ async function main(): Promise<void> {
     .command("exceptions")
     .description("Plan expiring-exception notifications, or deliver them with --deliver.")
     .option("--manifest <path>", "Path to manifest")
-    .option("--deliver", "Write notifications to the governing GitHub targets and configured webhook")
+    .option("--deliver", "Write notifications to governing GitHub targets; configured webhook delivery is currently disabled")
     .option("--json", "Emit versioned JSON")
     .action(async (options) => {
       const manifest = await loadManifest(resolveManifestPath(options.manifest));

--- a/src/conformance.ts
+++ b/src/conformance.ts
@@ -47,10 +47,27 @@ function summary(results: ConformanceResult[]): ConformanceReport["summary"] {
 
 export async function runConformance(manifest: BootstrapManifest, targetDir: string): Promise<ConformanceReport> {
   const results: ConformanceResult[] = [];
+  const exceptionReport = validatePolicyExceptions(manifest.exceptions);
+  const validExceptionIds = new Set(
+    exceptionReport.results.filter((entry) => entry.status !== "block").map((entry) => entry.exceptionId)
+  );
+  const classException = manifest.exceptions.find(
+    (entry) =>
+      entry.policy === "repository-classification" &&
+      entry.scope === "repo.class" &&
+      validExceptionIds.has(entry.id)
+  );
 
   results.push(
     manifest.repo.class
       ? result("PRS-CLASS-001", "pass", [manifest.repo.class], "Keep the canonical repository class current.")
+      : classException
+        ? result(
+            "PRS-CLASS-001",
+            "pass",
+            [`approved exception ${classException.id}`],
+            "Keep the approved repository-classification exception current until a canonical class is declared."
+          )
       : result("PRS-CLASS-001", "blocking", ["repo.class is absent"], "Declare a canonical repo.class or complete an explicit legacy migration.")
   );
   results.push(
@@ -75,7 +92,7 @@ export async function runConformance(manifest: BootstrapManifest, targetDir: str
     }
   }
 
-  for (const exception of validatePolicyExceptions(manifest.exceptions).results) {
+  for (const exception of exceptionReport.results) {
     results.push(
       result(
         exception.ruleId,

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -208,6 +208,10 @@ const publisherSchema = z.object({
     .optional()
 });
 
+const notificationSchema = z.object({
+  webhookUrlEnv: z.string().regex(/^[A-Z_][A-Z0-9_]*$/)
+});
+
 const exceptionSchema = z.object({
   id: z.string().min(1),
   policy: z.string().min(1),
@@ -302,6 +306,7 @@ const manifestSchema = z.object({
     defaultBranch: z.string().min(1).optional()
   }),
   publisher: publisherSchema.optional(),
+  notifications: notificationSchema.optional(),
   repo: z
     .object({
       class: z
@@ -431,7 +436,7 @@ const manifestSchema = z.object({
 }).passthrough();
 
 const KNOWN_MANIFEST_SETTINGS = new Set([
-  "version", "project", "publisher", "repo", "archetype", "github", "ci", "release", "agents", "capabilities", "policy", "exceptions", "environments"
+  "version", "project", "publisher", "notifications", "repo", "archetype", "github", "ci", "release", "agents", "capabilities", "policy", "exceptions", "environments"
 ]);
 
 function slugify(value: string): string {
@@ -776,6 +781,7 @@ export function normalizeManifest(raw: z.input<typeof manifestSchema>): Bootstra
         ? { spendingApprovalThreshold: { ...parsed.publisher.spendingApprovalThreshold } }
         : {})
     },
+    ...(parsed.notifications ? { notifications: { ...parsed.notifications } } : {}),
     repo: normalizeRepo(parsed.repo),
     archetype: {
       kind: parsed.archetype.kind,
@@ -944,6 +950,7 @@ export async function loadManifest(manifestPath: string): Promise<BootstrapManif
 interface ManifestOverrides {
   project?: Partial<BootstrapManifest["project"]>;
   publisher?: Partial<BootstrapManifest["publisher"]>;
+  notifications?: BootstrapManifest["notifications"];
   repo?: Partial<BootstrapManifest["repo"]>;
   archetype?: Partial<BootstrapManifest["archetype"]>;
   github?: Partial<BootstrapManifest["github"]>;
@@ -967,6 +974,7 @@ export function createSampleManifest(overrides?: ManifestOverrides): string {
       defaultBranch: overrides?.project?.defaultBranch ?? "main"
     },
     publisher: overrides?.publisher,
+    notifications: overrides?.notifications,
     repo: overrides?.repo,
     archetype: {
       kind: overrides?.archetype?.kind ?? "node-ts-service",

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -196,6 +196,18 @@ const policySchema = z.object({
   })
 });
 
+const publisherSchema = z.object({
+  key: z.string().min(1).optional(),
+  spendingApprovalThreshold: z
+    .object({
+      amount: z.number().finite().nonnegative(),
+      currency: z
+        .string()
+        .refine((value) => Intl.supportedValuesOf("currency").includes(value), "Use a supported ISO 4217 currency code.")
+    })
+    .optional()
+});
+
 const exceptionSchema = z.object({
   id: z.string().min(1),
   policy: z.string().min(1),
@@ -289,6 +301,7 @@ const manifestSchema = z.object({
     owner: z.string().min(1),
     defaultBranch: z.string().min(1).optional()
   }),
+  publisher: publisherSchema.optional(),
   repo: z
     .object({
       class: z
@@ -418,7 +431,7 @@ const manifestSchema = z.object({
 }).passthrough();
 
 const KNOWN_MANIFEST_SETTINGS = new Set([
-  "version", "project", "repo", "archetype", "github", "ci", "release", "agents", "capabilities", "policy", "exceptions", "environments"
+  "version", "project", "publisher", "repo", "archetype", "github", "ci", "release", "agents", "capabilities", "policy", "exceptions", "environments"
 ]);
 
 function slugify(value: string): string {
@@ -757,6 +770,12 @@ export function normalizeManifest(raw: z.input<typeof manifestSchema>): Bootstra
       owner: parsed.project.owner,
       defaultBranch
     },
+    publisher: {
+      key: parsed.publisher?.key ?? parsed.project.owner,
+      ...(parsed.publisher?.spendingApprovalThreshold
+        ? { spendingApprovalThreshold: { ...parsed.publisher.spendingApprovalThreshold } }
+        : {})
+    },
     repo: normalizeRepo(parsed.repo),
     archetype: {
       kind: parsed.archetype.kind,
@@ -924,6 +943,7 @@ export async function loadManifest(manifestPath: string): Promise<BootstrapManif
 
 interface ManifestOverrides {
   project?: Partial<BootstrapManifest["project"]>;
+  publisher?: Partial<BootstrapManifest["publisher"]>;
   repo?: Partial<BootstrapManifest["repo"]>;
   archetype?: Partial<BootstrapManifest["archetype"]>;
   github?: Partial<BootstrapManifest["github"]>;
@@ -946,6 +966,7 @@ export function createSampleManifest(overrides?: ManifestOverrides): string {
       owner: overrides?.project?.owner ?? "your-org",
       defaultBranch: overrides?.project?.defaultBranch ?? "main"
     },
+    publisher: overrides?.publisher,
     repo: overrides?.repo,
     archetype: {
       kind: overrides?.archetype?.kind ?? "node-ts-service",
@@ -964,7 +985,11 @@ export function createSampleManifest(overrides?: ManifestOverrides): string {
 }
 
 function serializableManifest(manifest: BootstrapManifest): BootstrapManifest | Record<string, unknown> {
-  const { unknownSettings: _unknownSettings, ...serializable } = manifest;
+  const { unknownSettings: _unknownSettings, publisher, ...withoutInternalSettings } = manifest;
+  const serializable =
+    publisher.key === manifest.project.owner && publisher.spendingApprovalThreshold === undefined
+      ? withoutInternalSettings
+      : { ...withoutInternalSettings, publisher };
   if (manifest.version !== 2 || !manifest.capabilities?.release) {
     return serializable;
   }

--- a/src/notifications.ts
+++ b/src/notifications.ts
@@ -1,7 +1,4 @@
 import { createHash } from "node:crypto";
-import { lookup } from "node:dns/promises";
-import { request as httpsRequest } from "node:https";
-import { BlockList, isIP, type LookupFunction } from "node:net";
 
 import { z } from "zod";
 
@@ -156,23 +153,8 @@ interface GitHubCollaboratorPermission {
 
 const maintainerRoles = new Set(["admin", "maintain"]);
 
-export interface WebhookResult {
-  ok: boolean;
-  status: number;
-}
-
-export type WebhookSender = (url: string, payload: MaterialActionPlan["webhookPayload"]) => Promise<WebhookResult>;
-export interface ResolvedWebhookAddress {
-  address: string;
-  family: 4 | 6;
-}
-export type WebhookResolver = (hostname: string) => Promise<ResolvedWebhookAddress[]>;
-
 export interface DeliveryOptions {
   githubClient?: GitHubClient;
-  environment?: NodeJS.ProcessEnv;
-  webhookSender?: WebhookSender;
-  webhookResolver?: WebhookResolver;
 }
 
 export interface ExceptionDeliveryOptions extends DeliveryOptions {
@@ -473,197 +455,6 @@ export function planMaterialAction(manifest: BootstrapManifest, input: unknown):
   });
 }
 
-const WEBHOOK_ALLOWED_HOSTS_ENV = "BOOTSTRAP_NOTIFICATION_WEBHOOK_ALLOWED_HOSTS";
-const reservedWebhookIpv4Addresses = new BlockList();
-const reservedWebhookIpv6Addresses = new BlockList();
-const publicWebhookIpv6Addresses = new BlockList();
-publicWebhookIpv6Addresses.addSubnet("2000::", 3, "ipv6");
-
-for (const [network, prefix] of [
-  ["0.0.0.0", 8],
-  ["10.0.0.0", 8],
-  ["100.64.0.0", 10],
-  ["127.0.0.0", 8],
-  ["169.254.0.0", 16],
-  ["172.16.0.0", 12],
-  ["192.0.0.0", 24],
-  ["192.0.2.0", 24],
-  ["192.88.99.0", 24],
-  ["192.168.0.0", 16],
-  ["198.18.0.0", 15],
-  ["198.51.100.0", 24],
-  ["203.0.113.0", 24],
-  ["224.0.0.0", 4],
-  ["240.0.0.0", 4]
-] as const) {
-  reservedWebhookIpv4Addresses.addSubnet(network, prefix, "ipv4");
-}
-
-for (const [network, prefix] of [
-  ["::", 128],
-  ["::1", 128],
-  ["::ffff:0:0", 96],
-  ["64:ff9b::", 96],
-  ["64:ff9b:1::", 48],
-  ["100::", 64],
-  ["2001::", 23],
-  ["2001:db8::", 32],
-  ["2002::", 16],
-  ["3fff::", 20],
-  ["fc00::", 7],
-  ["fe80::", 10],
-  ["ff00::", 8]
-] as const) {
-  reservedWebhookIpv6Addresses.addSubnet(network, prefix, "ipv6");
-}
-
-function normalizeWebhookHostname(hostname: string): string {
-  const withoutBrackets = hostname.startsWith("[") && hostname.endsWith("]") ? hostname.slice(1, -1) : hostname;
-  return withoutBrackets.replace(/\.$/, "").toLowerCase();
-}
-
-function approvedWebhookHosts(environment: NodeJS.ProcessEnv): Set<string> {
-  return new Set(
-    (environment[WEBHOOK_ALLOWED_HOSTS_ENV] ?? "")
-      .split(",")
-      .map((hostname) => normalizeWebhookHostname(hostname.trim()))
-      .filter(Boolean)
-  );
-}
-
-function isPublicWebhookAddress(address: string): address is string {
-  const family = isIP(address);
-  if (family === 4) return !reservedWebhookIpv4Addresses.check(address, "ipv4");
-  if (family === 6) {
-    return publicWebhookIpv6Addresses.check(address, "ipv6") && !reservedWebhookIpv6Addresses.check(address, "ipv6");
-  }
-  return false;
-}
-
-const defaultWebhookResolver: WebhookResolver = async (hostname) => {
-  const family = isIP(hostname);
-  if (family === 4 || family === 6) return [{ address: hostname, family }];
-  const addresses = await lookup(hostname, { all: true, verbatim: true });
-  return addresses.map(({ address, family: resolvedFamily }) => ({
-    address,
-    family: resolvedFamily === 6 ? 6 : 4
-  }));
-};
-
-async function validateWebhookDestination(
-  webhookUrl: string,
-  environment: NodeJS.ProcessEnv,
-  resolver: WebhookResolver,
-  deadline: number
-): Promise<{ url: URL; addresses: ResolvedWebhookAddress[] }> {
-  const url = new URL(webhookUrl);
-  if (url.protocol !== "https:") throw new Error("Webhook must use HTTPS.");
-  if (url.username || url.password) throw new Error("Webhook URLs must not contain credentials.");
-  if (url.port && url.port !== "443") throw new Error("Webhook delivery is restricted to HTTPS port 443.");
-
-  const hostname = normalizeWebhookHostname(url.hostname);
-  if (!approvedWebhookHosts(environment).has(hostname)) {
-    throw new Error(`Webhook hostname is not approved by ${WEBHOOK_ALLOWED_HOSTS_ENV}.`);
-  }
-
-  const addresses = await withDeadline(resolver(hostname), deadline, "Webhook hostname resolution timed out.");
-  if (addresses.length === 0) throw new Error("Webhook hostname did not resolve.");
-  const validated: ResolvedWebhookAddress[] = addresses.map(({ address }) => {
-    const family = isIP(address);
-    if ((family !== 4 && family !== 6) || !isPublicWebhookAddress(address)) {
-      throw new Error("Webhook hostname resolved to a non-public address.");
-    }
-    return { address, family: family as 4 | 6 };
-  });
-  return { url, addresses: validated };
-}
-
-async function withDeadline<T>(operation: Promise<T>, deadline: number, message: string): Promise<T> {
-  const remainingMilliseconds = deadline - Date.now();
-  if (remainingMilliseconds <= 0) throw new Error(message);
-
-  let timer: NodeJS.Timeout | undefined;
-  try {
-    return await Promise.race([
-      operation,
-      new Promise<never>((_resolve, reject) => {
-        timer = setTimeout(() => reject(new Error(message)), remainingMilliseconds);
-      })
-    ]);
-  } finally {
-    if (timer) clearTimeout(timer);
-  }
-}
-
-function pinnedLookup(address: ResolvedWebhookAddress): LookupFunction {
-  return ((_hostname, options, callback) => {
-    if (typeof options === "object" && options.all) {
-      callback(null, [address]);
-      return;
-    }
-    callback(null, address.address, address.family);
-  }) as LookupFunction;
-}
-
-function sendWebhookToAddress(
-  url: URL,
-  body: string,
-  address: ResolvedWebhookAddress,
-  timeoutMilliseconds: number
-): Promise<WebhookResult> {
-  return new Promise((resolve, reject) => {
-    const request = httpsRequest(
-      url,
-      {
-        method: "POST",
-        headers: {
-          "content-type": "application/json",
-          "content-length": Buffer.byteLength(body)
-        },
-        agent: false,
-        lookup: pinnedLookup(address),
-        signal: AbortSignal.timeout(timeoutMilliseconds)
-      },
-      (response) => {
-        response.once("error", reject);
-        response.resume();
-        response.once("end", () =>
-          resolve({
-            ok: response.statusCode !== undefined && response.statusCode >= 200 && response.statusCode < 300,
-            status: response.statusCode ?? 0
-          })
-        );
-      }
-    );
-    request.once("error", reject);
-    request.end(body);
-  });
-}
-
-async function defaultWebhookSender(
-  url: URL,
-  payload: MaterialActionPlan["webhookPayload"],
-  addresses: ResolvedWebhookAddress[],
-  deadline: number
-): Promise<WebhookResult> {
-  const body = JSON.stringify(payload);
-  let lastError: unknown;
-
-  for (const [index, address] of addresses.entries()) {
-    const remainingMilliseconds = deadline - Date.now();
-    if (remainingMilliseconds <= 0) break;
-    const remainingAddresses = addresses.length - index;
-    const attemptMilliseconds = Math.max(1, Math.floor(remainingMilliseconds / remainingAddresses));
-    try {
-      return await sendWebhookToAddress(url, body, address, attemptMilliseconds);
-    } catch (error) {
-      lastError = error;
-    }
-  }
-
-  throw lastError instanceof Error ? lastError : new Error("Webhook delivery exhausted all validated addresses.");
-}
-
 export async function deliverMaterialAction(
   manifest: BootstrapManifest,
   input: unknown,
@@ -673,8 +464,6 @@ export async function deliverMaterialAction(
   const plan = planMaterialAction(manifest, input);
   const githubTarget = parseGitHubTarget(plan.governingTarget, manifest);
   const githubClient = options.githubClient ?? new GitHubClient();
-  const environment = options.environment ?? process.env;
-  const webhookResolver = options.webhookResolver ?? defaultWebhookResolver;
   const destinations: MaterialActionPlan["notification"]["destinations"] = [];
   const hardStop = await verifiedHardStopResult(action, manifest, githubTarget, githubClient);
   const commentBody = materialActionCommentBody(action, buildPublicPayload(action), hardStop, plan.approvalDigest);
@@ -706,46 +495,13 @@ export async function deliverMaterialAction(
     }
   }
 
-  const webhookEnvironmentName = manifest.notifications?.webhookUrlEnv;
-  const webhookUrl = webhookEnvironmentName ? environment[webhookEnvironmentName] : undefined;
-  if (!githubTarget) {
-    destinations.push({
-      destination: "configured-webhook",
-      status: "failed",
-      detail: "Webhook delivery skipped because the governing target is invalid."
-    });
-  } else if (!webhookEnvironmentName || !webhookUrl) {
-    destinations.push({
-      destination: "configured-webhook",
-      status: "failed",
-      detail: webhookEnvironmentName
-        ? `Environment variable ${webhookEnvironmentName} is not set.`
-        : "No webhook environment-variable reference is configured."
-    });
-  } else {
-    try {
-      const deadline = Date.now() + 10_000;
-      const destination = await validateWebhookDestination(webhookUrl, environment, webhookResolver, deadline);
-      const response = options.webhookSender
-        ? await withDeadline(
-            options.webhookSender(webhookUrl, plan.webhookPayload),
-            deadline,
-            "Webhook delivery timed out."
-          )
-        : await defaultWebhookSender(destination.url, plan.webhookPayload, destination.addresses, deadline);
-      destinations.push({
-        destination: "configured-webhook",
-        status: response.ok ? "delivered" : "failed",
-        detail: response.ok ? `Webhook returned HTTP ${response.status}.` : `Webhook rejected delivery with HTTP ${response.status}.`
-      });
-    } catch {
-      destinations.push({
-        destination: "configured-webhook",
-        status: "failed",
-        detail: "Webhook delivery failed."
-      });
-    }
-  }
+  destinations.push({
+    destination: "configured-webhook",
+    status: "failed",
+    detail: githubTarget
+      ? "Webhook delivery is disabled until the secure transport follow-up is merged."
+      : "Webhook delivery skipped because the governing target is invalid."
+  });
 
   const delivered = destinations.every((destination) => destination.status === "delivered");
   const notification = notificationResultSchema.parse({

--- a/src/notifications.ts
+++ b/src/notifications.ts
@@ -1,4 +1,7 @@
 import { createHash } from "node:crypto";
+import { lookup } from "node:dns/promises";
+import { request as httpsRequest } from "node:https";
+import { BlockList, isIP, type LookupFunction } from "node:net";
 
 import { z } from "zod";
 
@@ -153,8 +156,23 @@ interface GitHubCollaboratorPermission {
 
 const maintainerRoles = new Set(["admin", "maintain"]);
 
+export interface WebhookResult {
+  ok: boolean;
+  status: number;
+}
+
+export type WebhookSender = (url: string, payload: MaterialActionPlan["webhookPayload"]) => Promise<WebhookResult>;
+export interface ResolvedWebhookAddress {
+  address: string;
+  family: 4 | 6;
+}
+export type WebhookResolver = (hostname: string) => Promise<ResolvedWebhookAddress[]>;
+
 export interface DeliveryOptions {
   githubClient?: GitHubClient;
+  environment?: NodeJS.ProcessEnv;
+  webhookSender?: WebhookSender;
+  webhookResolver?: WebhookResolver;
 }
 
 export interface ExceptionDeliveryOptions extends DeliveryOptions {
@@ -455,6 +473,197 @@ export function planMaterialAction(manifest: BootstrapManifest, input: unknown):
   });
 }
 
+const WEBHOOK_ALLOWED_HOSTS_ENV = "BOOTSTRAP_NOTIFICATION_WEBHOOK_ALLOWED_HOSTS";
+const reservedWebhookIpv4Addresses = new BlockList();
+const reservedWebhookIpv6Addresses = new BlockList();
+const publicWebhookIpv6Addresses = new BlockList();
+publicWebhookIpv6Addresses.addSubnet("2000::", 3, "ipv6");
+
+for (const [network, prefix] of [
+  ["0.0.0.0", 8],
+  ["10.0.0.0", 8],
+  ["100.64.0.0", 10],
+  ["127.0.0.0", 8],
+  ["169.254.0.0", 16],
+  ["172.16.0.0", 12],
+  ["192.0.0.0", 24],
+  ["192.0.2.0", 24],
+  ["192.88.99.0", 24],
+  ["192.168.0.0", 16],
+  ["198.18.0.0", 15],
+  ["198.51.100.0", 24],
+  ["203.0.113.0", 24],
+  ["224.0.0.0", 4],
+  ["240.0.0.0", 4]
+] as const) {
+  reservedWebhookIpv4Addresses.addSubnet(network, prefix, "ipv4");
+}
+
+for (const [network, prefix] of [
+  ["::", 128],
+  ["::1", 128],
+  ["::ffff:0:0", 96],
+  ["64:ff9b::", 96],
+  ["64:ff9b:1::", 48],
+  ["100::", 64],
+  ["2001::", 23],
+  ["2001:db8::", 32],
+  ["2002::", 16],
+  ["3fff::", 20],
+  ["fc00::", 7],
+  ["fe80::", 10],
+  ["ff00::", 8]
+] as const) {
+  reservedWebhookIpv6Addresses.addSubnet(network, prefix, "ipv6");
+}
+
+function normalizeWebhookHostname(hostname: string): string {
+  const withoutBrackets = hostname.startsWith("[") && hostname.endsWith("]") ? hostname.slice(1, -1) : hostname;
+  return withoutBrackets.replace(/\.$/, "").toLowerCase();
+}
+
+function approvedWebhookHosts(environment: NodeJS.ProcessEnv): Set<string> {
+  return new Set(
+    (environment[WEBHOOK_ALLOWED_HOSTS_ENV] ?? "")
+      .split(",")
+      .map((hostname) => normalizeWebhookHostname(hostname.trim()))
+      .filter(Boolean)
+  );
+}
+
+function isPublicWebhookAddress(address: string): address is string {
+  const family = isIP(address);
+  if (family === 4) return !reservedWebhookIpv4Addresses.check(address, "ipv4");
+  if (family === 6) {
+    return publicWebhookIpv6Addresses.check(address, "ipv6") && !reservedWebhookIpv6Addresses.check(address, "ipv6");
+  }
+  return false;
+}
+
+const defaultWebhookResolver: WebhookResolver = async (hostname) => {
+  const family = isIP(hostname);
+  if (family === 4 || family === 6) return [{ address: hostname, family }];
+  const addresses = await lookup(hostname, { all: true, verbatim: true });
+  return addresses.map(({ address, family: resolvedFamily }) => ({
+    address,
+    family: resolvedFamily === 6 ? 6 : 4
+  }));
+};
+
+async function validateWebhookDestination(
+  webhookUrl: string,
+  environment: NodeJS.ProcessEnv,
+  resolver: WebhookResolver,
+  deadline: number
+): Promise<{ url: URL; addresses: ResolvedWebhookAddress[] }> {
+  const url = new URL(webhookUrl);
+  if (url.protocol !== "https:") throw new Error("Webhook must use HTTPS.");
+  if (url.username || url.password) throw new Error("Webhook URLs must not contain credentials.");
+  if (url.port && url.port !== "443") throw new Error("Webhook delivery is restricted to HTTPS port 443.");
+
+  const hostname = normalizeWebhookHostname(url.hostname);
+  if (!approvedWebhookHosts(environment).has(hostname)) {
+    throw new Error(`Webhook hostname is not approved by ${WEBHOOK_ALLOWED_HOSTS_ENV}.`);
+  }
+
+  const addresses = await withDeadline(resolver(hostname), deadline, "Webhook hostname resolution timed out.");
+  if (addresses.length === 0) throw new Error("Webhook hostname did not resolve.");
+  const validated: ResolvedWebhookAddress[] = addresses.map(({ address }) => {
+    const family = isIP(address);
+    if ((family !== 4 && family !== 6) || !isPublicWebhookAddress(address)) {
+      throw new Error("Webhook hostname resolved to a non-public address.");
+    }
+    return { address, family: family as 4 | 6 };
+  });
+  return { url, addresses: validated };
+}
+
+async function withDeadline<T>(operation: Promise<T>, deadline: number, message: string): Promise<T> {
+  const remainingMilliseconds = deadline - Date.now();
+  if (remainingMilliseconds <= 0) throw new Error(message);
+
+  let timer: NodeJS.Timeout | undefined;
+  try {
+    return await Promise.race([
+      operation,
+      new Promise<never>((_resolve, reject) => {
+        timer = setTimeout(() => reject(new Error(message)), remainingMilliseconds);
+      })
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+function pinnedLookup(address: ResolvedWebhookAddress): LookupFunction {
+  return ((_hostname, options, callback) => {
+    if (typeof options === "object" && options.all) {
+      callback(null, [address]);
+      return;
+    }
+    callback(null, address.address, address.family);
+  }) as LookupFunction;
+}
+
+function sendWebhookToAddress(
+  url: URL,
+  body: string,
+  address: ResolvedWebhookAddress,
+  timeoutMilliseconds: number
+): Promise<WebhookResult> {
+  return new Promise((resolve, reject) => {
+    const request = httpsRequest(
+      url,
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "content-length": Buffer.byteLength(body)
+        },
+        agent: false,
+        lookup: pinnedLookup(address),
+        signal: AbortSignal.timeout(timeoutMilliseconds)
+      },
+      (response) => {
+        response.once("error", reject);
+        response.resume();
+        response.once("end", () =>
+          resolve({
+            ok: response.statusCode !== undefined && response.statusCode >= 200 && response.statusCode < 300,
+            status: response.statusCode ?? 0
+          })
+        );
+      }
+    );
+    request.once("error", reject);
+    request.end(body);
+  });
+}
+
+async function defaultWebhookSender(
+  url: URL,
+  payload: MaterialActionPlan["webhookPayload"],
+  addresses: ResolvedWebhookAddress[],
+  deadline: number
+): Promise<WebhookResult> {
+  const body = JSON.stringify(payload);
+  let lastError: unknown;
+
+  for (const [index, address] of addresses.entries()) {
+    const remainingMilliseconds = deadline - Date.now();
+    if (remainingMilliseconds <= 0) break;
+    const remainingAddresses = addresses.length - index;
+    const attemptMilliseconds = Math.max(1, Math.floor(remainingMilliseconds / remainingAddresses));
+    try {
+      return await sendWebhookToAddress(url, body, address, attemptMilliseconds);
+    } catch (error) {
+      lastError = error;
+    }
+  }
+
+  throw lastError instanceof Error ? lastError : new Error("Webhook delivery exhausted all validated addresses.");
+}
+
 export async function deliverMaterialAction(
   manifest: BootstrapManifest,
   input: unknown,
@@ -464,6 +673,8 @@ export async function deliverMaterialAction(
   const plan = planMaterialAction(manifest, input);
   const githubTarget = parseGitHubTarget(plan.governingTarget, manifest);
   const githubClient = options.githubClient ?? new GitHubClient();
+  const environment = options.environment ?? process.env;
+  const webhookResolver = options.webhookResolver ?? defaultWebhookResolver;
   const destinations: MaterialActionPlan["notification"]["destinations"] = [];
   const hardStop = await verifiedHardStopResult(action, manifest, githubTarget, githubClient);
   const commentBody = materialActionCommentBody(action, buildPublicPayload(action), hardStop, plan.approvalDigest);
@@ -495,13 +706,46 @@ export async function deliverMaterialAction(
     }
   }
 
-  destinations.push({
-    destination: "configured-webhook",
-    status: "failed",
-    detail: githubTarget
-      ? "Webhook delivery is disabled until the secure transport follow-up is merged."
-      : "Webhook delivery skipped because the governing target is invalid."
-  });
+  const webhookEnvironmentName = manifest.notifications?.webhookUrlEnv;
+  const webhookUrl = webhookEnvironmentName ? environment[webhookEnvironmentName] : undefined;
+  if (!githubTarget) {
+    destinations.push({
+      destination: "configured-webhook",
+      status: "failed",
+      detail: "Webhook delivery skipped because the governing target is invalid."
+    });
+  } else if (!webhookEnvironmentName || !webhookUrl) {
+    destinations.push({
+      destination: "configured-webhook",
+      status: "failed",
+      detail: webhookEnvironmentName
+        ? `Environment variable ${webhookEnvironmentName} is not set.`
+        : "No webhook environment-variable reference is configured."
+    });
+  } else {
+    try {
+      const deadline = Date.now() + 10_000;
+      const destination = await validateWebhookDestination(webhookUrl, environment, webhookResolver, deadline);
+      const response = options.webhookSender
+        ? await withDeadline(
+            options.webhookSender(webhookUrl, plan.webhookPayload),
+            deadline,
+            "Webhook delivery timed out."
+          )
+        : await defaultWebhookSender(destination.url, plan.webhookPayload, destination.addresses, deadline);
+      destinations.push({
+        destination: "configured-webhook",
+        status: response.ok ? "delivered" : "failed",
+        detail: response.ok ? `Webhook returned HTTP ${response.status}.` : `Webhook rejected delivery with HTTP ${response.status}.`
+      });
+    } catch {
+      destinations.push({
+        destination: "configured-webhook",
+        status: "failed",
+        detail: "Webhook delivery failed."
+      });
+    }
+  }
 
   const delivered = destinations.every((destination) => destination.status === "delivered");
   const notification = notificationResultSchema.parse({

--- a/src/notifications.ts
+++ b/src/notifications.ts
@@ -1,0 +1,649 @@
+import { createHash } from "node:crypto";
+
+import { z } from "zod";
+
+import { GitHubClient } from "./github/client.js";
+import { validatePolicyExceptions } from "./exceptions.js";
+import { containsCredential, redactPublicText } from "./provenance.js";
+import type { BootstrapManifest } from "./types.js";
+
+export const MATERIAL_ACTIONS = [
+  "adr-change",
+  "public-api-change",
+  "breaking-compatibility-change",
+  "database-migration",
+  "runtime-dependency-addition",
+  "authentication-authorization-change",
+  "security-finding-or-waiver",
+  "production-deployment",
+  "release-publication",
+  "repository-visibility-change",
+  "repository-settings-change",
+  "material-recurring-cost",
+  "policy-exception",
+  "major-feature-removal",
+  "provenance-capture-failure",
+  "conformance-bypass"
+] as const;
+
+export const HUMAN_HARD_STOP_CATEGORIES = [
+  "license-change",
+  "public-ownership-change",
+  "repository-ownership-transfer",
+  "expose-previously-private-data",
+  "irreversible-production-data-destruction",
+  "external-legal-contractual-obligation",
+  "spend-above-configured-threshold",
+  "grant-organization-owner-permission",
+  "grant-billing-permission",
+  "permanent-policy-exception"
+] as const;
+
+export const ACTION_CATEGORIES = [...MATERIAL_ACTIONS, ...HUMAN_HARD_STOP_CATEGORIES] as const;
+const hardStopCategorySet = new Set<string>(HUMAN_HARD_STOP_CATEGORIES);
+
+export const materialActionSchema = z
+  .object({
+    id: z.string().regex(/^[A-Za-z0-9._-]+$/),
+    action: z.enum(ACTION_CATEGORIES),
+    summary: z
+      .string()
+      .min(1)
+      .max(2_000)
+      .refine((value) => !/[\r\n\u2028\u2029]/.test(value), "Material-action summaries must be a single line."),
+    governingTarget: z.string().min(1),
+    approval: z
+      .object({
+        evidence: z.string().url()
+      })
+      .optional()
+  })
+  .superRefine((action, context) => {
+    if (containsCredential(action.id)) {
+      context.addIssue({ code: "custom", path: ["id"], message: "Action IDs must not contain credential-like literals." });
+    }
+    if (action.approval && !hardStopCategorySet.has(action.action)) {
+      context.addIssue({ code: "custom", path: ["approval"], message: "Approval evidence is valid only for a defined human hard-stop category." });
+    }
+    if (containsCredential(action.governingTarget)) {
+      context.addIssue({ code: "custom", path: ["governingTarget"], message: "Governing targets must not contain credential-like literals." });
+    }
+  });
+
+export type MaterialAction = z.infer<typeof materialActionSchema>;
+
+const hardStopResultSchema = z.object({
+  ruleId: z.literal("PRS-HARDSTOP-001"),
+  status: z.enum(["not-applicable", "verification-required", "approved", "blocking"]),
+  category: z.enum(HUMAN_HARD_STOP_CATEGORIES).optional(),
+  detail: z.string()
+});
+
+const notificationResultSchema = z.object({
+  ruleId: z.literal("PRS-NOTIFY-001"),
+  status: z.enum(["ready", "delivered", "blocking"]),
+  destinations: z.array(
+    z.object({
+      destination: z.enum(["governing-issue-or-pull-request", "configured-webhook"]),
+      status: z.enum(["planned", "delivered", "failed"]),
+      detail: z.string()
+    })
+  ),
+  detail: z.string()
+});
+
+const webhookPayloadSchema = z.object({
+  schemaVersion: z.literal(1),
+  ruleId: z.literal("PRS-NOTIFY-001"),
+  actionId: z.string(),
+  action: z.enum(ACTION_CATEGORIES),
+  summary: z.string(),
+  governingTarget: z.string(),
+  hardStopCategory: z.enum(HUMAN_HARD_STOP_CATEGORIES).optional(),
+  approvalDigest: z.string().regex(/^[0-9a-f]{64}$/).optional(),
+  approvalEvidence: z.string().optional()
+});
+
+export const materialActionPlanSchema = z.object({
+  schemaVersion: z.literal(1),
+  actionId: z.string(),
+  action: z.enum(ACTION_CATEGORIES),
+  governingTarget: z.string(),
+  approvalDigest: z.string().regex(/^[0-9a-f]{64}$/).optional(),
+  notification: notificationResultSchema,
+  hardStop: hardStopResultSchema,
+  continueAfterNotification: z.boolean(),
+  redactions: z.number().int().nonnegative(),
+  commentBody: z.string(),
+  webhookPayload: webhookPayloadSchema,
+  exitCode: z.union([z.literal(0), z.literal(1)])
+});
+
+export type MaterialActionPlan = z.infer<typeof materialActionPlanSchema>;
+export type MaterialActionDeliveryReport = MaterialActionPlan;
+
+export const exceptionNotificationReportSchema = z.object({
+  schemaVersion: z.literal(1),
+  mode: z.enum(["plan", "deliver"]),
+  notifications: z.array(materialActionPlanSchema),
+  blockingExceptions: z.boolean(),
+  exitCode: z.union([z.literal(0), z.literal(1)])
+});
+
+export type ExceptionNotificationReport = z.infer<typeof exceptionNotificationReportSchema>;
+
+interface GitHubTarget {
+  owner: string;
+  repo: string;
+  number: number;
+}
+
+interface GitHubIssueComment {
+  body?: string;
+  html_url?: string;
+  issue_url?: string;
+  author_association?: string;
+  user?: { login?: string };
+}
+
+interface GitHubCollaboratorPermission {
+  permission?: string;
+  role_name?: string;
+}
+
+const maintainerRoles = new Set(["admin", "maintain"]);
+
+export interface WebhookResult {
+  ok: boolean;
+  status: number;
+}
+
+export type WebhookSender = (url: string, payload: MaterialActionPlan["webhookPayload"]) => Promise<WebhookResult>;
+
+export interface DeliveryOptions {
+  githubClient?: GitHubClient;
+  environment?: NodeJS.ProcessEnv;
+  webhookSender?: WebhookSender;
+}
+
+export interface ExceptionDeliveryOptions extends DeliveryOptions {
+  now?: Date;
+}
+
+function parseGitHubTarget(value: string, manifest: BootstrapManifest): GitHubTarget | undefined {
+  const local = /^#([1-9][0-9]*)$/.exec(value);
+  if (local) {
+    const number = safePositiveInteger(local[1]!);
+    return number && validGitHubOwner(manifest.project.owner) && validGitHubRepo(manifest.project.name)
+      ? { owner: manifest.project.owner, repo: manifest.project.name, number }
+      : undefined;
+  }
+
+  const shorthand = /^([^/\s]+)\/([^/#\s]+)#([1-9][0-9]*)$/.exec(value);
+  if (shorthand) {
+    const number = safePositiveInteger(shorthand[3]!);
+    return number && validGitHubOwner(shorthand[1]!) && validGitHubRepo(shorthand[2]!)
+      ? { owner: shorthand[1]!, repo: shorthand[2]!, number }
+      : undefined;
+  }
+
+  const url = /^https:\/\/github\.com\/([^/\s]+)\/([^/\s]+)\/(?:issues|pull)\/([1-9][0-9]*)\/?$/.exec(value);
+  if (url) {
+    const number = safePositiveInteger(url[3]!);
+    return number && validGitHubOwner(url[1]!) && validGitHubRepo(url[2]!)
+      ? { owner: url[1]!, repo: url[2]!, number }
+      : undefined;
+  }
+
+  return undefined;
+}
+
+function validGitHubOwner(value: string): boolean {
+  return /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$/.test(value);
+}
+
+function validGitHubRepo(value: string): boolean {
+  return /^[A-Za-z0-9_.-]{1,100}$/.test(value) && value !== "." && value !== "..";
+}
+
+function safePositiveInteger(value: string): number | undefined {
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : undefined;
+}
+
+function parseApprovalEvidence(value: string): (GitHubTarget & { commentId: number }) | undefined {
+  const match = /^https:\/\/github\.com\/([^/\s]+)\/([^/\s]+)\/(?:issues|pull)\/([1-9][0-9]*)#issuecomment-([1-9][0-9]*)$/.exec(value);
+  if (!match) return undefined;
+  const number = safePositiveInteger(match[3]!);
+  const commentId = safePositiveInteger(match[4]!);
+  return number && commentId && validGitHubOwner(match[1]!) && validGitHubRepo(match[2]!)
+    ? { owner: match[1]!, repo: match[2]!, number, commentId }
+    : undefined;
+}
+
+function parseApiIssueUrl(value: string): GitHubTarget | undefined {
+  const match = /^https:\/\/api\.github\.com\/repos\/([^/\s]+)\/([^/\s]+)\/issues\/([1-9][0-9]*)\/?$/i.exec(value);
+  if (!match) return undefined;
+  const number = safePositiveInteger(match[3]!);
+  return number && validGitHubOwner(match[1]!) && validGitHubRepo(match[2]!)
+    ? { owner: match[1]!, repo: match[2]!, number }
+    : undefined;
+}
+
+function sameGitHubTarget(left: GitHubTarget, right: GitHubTarget): boolean {
+  return (
+    left.owner.toLowerCase() === right.owner.toLowerCase() &&
+    left.repo.toLowerCase() === right.repo.toLowerCase() &&
+    left.number === right.number
+  );
+}
+
+function approvalDigest(action: MaterialAction): string {
+  const canonical = JSON.stringify({
+    schemaVersion: 1,
+    id: action.id,
+    action: action.action,
+    summary: action.summary,
+    governingTarget: action.governingTarget
+  });
+  return createHash("sha256").update(canonical, "utf8").digest("hex");
+}
+
+async function verifiedHardStopResult(
+  action: MaterialAction,
+  manifest: BootstrapManifest,
+  governingTarget: GitHubTarget | undefined,
+  githubClient: GitHubClient
+): Promise<z.infer<typeof hardStopResultSchema>> {
+  const category = hardStopCategory(action);
+  if (!category || !action.approval || !governingTarget) return hardStopResult(action);
+  const evidence = parseApprovalEvidence(action.approval.evidence);
+  if (!evidence || !sameGitHubTarget(evidence, governingTarget)) {
+    return {
+      ruleId: "PRS-HARDSTOP-001",
+      status: "blocking",
+      category,
+      detail: `Approval evidence was not verified for ${category}.`
+    };
+  }
+
+  try {
+    const comment = await githubClient.api<GitHubIssueComment>(
+      "GET",
+      `/repos/${evidence.owner}/${evidence.repo}/issues/comments/${evidence.commentId}`
+    );
+    const author = comment.user?.login;
+    const returnedEvidence = comment.html_url ? parseApprovalEvidence(comment.html_url) : undefined;
+    const returnedIssue = comment.issue_url ? parseApiIssueUrl(comment.issue_url) : undefined;
+    const digest = approvalDigest(action);
+    const expectedMarker = `APPROVE PRS-HARDSTOP-001 action=${action.id} category=${category} digest=${digest}`;
+    const markerPresent = comment.body?.split(/\r?\n/).some((line) => line.trim() === expectedMarker) ?? false;
+    const commentVerified =
+      returnedEvidence !== undefined &&
+      returnedEvidence.commentId === evidence.commentId &&
+      sameGitHubTarget(returnedEvidence, evidence) &&
+      returnedIssue !== undefined &&
+      sameGitHubTarget(returnedIssue, evidence) &&
+      author !== undefined &&
+      manifest.github.reviewers.some((reviewer) => reviewer.toLowerCase() === author.toLowerCase()) &&
+      markerPresent;
+    const permission = commentVerified
+      ? await githubClient.api<GitHubCollaboratorPermission>(
+          "GET",
+          `/repos/${evidence.owner}/${evidence.repo}/collaborators/${encodeURIComponent(author!)}/permission`
+        )
+      : undefined;
+    const verified =
+      commentVerified &&
+      (maintainerRoles.has(permission?.role_name?.toLowerCase() ?? "") || permission?.permission?.toLowerCase() === "admin");
+    return verified
+      ? {
+          ruleId: "PRS-HARDSTOP-001",
+          status: "approved",
+          category,
+          detail: `Verified GitHub approval from configured reviewer ${author}.`
+        }
+      : {
+          ruleId: "PRS-HARDSTOP-001",
+          status: "blocking",
+          category,
+          detail: `Approval evidence was not verified for ${category}.`
+        };
+  } catch {
+    return {
+      ruleId: "PRS-HARDSTOP-001",
+      status: "blocking",
+      category,
+      detail: `Approval evidence was not verified for ${category}.`
+    };
+  }
+}
+
+function redacted(value: string): { value: string; replacements: number } {
+  return redactPublicText(value);
+}
+
+function hardStopCategory(action: MaterialAction): (typeof HUMAN_HARD_STOP_CATEGORIES)[number] | undefined {
+  return HUMAN_HARD_STOP_CATEGORIES.find((category) => category === action.action);
+}
+
+function hardStopResult(action: MaterialAction): z.infer<typeof hardStopResultSchema> {
+  const category = hardStopCategory(action);
+  if (!category) {
+    return {
+      ruleId: "PRS-HARDSTOP-001",
+      status: "not-applicable",
+      detail: "No defined human hard stop applies."
+    };
+  }
+
+  if (!action.approval) {
+    return {
+      ruleId: "PRS-HARDSTOP-001",
+      status: "blocking",
+      category,
+      detail: `Explicit human approval evidence is required for ${category}.`
+    };
+  }
+
+  return {
+    ruleId: "PRS-HARDSTOP-001",
+    status: "verification-required",
+    category,
+    detail: `GitHub approval evidence must be verified for ${category}.`
+  };
+}
+
+function buildPublicPayload(action: MaterialAction): {
+  summary: string;
+  approvalEvidence?: string;
+  redactions: number;
+} {
+  const summary = redacted(action.summary);
+  const approvalEvidence = action.approval ? redacted(action.approval.evidence) : undefined;
+  return {
+    summary: summary.value,
+    ...(approvalEvidence ? { approvalEvidence: approvalEvidence.value } : {}),
+    redactions: summary.replacements + (approvalEvidence?.replacements ?? 0)
+  };
+}
+
+function escapeGitHubMarkdownText(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/([\\`*_{}\[\]()#+.!|~-])/g, "\\$1");
+}
+
+function materialActionCommentBody(
+  action: MaterialAction,
+  publicPayload: ReturnType<typeof buildPublicPayload>,
+  hardStop: z.infer<typeof hardStopResultSchema>,
+  digest?: string
+): string {
+  const renderedSummary = escapeGitHubMarkdownText(publicPayload.summary);
+  const renderedApprovalEvidence = publicPayload.approvalEvidence
+    ? escapeGitHubMarkdownText(publicPayload.approvalEvidence)
+    : undefined;
+  const approvalLine = action.approval
+    ? `- Approval evidence: ${renderedApprovalEvidence} (${hardStop.status === "approved" ? "verified" : "verification required"})`
+    : "- Approval: not supplied";
+  const mayContinue = hardStop.status === "not-applicable" || hardStop.status === "approved";
+  return [
+    "## Material action notification",
+    "",
+    "- Rule: PRS-NOTIFY-001",
+    `- Action ID: ${action.id}`,
+    `- Action: ${action.action}`,
+    `- Summary: ${renderedSummary}`,
+    `- Hard stop: ${hardStop.category ?? "none"}`,
+    ...(digest ? [`- Approval digest: ${digest}`] : []),
+    approvalLine,
+    `- Decision: ${mayContinue ? "continue after required notifications are delivered" : "stop pending verified human approval"}`
+  ].join("\n");
+}
+
+export function planMaterialAction(manifest: BootstrapManifest, input: unknown): MaterialActionPlan {
+  const action = materialActionSchema.parse(input);
+  const githubTarget = parseGitHubTarget(action.governingTarget, manifest);
+  const publicGoverningTarget = githubTarget
+    ? `${githubTarget.owner}/${githubTarget.repo}#${githubTarget.number}`
+    : "[INVALID:GOVERNING-TARGET]";
+  const publicPayload = buildPublicPayload(action);
+  const hardStop = hardStopResult(action);
+  const digest = hardStop.category ? approvalDigest(action) : undefined;
+  const configurationErrors = [
+    ...(!githubTarget ? ["governingTarget must identify a GitHub issue or pull request."] : []),
+    ...(!manifest.notifications ? ["notifications.webhookUrlEnv is not configured."] : [])
+  ];
+  const notificationStatus = configurationErrors.length === 0 ? "ready" : "blocking";
+  const commentBody = materialActionCommentBody(action, publicPayload, hardStop, digest);
+  const webhookPayload = webhookPayloadSchema.parse({
+    schemaVersion: 1,
+    ruleId: "PRS-NOTIFY-001",
+    actionId: action.id,
+    action: action.action,
+    summary: publicPayload.summary,
+    governingTarget: publicGoverningTarget,
+    ...(hardStop.category ? { hardStopCategory: hardStop.category } : {}),
+    ...(digest ? { approvalDigest: digest } : {}),
+    ...(publicPayload.approvalEvidence ? { approvalEvidence: publicPayload.approvalEvidence } : {})
+  });
+  const notification = notificationResultSchema.parse({
+    ruleId: "PRS-NOTIFY-001",
+    status: notificationStatus,
+    destinations: [
+      {
+        destination: "governing-issue-or-pull-request",
+        status: "planned",
+        detail: githubTarget ? action.governingTarget : "Invalid governing target."
+      },
+      {
+        destination: "configured-webhook",
+        status: "planned",
+        detail: manifest.notifications?.webhookUrlEnv ?? "No webhook environment-variable reference is configured."
+      }
+    ],
+    detail: configurationErrors.length === 0 ? "Both required notification destinations are configured." : configurationErrors.join(" ")
+  });
+
+  return materialActionPlanSchema.parse({
+    schemaVersion: 1,
+    actionId: action.id,
+    action: action.action,
+    governingTarget: publicGoverningTarget,
+    ...(digest ? { approvalDigest: digest } : {}),
+    notification,
+    hardStop,
+    continueAfterNotification: notification.status !== "blocking" && hardStop.status === "not-applicable",
+    redactions: publicPayload.redactions,
+    commentBody,
+    webhookPayload,
+    exitCode: notification.status === "blocking" || hardStop.status !== "not-applicable" ? 1 : 0
+  });
+}
+
+const defaultWebhookSender: WebhookSender = async (url, payload) => {
+  const response = await fetch(url, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(payload),
+    redirect: "error",
+    signal: AbortSignal.timeout(10_000)
+  });
+  return { ok: response.ok, status: response.status };
+};
+
+export async function deliverMaterialAction(
+  manifest: BootstrapManifest,
+  input: unknown,
+  options: DeliveryOptions = {}
+): Promise<MaterialActionDeliveryReport> {
+  const action = materialActionSchema.parse(input);
+  const plan = planMaterialAction(manifest, input);
+  const githubTarget = parseGitHubTarget(plan.governingTarget, manifest);
+  const githubClient = options.githubClient ?? new GitHubClient();
+  const environment = options.environment ?? process.env;
+  const webhookSender = options.webhookSender ?? defaultWebhookSender;
+  const destinations: MaterialActionPlan["notification"]["destinations"] = [];
+  const hardStop = await verifiedHardStopResult(action, manifest, githubTarget, githubClient);
+  const commentBody = materialActionCommentBody(action, buildPublicPayload(action), hardStop, plan.approvalDigest);
+
+  if (!githubTarget) {
+    destinations.push({
+      destination: "governing-issue-or-pull-request",
+      status: "failed",
+      detail: "Invalid governing target."
+    });
+  } else {
+    try {
+      await githubClient.api(
+        "POST",
+        `/repos/${githubTarget.owner}/${githubTarget.repo}/issues/${githubTarget.number}/comments`,
+        { body: commentBody }
+      );
+      destinations.push({
+        destination: "governing-issue-or-pull-request",
+        status: "delivered",
+        detail: plan.governingTarget
+      });
+    } catch {
+      destinations.push({
+        destination: "governing-issue-or-pull-request",
+        status: "failed",
+        detail: "GitHub comment delivery failed."
+      });
+    }
+  }
+
+  const webhookEnvironmentName = manifest.notifications?.webhookUrlEnv;
+  const webhookUrl = webhookEnvironmentName ? environment[webhookEnvironmentName] : undefined;
+  if (!githubTarget) {
+    destinations.push({
+      destination: "configured-webhook",
+      status: "failed",
+      detail: "Webhook delivery skipped because the governing target is invalid."
+    });
+  } else if (!webhookEnvironmentName || !webhookUrl) {
+    destinations.push({
+      destination: "configured-webhook",
+      status: "failed",
+      detail: webhookEnvironmentName
+        ? `Environment variable ${webhookEnvironmentName} is not set.`
+        : "No webhook environment-variable reference is configured."
+    });
+  } else {
+    try {
+      const parsedUrl = new URL(webhookUrl);
+      if (parsedUrl.protocol !== "https:") throw new Error("Webhook must use HTTPS.");
+      const response = await webhookSender(webhookUrl, plan.webhookPayload);
+      destinations.push({
+        destination: "configured-webhook",
+        status: response.ok ? "delivered" : "failed",
+        detail: response.ok ? `Webhook returned HTTP ${response.status}.` : `Webhook rejected delivery with HTTP ${response.status}.`
+      });
+    } catch {
+      destinations.push({
+        destination: "configured-webhook",
+        status: "failed",
+        detail: "Webhook delivery failed."
+      });
+    }
+  }
+
+  const delivered = destinations.every((destination) => destination.status === "delivered");
+  const notification = notificationResultSchema.parse({
+    ruleId: "PRS-NOTIFY-001",
+    status: delivered ? "delivered" : "blocking",
+    destinations,
+    detail: delivered ? "Both required notification destinations were delivered." : "A required notification destination failed."
+  });
+
+  return materialActionPlanSchema.parse({
+    ...plan,
+    notification,
+    hardStop,
+    commentBody,
+    continueAfterNotification: delivered && (hardStop.status === "not-applicable" || hardStop.status === "approved"),
+    exitCode: delivered && (hardStop.status === "not-applicable" || hardStop.status === "approved") ? 0 : 1
+  });
+}
+
+function exceptionMaterialActions(manifest: BootstrapManifest, now: Date): {
+  actions: MaterialAction[];
+  blocking: boolean;
+} {
+  const validation = validatePolicyExceptions(manifest.exceptions, now);
+  const actions = validation.notifications.map((notification) => {
+    const exception = manifest.exceptions.find((entry) => entry.id === notification.exceptionId);
+    if (!exception?.expiresAt) {
+      throw new Error(`Notification intent ${notification.exceptionId} has no matching expiring exception.`);
+    }
+    const idDigest = createHash("sha256").update(exception.id, "utf8").digest("hex").slice(0, 12);
+    const displayId = redactPublicText(exception.id).value.replace(/[\r\n\u2028\u2029]+/g, " ").slice(0, 512);
+    const governingTarget = containsCredential(exception.issue) ? "invalid-governing-target" : exception.issue;
+    return materialActionSchema.parse({
+      id: `exception-${idDigest}-expiring`,
+      action: "policy-exception",
+      summary: `Temporary policy exception ${displayId} expires on ${exception.expiresAt}.`,
+      governingTarget
+    });
+  });
+  return { actions, blocking: validation.blocking };
+}
+
+export function planExceptionNotifications(
+  manifest: BootstrapManifest,
+  now = new Date()
+): ExceptionNotificationReport {
+  const exceptions = exceptionMaterialActions(manifest, now);
+  const notifications = exceptions.actions.map((action) => planMaterialAction(manifest, action));
+  return exceptionNotificationReportSchema.parse({
+    schemaVersion: 1,
+    mode: "plan",
+    notifications,
+    blockingExceptions: exceptions.blocking,
+    exitCode: exceptions.blocking || notifications.some((notification) => notification.exitCode === 1) ? 1 : 0
+  });
+}
+
+export async function deliverExceptionNotifications(
+  manifest: BootstrapManifest,
+  options: ExceptionDeliveryOptions = {}
+): Promise<ExceptionNotificationReport> {
+  const exceptions = exceptionMaterialActions(manifest, options.now ?? new Date());
+  const notifications: MaterialActionPlan[] = [];
+  for (const action of exceptions.actions) {
+    notifications.push(await deliverMaterialAction(manifest, action, options));
+  }
+  return exceptionNotificationReportSchema.parse({
+    schemaVersion: 1,
+    mode: "deliver",
+    notifications,
+    blockingExceptions: exceptions.blocking,
+    exitCode: exceptions.blocking || notifications.some((notification) => notification.exitCode === 1) ? 1 : 0
+  });
+}
+
+export function formatMaterialActionReport(report: MaterialActionPlan): string {
+  return [
+    `Material action ${report.actionId}: ${report.exitCode === 0 ? "ready" : "blocked"}`,
+    `- [${report.notification.status}] ${report.notification.ruleId}: ${report.notification.detail}`,
+    ...report.notification.destinations.map(
+      (destination) => `  - [${destination.status}] ${destination.destination}: ${destination.detail}`
+    ),
+    `- [${report.hardStop.status}] ${report.hardStop.ruleId}: ${report.hardStop.detail}`,
+    ...(report.approvalDigest ? [`- Approval digest: ${report.approvalDigest}`] : []),
+    `- Continue after notification: ${report.continueAfterNotification ? "yes" : "no"}`,
+    `- Redactions: ${report.redactions}`
+  ].join("\n");
+}
+
+export function formatExceptionNotificationReport(report: ExceptionNotificationReport): string {
+  return [
+    `Exception notifications ${report.mode}: ${report.notifications.length} intent(s), ${report.blockingExceptions ? "blocking exceptions present" : "no blocking exceptions"}`,
+    ...report.notifications.flatMap((notification) => formatMaterialActionReport(notification).split("\n")),
+    `Exception notification result: ${report.exitCode === 0 ? "pass" : "block"}`
+  ].join("\n");
+}

--- a/src/notifications.ts
+++ b/src/notifications.ts
@@ -1,4 +1,7 @@
 import { createHash } from "node:crypto";
+import { lookup } from "node:dns/promises";
+import { request as httpsRequest } from "node:https";
+import { BlockList, isIP, type LookupFunction } from "node:net";
 
 import { z } from "zod";
 
@@ -159,11 +162,17 @@ export interface WebhookResult {
 }
 
 export type WebhookSender = (url: string, payload: MaterialActionPlan["webhookPayload"]) => Promise<WebhookResult>;
+export interface ResolvedWebhookAddress {
+  address: string;
+  family: 4 | 6;
+}
+export type WebhookResolver = (hostname: string) => Promise<ResolvedWebhookAddress[]>;
 
 export interface DeliveryOptions {
   githubClient?: GitHubClient;
   environment?: NodeJS.ProcessEnv;
   webhookSender?: WebhookSender;
+  webhookResolver?: WebhookResolver;
 }
 
 export interface ExceptionDeliveryOptions extends DeliveryOptions {
@@ -464,16 +473,195 @@ export function planMaterialAction(manifest: BootstrapManifest, input: unknown):
   });
 }
 
-const defaultWebhookSender: WebhookSender = async (url, payload) => {
-  const response = await fetch(url, {
-    method: "POST",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify(payload),
-    redirect: "error",
-    signal: AbortSignal.timeout(10_000)
-  });
-  return { ok: response.ok, status: response.status };
+const WEBHOOK_ALLOWED_HOSTS_ENV = "BOOTSTRAP_NOTIFICATION_WEBHOOK_ALLOWED_HOSTS";
+const reservedWebhookIpv4Addresses = new BlockList();
+const reservedWebhookIpv6Addresses = new BlockList();
+const publicWebhookIpv6Addresses = new BlockList();
+publicWebhookIpv6Addresses.addSubnet("2000::", 3, "ipv6");
+
+for (const [network, prefix] of [
+  ["0.0.0.0", 8],
+  ["10.0.0.0", 8],
+  ["100.64.0.0", 10],
+  ["127.0.0.0", 8],
+  ["169.254.0.0", 16],
+  ["172.16.0.0", 12],
+  ["192.0.0.0", 24],
+  ["192.0.2.0", 24],
+  ["192.88.99.0", 24],
+  ["192.168.0.0", 16],
+  ["198.18.0.0", 15],
+  ["198.51.100.0", 24],
+  ["203.0.113.0", 24],
+  ["224.0.0.0", 4],
+  ["240.0.0.0", 4]
+] as const) {
+  reservedWebhookIpv4Addresses.addSubnet(network, prefix, "ipv4");
+}
+
+for (const [network, prefix] of [
+  ["::", 128],
+  ["::1", 128],
+  ["::ffff:0:0", 96],
+  ["64:ff9b::", 96],
+  ["64:ff9b:1::", 48],
+  ["100::", 64],
+  ["2001::", 23],
+  ["2001:db8::", 32],
+  ["2002::", 16],
+  ["3fff::", 20],
+  ["fc00::", 7],
+  ["fe80::", 10],
+  ["ff00::", 8]
+] as const) {
+  reservedWebhookIpv6Addresses.addSubnet(network, prefix, "ipv6");
+}
+
+function normalizeWebhookHostname(hostname: string): string {
+  const withoutBrackets = hostname.startsWith("[") && hostname.endsWith("]") ? hostname.slice(1, -1) : hostname;
+  return withoutBrackets.replace(/\.$/, "").toLowerCase();
+}
+
+function approvedWebhookHosts(environment: NodeJS.ProcessEnv): Set<string> {
+  return new Set(
+    (environment[WEBHOOK_ALLOWED_HOSTS_ENV] ?? "")
+      .split(",")
+      .map((hostname) => normalizeWebhookHostname(hostname.trim()))
+      .filter(Boolean)
+  );
+}
+
+function isPublicWebhookAddress(address: string): address is string {
+  const family = isIP(address);
+  if (family === 4) return !reservedWebhookIpv4Addresses.check(address, "ipv4");
+  if (family === 6) {
+    return publicWebhookIpv6Addresses.check(address, "ipv6") && !reservedWebhookIpv6Addresses.check(address, "ipv6");
+  }
+  return false;
+}
+
+const defaultWebhookResolver: WebhookResolver = async (hostname) => {
+  const family = isIP(hostname);
+  if (family === 4 || family === 6) return [{ address: hostname, family }];
+  const addresses = await lookup(hostname, { all: true, verbatim: true });
+  return addresses.map(({ address, family: resolvedFamily }) => ({
+    address,
+    family: resolvedFamily === 6 ? 6 : 4
+  }));
 };
+
+async function validateWebhookDestination(
+  webhookUrl: string,
+  environment: NodeJS.ProcessEnv,
+  resolver: WebhookResolver,
+  deadline: number
+): Promise<{ url: URL; addresses: ResolvedWebhookAddress[] }> {
+  const url = new URL(webhookUrl);
+  if (url.protocol !== "https:") throw new Error("Webhook must use HTTPS.");
+  if (url.username || url.password) throw new Error("Webhook URLs must not contain credentials.");
+  if (url.port && url.port !== "443") throw new Error("Webhook delivery is restricted to HTTPS port 443.");
+
+  const hostname = normalizeWebhookHostname(url.hostname);
+  if (!approvedWebhookHosts(environment).has(hostname)) {
+    throw new Error(`Webhook hostname is not approved by ${WEBHOOK_ALLOWED_HOSTS_ENV}.`);
+  }
+
+  const addresses = await withDeadline(resolver(hostname), deadline, "Webhook hostname resolution timed out.");
+  if (addresses.length === 0) throw new Error("Webhook hostname did not resolve.");
+  const validated: ResolvedWebhookAddress[] = addresses.map(({ address }) => {
+    const family = isIP(address);
+    if ((family !== 4 && family !== 6) || !isPublicWebhookAddress(address)) {
+      throw new Error("Webhook hostname resolved to a non-public address.");
+    }
+    return { address, family: family as 4 | 6 };
+  });
+  return { url, addresses: validated };
+}
+
+async function withDeadline<T>(operation: Promise<T>, deadline: number, message: string): Promise<T> {
+  const remainingMilliseconds = deadline - Date.now();
+  if (remainingMilliseconds <= 0) throw new Error(message);
+
+  let timer: NodeJS.Timeout | undefined;
+  try {
+    return await Promise.race([
+      operation,
+      new Promise<never>((_resolve, reject) => {
+        timer = setTimeout(() => reject(new Error(message)), remainingMilliseconds);
+      })
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+function pinnedLookup(address: ResolvedWebhookAddress): LookupFunction {
+  return ((_hostname, options, callback) => {
+    if (typeof options === "object" && options.all) {
+      callback(null, [address]);
+      return;
+    }
+    callback(null, address.address, address.family);
+  }) as LookupFunction;
+}
+
+function sendWebhookToAddress(
+  url: URL,
+  body: string,
+  address: ResolvedWebhookAddress,
+  timeoutMilliseconds: number
+): Promise<WebhookResult> {
+  return new Promise((resolve, reject) => {
+    const request = httpsRequest(
+      url,
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "content-length": Buffer.byteLength(body)
+        },
+        lookup: pinnedLookup(address),
+        signal: AbortSignal.timeout(timeoutMilliseconds)
+      },
+      (response) => {
+        response.once("error", reject);
+        response.resume();
+        response.once("end", () =>
+          resolve({
+            ok: response.statusCode !== undefined && response.statusCode >= 200 && response.statusCode < 300,
+            status: response.statusCode ?? 0
+          })
+        );
+      }
+    );
+    request.once("error", reject);
+    request.end(body);
+  });
+}
+
+async function defaultWebhookSender(
+  url: URL,
+  payload: MaterialActionPlan["webhookPayload"],
+  addresses: ResolvedWebhookAddress[],
+  deadline: number
+): Promise<WebhookResult> {
+  const body = JSON.stringify(payload);
+  let lastError: unknown;
+
+  for (const [index, address] of addresses.entries()) {
+    const remainingMilliseconds = deadline - Date.now();
+    if (remainingMilliseconds <= 0) break;
+    const remainingAddresses = addresses.length - index;
+    const attemptMilliseconds = Math.max(1, Math.floor(remainingMilliseconds / remainingAddresses));
+    try {
+      return await sendWebhookToAddress(url, body, address, attemptMilliseconds);
+    } catch (error) {
+      lastError = error;
+    }
+  }
+
+  throw lastError instanceof Error ? lastError : new Error("Webhook delivery exhausted all validated addresses.");
+}
 
 export async function deliverMaterialAction(
   manifest: BootstrapManifest,
@@ -485,7 +673,7 @@ export async function deliverMaterialAction(
   const githubTarget = parseGitHubTarget(plan.governingTarget, manifest);
   const githubClient = options.githubClient ?? new GitHubClient();
   const environment = options.environment ?? process.env;
-  const webhookSender = options.webhookSender ?? defaultWebhookSender;
+  const webhookResolver = options.webhookResolver ?? defaultWebhookResolver;
   const destinations: MaterialActionPlan["notification"]["destinations"] = [];
   const hardStop = await verifiedHardStopResult(action, manifest, githubTarget, githubClient);
   const commentBody = materialActionCommentBody(action, buildPublicPayload(action), hardStop, plan.approvalDigest);
@@ -535,9 +723,15 @@ export async function deliverMaterialAction(
     });
   } else {
     try {
-      const parsedUrl = new URL(webhookUrl);
-      if (parsedUrl.protocol !== "https:") throw new Error("Webhook must use HTTPS.");
-      const response = await webhookSender(webhookUrl, plan.webhookPayload);
+      const deadline = Date.now() + 10_000;
+      const destination = await validateWebhookDestination(webhookUrl, environment, webhookResolver, deadline);
+      const response = options.webhookSender
+        ? await withDeadline(
+            options.webhookSender(webhookUrl, plan.webhookPayload),
+            deadline,
+            "Webhook delivery timed out."
+          )
+        : await defaultWebhookSender(destination.url, plan.webhookPayload, destination.addresses, deadline);
       destinations.push({
         destination: "configured-webhook",
         status: response.ok ? "delivered" : "failed",

--- a/src/notifications.ts
+++ b/src/notifications.ts
@@ -1,7 +1,4 @@
 import { createHash } from "node:crypto";
-import { lookup } from "node:dns/promises";
-import { request as httpsRequest } from "node:https";
-import { BlockList, isIP, type LookupFunction } from "node:net";
 
 import { z } from "zod";
 
@@ -156,23 +153,8 @@ interface GitHubCollaboratorPermission {
 
 const maintainerRoles = new Set(["admin", "maintain"]);
 
-export interface WebhookResult {
-  ok: boolean;
-  status: number;
-}
-
-export type WebhookSender = (url: string, payload: MaterialActionPlan["webhookPayload"]) => Promise<WebhookResult>;
-export interface ResolvedWebhookAddress {
-  address: string;
-  family: 4 | 6;
-}
-export type WebhookResolver = (hostname: string) => Promise<ResolvedWebhookAddress[]>;
-
 export interface DeliveryOptions {
   githubClient?: GitHubClient;
-  environment?: NodeJS.ProcessEnv;
-  webhookSender?: WebhookSender;
-  webhookResolver?: WebhookResolver;
 }
 
 export interface ExceptionDeliveryOptions extends DeliveryOptions {
@@ -473,196 +455,6 @@ export function planMaterialAction(manifest: BootstrapManifest, input: unknown):
   });
 }
 
-const WEBHOOK_ALLOWED_HOSTS_ENV = "BOOTSTRAP_NOTIFICATION_WEBHOOK_ALLOWED_HOSTS";
-const reservedWebhookIpv4Addresses = new BlockList();
-const reservedWebhookIpv6Addresses = new BlockList();
-const publicWebhookIpv6Addresses = new BlockList();
-publicWebhookIpv6Addresses.addSubnet("2000::", 3, "ipv6");
-
-for (const [network, prefix] of [
-  ["0.0.0.0", 8],
-  ["10.0.0.0", 8],
-  ["100.64.0.0", 10],
-  ["127.0.0.0", 8],
-  ["169.254.0.0", 16],
-  ["172.16.0.0", 12],
-  ["192.0.0.0", 24],
-  ["192.0.2.0", 24],
-  ["192.88.99.0", 24],
-  ["192.168.0.0", 16],
-  ["198.18.0.0", 15],
-  ["198.51.100.0", 24],
-  ["203.0.113.0", 24],
-  ["224.0.0.0", 4],
-  ["240.0.0.0", 4]
-] as const) {
-  reservedWebhookIpv4Addresses.addSubnet(network, prefix, "ipv4");
-}
-
-for (const [network, prefix] of [
-  ["::", 128],
-  ["::1", 128],
-  ["::ffff:0:0", 96],
-  ["64:ff9b::", 96],
-  ["64:ff9b:1::", 48],
-  ["100::", 64],
-  ["2001::", 23],
-  ["2001:db8::", 32],
-  ["2002::", 16],
-  ["3fff::", 20],
-  ["fc00::", 7],
-  ["fe80::", 10],
-  ["ff00::", 8]
-] as const) {
-  reservedWebhookIpv6Addresses.addSubnet(network, prefix, "ipv6");
-}
-
-function normalizeWebhookHostname(hostname: string): string {
-  const withoutBrackets = hostname.startsWith("[") && hostname.endsWith("]") ? hostname.slice(1, -1) : hostname;
-  return withoutBrackets.replace(/\.$/, "").toLowerCase();
-}
-
-function approvedWebhookHosts(environment: NodeJS.ProcessEnv): Set<string> {
-  return new Set(
-    (environment[WEBHOOK_ALLOWED_HOSTS_ENV] ?? "")
-      .split(",")
-      .map((hostname) => normalizeWebhookHostname(hostname.trim()))
-      .filter(Boolean)
-  );
-}
-
-function isPublicWebhookAddress(address: string): address is string {
-  const family = isIP(address);
-  if (family === 4) return !reservedWebhookIpv4Addresses.check(address, "ipv4");
-  if (family === 6) {
-    return publicWebhookIpv6Addresses.check(address, "ipv6") && !reservedWebhookIpv6Addresses.check(address, "ipv6");
-  }
-  return false;
-}
-
-const defaultWebhookResolver: WebhookResolver = async (hostname) => {
-  const family = isIP(hostname);
-  if (family === 4 || family === 6) return [{ address: hostname, family }];
-  const addresses = await lookup(hostname, { all: true, verbatim: true });
-  return addresses.map(({ address, family: resolvedFamily }) => ({
-    address,
-    family: resolvedFamily === 6 ? 6 : 4
-  }));
-};
-
-async function validateWebhookDestination(
-  webhookUrl: string,
-  environment: NodeJS.ProcessEnv,
-  resolver: WebhookResolver,
-  deadline: number
-): Promise<{ url: URL; addresses: ResolvedWebhookAddress[] }> {
-  const url = new URL(webhookUrl);
-  if (url.protocol !== "https:") throw new Error("Webhook must use HTTPS.");
-  if (url.username || url.password) throw new Error("Webhook URLs must not contain credentials.");
-  if (url.port && url.port !== "443") throw new Error("Webhook delivery is restricted to HTTPS port 443.");
-
-  const hostname = normalizeWebhookHostname(url.hostname);
-  if (!approvedWebhookHosts(environment).has(hostname)) {
-    throw new Error(`Webhook hostname is not approved by ${WEBHOOK_ALLOWED_HOSTS_ENV}.`);
-  }
-
-  const addresses = await withDeadline(resolver(hostname), deadline, "Webhook hostname resolution timed out.");
-  if (addresses.length === 0) throw new Error("Webhook hostname did not resolve.");
-  const validated: ResolvedWebhookAddress[] = addresses.map(({ address }) => {
-    const family = isIP(address);
-    if ((family !== 4 && family !== 6) || !isPublicWebhookAddress(address)) {
-      throw new Error("Webhook hostname resolved to a non-public address.");
-    }
-    return { address, family: family as 4 | 6 };
-  });
-  return { url, addresses: validated };
-}
-
-async function withDeadline<T>(operation: Promise<T>, deadline: number, message: string): Promise<T> {
-  const remainingMilliseconds = deadline - Date.now();
-  if (remainingMilliseconds <= 0) throw new Error(message);
-
-  let timer: NodeJS.Timeout | undefined;
-  try {
-    return await Promise.race([
-      operation,
-      new Promise<never>((_resolve, reject) => {
-        timer = setTimeout(() => reject(new Error(message)), remainingMilliseconds);
-      })
-    ]);
-  } finally {
-    if (timer) clearTimeout(timer);
-  }
-}
-
-function pinnedLookup(address: ResolvedWebhookAddress): LookupFunction {
-  return ((_hostname, options, callback) => {
-    if (typeof options === "object" && options.all) {
-      callback(null, [address]);
-      return;
-    }
-    callback(null, address.address, address.family);
-  }) as LookupFunction;
-}
-
-function sendWebhookToAddress(
-  url: URL,
-  body: string,
-  address: ResolvedWebhookAddress,
-  timeoutMilliseconds: number
-): Promise<WebhookResult> {
-  return new Promise((resolve, reject) => {
-    const request = httpsRequest(
-      url,
-      {
-        method: "POST",
-        headers: {
-          "content-type": "application/json",
-          "content-length": Buffer.byteLength(body)
-        },
-        lookup: pinnedLookup(address),
-        signal: AbortSignal.timeout(timeoutMilliseconds)
-      },
-      (response) => {
-        response.once("error", reject);
-        response.resume();
-        response.once("end", () =>
-          resolve({
-            ok: response.statusCode !== undefined && response.statusCode >= 200 && response.statusCode < 300,
-            status: response.statusCode ?? 0
-          })
-        );
-      }
-    );
-    request.once("error", reject);
-    request.end(body);
-  });
-}
-
-async function defaultWebhookSender(
-  url: URL,
-  payload: MaterialActionPlan["webhookPayload"],
-  addresses: ResolvedWebhookAddress[],
-  deadline: number
-): Promise<WebhookResult> {
-  const body = JSON.stringify(payload);
-  let lastError: unknown;
-
-  for (const [index, address] of addresses.entries()) {
-    const remainingMilliseconds = deadline - Date.now();
-    if (remainingMilliseconds <= 0) break;
-    const remainingAddresses = addresses.length - index;
-    const attemptMilliseconds = Math.max(1, Math.floor(remainingMilliseconds / remainingAddresses));
-    try {
-      return await sendWebhookToAddress(url, body, address, attemptMilliseconds);
-    } catch (error) {
-      lastError = error;
-    }
-  }
-
-  throw lastError instanceof Error ? lastError : new Error("Webhook delivery exhausted all validated addresses.");
-}
-
 export async function deliverMaterialAction(
   manifest: BootstrapManifest,
   input: unknown,
@@ -672,8 +464,6 @@ export async function deliverMaterialAction(
   const plan = planMaterialAction(manifest, input);
   const githubTarget = parseGitHubTarget(plan.governingTarget, manifest);
   const githubClient = options.githubClient ?? new GitHubClient();
-  const environment = options.environment ?? process.env;
-  const webhookResolver = options.webhookResolver ?? defaultWebhookResolver;
   const destinations: MaterialActionPlan["notification"]["destinations"] = [];
   const hardStop = await verifiedHardStopResult(action, manifest, githubTarget, githubClient);
   const commentBody = materialActionCommentBody(action, buildPublicPayload(action), hardStop, plan.approvalDigest);
@@ -705,46 +495,13 @@ export async function deliverMaterialAction(
     }
   }
 
-  const webhookEnvironmentName = manifest.notifications?.webhookUrlEnv;
-  const webhookUrl = webhookEnvironmentName ? environment[webhookEnvironmentName] : undefined;
-  if (!githubTarget) {
-    destinations.push({
-      destination: "configured-webhook",
-      status: "failed",
-      detail: "Webhook delivery skipped because the governing target is invalid."
-    });
-  } else if (!webhookEnvironmentName || !webhookUrl) {
-    destinations.push({
-      destination: "configured-webhook",
-      status: "failed",
-      detail: webhookEnvironmentName
-        ? `Environment variable ${webhookEnvironmentName} is not set.`
-        : "No webhook environment-variable reference is configured."
-    });
-  } else {
-    try {
-      const deadline = Date.now() + 10_000;
-      const destination = await validateWebhookDestination(webhookUrl, environment, webhookResolver, deadline);
-      const response = options.webhookSender
-        ? await withDeadline(
-            options.webhookSender(webhookUrl, plan.webhookPayload),
-            deadline,
-            "Webhook delivery timed out."
-          )
-        : await defaultWebhookSender(destination.url, plan.webhookPayload, destination.addresses, deadline);
-      destinations.push({
-        destination: "configured-webhook",
-        status: response.ok ? "delivered" : "failed",
-        detail: response.ok ? `Webhook returned HTTP ${response.status}.` : `Webhook rejected delivery with HTTP ${response.status}.`
-      });
-    } catch {
-      destinations.push({
-        destination: "configured-webhook",
-        status: "failed",
-        detail: "Webhook delivery failed."
-      });
-    }
-  }
+  destinations.push({
+    destination: "configured-webhook",
+    status: "failed",
+    detail: githubTarget
+      ? "Webhook delivery is disabled until the secure transport follow-up is merged."
+      : "Webhook delivery skipped because the governing target is invalid."
+  });
 
   const delivered = destinations.every((destination) => destination.status === "delivered");
   const notification = notificationResultSchema.parse({

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,6 +27,16 @@ export interface PolicyException {
   adr?: string;
 }
 
+export interface SpendingApprovalThreshold {
+  amount: number;
+  currency: string;
+}
+
+export interface PublisherConfig {
+  key: string;
+  spendingApprovalThreshold?: SpendingApprovalThreshold;
+}
+
 export interface CodeownerRule {
   pattern: string;
   owners: string[];
@@ -175,6 +185,7 @@ export interface BootstrapManifest {
     owner: string;
     defaultBranch: string;
   };
+  publisher: PublisherConfig;
   repo: RepoConfig;
   archetype: {
     kind: ArchetypeKind;

--- a/src/types.ts
+++ b/src/types.ts
@@ -37,6 +37,10 @@ export interface PublisherConfig {
   spendingApprovalThreshold?: SpendingApprovalThreshold;
 }
 
+export interface NotificationConfig {
+  webhookUrlEnv: string;
+}
+
 export interface CodeownerRule {
   pattern: string;
   owners: string[];
@@ -186,6 +190,7 @@ export interface BootstrapManifest {
     defaultBranch: string;
   };
   publisher: PublisherConfig;
+  notifications?: NotificationConfig;
   repo: RepoConfig;
   archetype: {
     kind: ArchetypeKind;

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -1,0 +1,20 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+import { describe, expect, it } from "vitest";
+
+const execFileAsync = promisify(execFile);
+const tsx = new URL("../node_modules/.bin/tsx", import.meta.url).pathname;
+const cli = new URL("../src/cli.ts", import.meta.url).pathname;
+
+describe("notification CLI help", () => {
+  it("does not promise disabled webhook delivery", async () => {
+    const [deliver, exceptions] = await Promise.all([
+      execFileAsync(tsx, [cli, "notifications", "deliver", "--help"]),
+      execFileAsync(tsx, [cli, "notifications", "exceptions", "--help"])
+    ]);
+
+    expect(deliver.stdout).toContain("configured webhook delivery is currently disabled");
+    expect(exceptions.stdout).toContain("configured webhook delivery is currently disabled");
+  });
+});

--- a/tests/conformance.test.ts
+++ b/tests/conformance.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, writeFile } from "node:fs/promises";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
@@ -34,17 +34,12 @@ describe("runConformance", () => {
     const manifest = normalizeManifest({
       project: { name: "canonical-contract", owner: "acme", maturity: "stable" },
       repo: { class: "service" },
-      archetype: { kind: "generic-empty" }
-    });
-    await applyRepo(manifest, directory);
-
-    const evaluatedManifest = normalizeManifest({
-      project: { name: "canonical-contract", owner: "acme", maturity: "stable" },
-      repo: { class: "service" },
       archetype: { kind: "node-ts-service" }
     });
+    await applyRepo(manifest, directory);
+    await rm(path.join(directory, "src/index.ts"));
 
-    const report = await runConformance(evaluatedManifest, directory);
+    const report = await runConformance(manifest, directory);
 
     expect(report.exitCode).toBe(0);
     expect(report.summary.warning).toBe(1);

--- a/tests/conformance.test.ts
+++ b/tests/conformance.test.ts
@@ -1,7 +1,7 @@
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { conformanceReportSchema, formatConformanceReport, runConformance } from "../src/conformance.js";
 import { normalizeManifest } from "../src/manifest.js";
@@ -45,5 +45,43 @@ describe("runConformance", () => {
     expect(report.summary.warning).toBe(1);
     expect(report.results).toContainEqual(expect.objectContaining({ ruleId: "PRS-PROFILE-001", severity: "warning" }));
     expect(formatConformanceReport(report)).toContain("Conformance: 0 blocking, 1 warning");
+  });
+
+  it("accepts a missing canonical class with a valid scoped exception that is nearing expiry", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-16T12:00:00.000Z"));
+    const directory = await fixtureDirectory();
+    const manifest = normalizeManifest({
+      project: { name: "class-exception", owner: "acme", maturity: "maintenance" },
+      archetype: { kind: "generic-empty" },
+      exceptions: [
+        {
+          id: "legacy-class",
+          policy: "repository-classification",
+          scope: "repo.class",
+          rationale: "Class selection is pending owner review.",
+          approvedBy: "alice",
+          issue: "#56",
+          expiresAt: "2026-07-20"
+        }
+      ]
+    });
+
+    try {
+      const report = await runConformance(manifest, directory);
+
+      expect(report.results).toContainEqual(
+        expect.objectContaining({
+          ruleId: "PRS-CLASS-001",
+          severity: "pass",
+          evidence: ["approved exception legacy-class"]
+        })
+      );
+      expect(report.results).toContainEqual(
+        expect.objectContaining({ ruleId: "PRS-EXCEPTION-001", severity: "warning" })
+      );
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/tests/manifest.test.ts
+++ b/tests/manifest.test.ts
@@ -82,6 +82,38 @@ describe("normalizeManifest", () => {
     expect(manifest.release.maturity).toBe("regulated");
   });
 
+  it("resolves publisher identity without inventing a spending threshold", () => {
+    const defaultPublisher = normalizeManifest({
+      project: { name: "publisher-default", owner: "acme" },
+      archetype: { kind: "generic-empty" }
+    });
+
+    expect(defaultPublisher.publisher).toEqual({ key: "acme" });
+    expect(stringifyManifest(defaultPublisher)).not.toContain("publisher:");
+
+    const configuredPublisher = normalizeManifest({
+      project: { name: "publisher-configured", owner: "acme" },
+      publisher: {
+        key: "acme-public",
+        spendingApprovalThreshold: { amount: 500, currency: "USD" }
+      },
+      archetype: { kind: "generic-empty" }
+    });
+
+    expect(configuredPublisher.publisher).toEqual({
+      key: "acme-public",
+      spendingApprovalThreshold: { amount: 500, currency: "USD" }
+    });
+    expect(stringifyManifest(configuredPublisher)).toContain("spendingApprovalThreshold:");
+    expect(() =>
+      normalizeManifest({
+        project: { name: "invalid-currency", owner: "acme" },
+        publisher: { spendingApprovalThreshold: { amount: 500, currency: "ZZZ" } },
+        archetype: { kind: "generic-empty" }
+      })
+    ).toThrow();
+  });
+
   it("applies defaults and reviewer-derived governance", () => {
     const manifest = normalizeManifest({
       project: {

--- a/tests/notifications.test.ts
+++ b/tests/notifications.test.ts
@@ -1,0 +1,373 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { GitHubClient } from "../src/github/client.js";
+import { normalizeManifest, stringifyManifest } from "../src/manifest.js";
+import {
+  deliverExceptionNotifications,
+  deliverMaterialAction,
+  exceptionNotificationReportSchema,
+  materialActionPlanSchema,
+  planExceptionNotifications,
+  planMaterialAction,
+  type WebhookSender
+} from "../src/notifications.js";
+import type { CommandRunner } from "../src/lib/process.js";
+
+const githubPat = ["github", "pat"].join("_") + "_abcdefghijklmnopqrstuvwxyz123456";
+
+function manifest(withNotifications = true) {
+  return normalizeManifest({
+    project: { name: "notifications", owner: "acme" },
+    ...(withNotifications ? { notifications: { webhookUrlEnv: "BOOTSTRAP_NOTIFICATION_WEBHOOK_URL" } } : {}),
+    archetype: { kind: "generic-empty" },
+    github: { reviewers: ["maintainer"] }
+  });
+}
+
+function action(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "action-55",
+    action: "repository-settings-change",
+    summary: "Enable private vulnerability reporting.",
+    governingTarget: "#55",
+    ...overrides
+  };
+}
+
+describe("material-action notifications", () => {
+  it("plans both required destinations, redacts credentials, and preserves continue semantics", () => {
+    const report = planMaterialAction(
+      manifest(),
+      action({ summary: `Rotate token=${githubPat} before changing repository settings.` })
+    );
+
+    expect(materialActionPlanSchema.parse(report)).toEqual(report);
+    expect(report.notification).toMatchObject({ ruleId: "PRS-NOTIFY-001", status: "ready" });
+    expect(report.hardStop).toMatchObject({ ruleId: "PRS-HARDSTOP-001", status: "not-applicable" });
+    expect(report.continueAfterNotification).toBe(true);
+    expect(report.redactions).toBeGreaterThan(0);
+    expect(JSON.stringify(report)).not.toContain(githubPat);
+    expect(report.notification.destinations.map((entry) => entry.destination)).toEqual([
+      "governing-issue-or-pull-request",
+      "configured-webhook"
+    ]);
+  });
+
+  it("blocks defined hard stops without explicit approval evidence", () => {
+    const report = planMaterialAction(manifest(), action({ action: "license-change" }));
+
+    expect(report.notification.status).toBe("ready");
+    expect(report.hardStop).toMatchObject({
+      ruleId: "PRS-HARDSTOP-001",
+      status: "blocking",
+      category: "license-change"
+    });
+    expect(report.continueAfterNotification).toBe(false);
+    expect(report.exitCode).toBe(1);
+  });
+
+  it("delivers to GitHub and the configured webhook before allowing work to continue", async () => {
+    const approvalEvidence = "https://github.com/ACME/Notifications/issues/55#issuecomment-1";
+    const actionInput = action({
+      action: "license-change",
+      summary: "Still (verification required); never copy stop pending verified human approval from summary text.",
+      approval: { evidence: approvalEvidence }
+    });
+    const planned = planMaterialAction(manifest(), actionInput);
+    const runner = vi.fn<CommandRunner>(async (_command, args) => ({
+      stdout: args?.some((arg) => arg.toLowerCase() === "/repos/acme/notifications/issues/comments/1")
+        ? JSON.stringify({
+            body: `APPROVE PRS-HARDSTOP-001 action=action-55 category=license-change digest=${planned.approvalDigest}`,
+            html_url: "https://github.com/acme/notifications/issues/55#issuecomment-1",
+            issue_url: "https://api.github.com/repos/acme/notifications/issues/55",
+            user: { login: "Maintainer" }
+          })
+        : args?.some((arg) => arg.toLowerCase() === "/repos/acme/notifications/collaborators/maintainer/permission")
+          ? JSON.stringify({ permission: "write", role_name: "maintain" })
+          : "{}",
+      stderr: "",
+      exitCode: 0
+    }));
+    const webhookSender = vi.fn<WebhookSender>(async () => ({ ok: true, status: 204 }));
+    const report = await deliverMaterialAction(
+      manifest(),
+      actionInput,
+      {
+        githubClient: new GitHubClient({ runner }),
+        environment: { BOOTSTRAP_NOTIFICATION_WEBHOOK_URL: "https://notifications.example.test/hooks/material" },
+        webhookSender
+      }
+    );
+
+    expect(planned.hardStop.status).toBe("verification-required");
+    expect(planned.approvalDigest).toMatch(/^[0-9a-f]{64}$/);
+    expect(planned.continueAfterNotification).toBe(false);
+    expect(planned.exitCode).toBe(1);
+    expect(report.notification.status).toBe("delivered");
+    expect(report.hardStop.status).toBe("approved");
+    expect(report.continueAfterNotification).toBe(true);
+    expect(report.exitCode).toBe(0);
+    expect(report.commentBody).toContain("- Approval evidence: ");
+    expect(report.commentBody).toContain("(verified)");
+    expect(report.commentBody).toContain("- Decision: continue after required notifications are delivered");
+    expect(runner).toHaveBeenCalledWith(
+      "gh",
+      expect.arrayContaining(["/repos/acme/notifications/issues/55/comments"]),
+      expect.objectContaining({ input: expect.stringContaining("PRS-NOTIFY-001") })
+    );
+    expect(webhookSender).toHaveBeenCalledWith(
+      "https://notifications.example.test/hooks/material",
+      expect.objectContaining({ ruleId: "PRS-NOTIFY-001", actionId: "action-55", hardStopCategory: "license-change" })
+    );
+  });
+
+  it("rejects hard-stop approval from a configured reviewer without maintain permission", async () => {
+    const approvalEvidence = "https://github.com/acme/notifications/issues/55#issuecomment-2";
+    const actionInput = action({ action: "license-change", approval: { evidence: approvalEvidence } });
+    const planned = planMaterialAction(manifest(), actionInput);
+    const runner: CommandRunner = async (_command, args) => ({
+      stdout: args?.includes("/repos/acme/notifications/issues/comments/2")
+        ? JSON.stringify({
+            body: `APPROVE PRS-HARDSTOP-001 action=action-55 category=license-change digest=${planned.approvalDigest}`,
+            html_url: approvalEvidence,
+            issue_url: "https://api.github.com/repos/acme/notifications/issues/55",
+            user: { login: "maintainer" }
+          })
+        : args?.includes("/repos/acme/notifications/collaborators/maintainer/permission")
+          ? JSON.stringify({ permission: "write", role_name: "write" })
+          : "{}",
+      stderr: "",
+      exitCode: 0
+    });
+    const report = await deliverMaterialAction(
+      manifest(),
+      actionInput,
+      {
+        githubClient: new GitHubClient({ runner }),
+        environment: { BOOTSTRAP_NOTIFICATION_WEBHOOK_URL: "https://notifications.example.test/hooks/material" },
+        webhookSender: async () => ({ ok: true, status: 204 })
+      }
+    );
+
+    expect(report.notification.status).toBe("delivered");
+    expect(report.hardStop).toMatchObject({ status: "blocking", category: "license-change" });
+    expect(report.continueAfterNotification).toBe(false);
+    expect(report.exitCode).toBe(1);
+  });
+
+  it("rejects replaying approval after immutable action contents change", async () => {
+    const approvalEvidence = "https://github.com/acme/notifications/issues/55#issuecomment-3";
+    const approvedInput = action({
+      action: "license-change",
+      summary: "Apply the reviewed MIT license change.",
+      approval: { evidence: approvalEvidence }
+    });
+    const approvedPlan = planMaterialAction(manifest(), approvedInput);
+    const changedInput = action({
+      action: "license-change",
+      summary: "Apply a different proprietary license change.",
+      approval: { evidence: approvalEvidence }
+    });
+    const runner: CommandRunner = async (_command, args) => ({
+      stdout: args?.includes("/repos/acme/notifications/issues/comments/3")
+        ? JSON.stringify({
+            body: `APPROVE PRS-HARDSTOP-001 action=action-55 category=license-change digest=${approvedPlan.approvalDigest}`,
+            html_url: approvalEvidence,
+            issue_url: "https://api.github.com/repos/acme/notifications/issues/55",
+            author_association: "MEMBER",
+            user: { login: "maintainer" }
+          })
+        : "{}",
+      stderr: "",
+      exitCode: 0
+    });
+
+    const report = await deliverMaterialAction(manifest(), changedInput, {
+      githubClient: new GitHubClient({ runner }),
+      environment: { BOOTSTRAP_NOTIFICATION_WEBHOOK_URL: "https://notifications.example.test/hooks/material" },
+      webhookSender: async () => ({ ok: true, status: 204 })
+    });
+
+    expect(planMaterialAction(manifest(), changedInput).approvalDigest).not.toBe(approvedPlan.approvalDigest);
+    expect(report.hardStop.status).toBe("blocking");
+    expect(report.continueAfterNotification).toBe(false);
+    expect(report.exitCode).toBe(1);
+  });
+
+  it("rejects credential-like action IDs before building public payloads", () => {
+    expect(() => planMaterialAction(manifest(), action({ id: githubPat }))).toThrow("credential-like literals");
+    expect(() => planMaterialAction(manifest(), action({ governingTarget: githubPat }))).toThrow("credential-like literals");
+  });
+
+  it("rejects summaries that could mint a standalone approval marker", () => {
+    const approvalEvidence = "https://github.com/acme/notifications/issues/55#issuecomment-4";
+    const hardStop = planMaterialAction(
+      manifest(),
+      action({ action: "license-change", approval: { evidence: approvalEvidence } })
+    );
+    const injectedMarker = `APPROVE PRS-HARDSTOP-001 action=action-55 category=license-change digest=${hardStop.approvalDigest}`;
+
+    expect(() =>
+      planMaterialAction(
+        manifest(),
+        action({ id: "ordinary-action", summary: `Ordinary notification.\n${injectedMarker}` })
+      )
+    ).toThrow("single line");
+  });
+
+  it("escapes Markdown and HTML that could hide governing-record audit fields", () => {
+    const report = planMaterialAction(
+      manifest(),
+      action({ summary: "Routine [change](https://example.test) <!-- hide decision" })
+    );
+
+    expect(report.commentBody).not.toContain("<!--");
+    expect(report.commentBody).not.toContain("[change](https://example.test)");
+    expect(report.commentBody).toContain("&lt;");
+    expect(report.commentBody).toContain("- Decision: continue after required notifications are delivered");
+  });
+
+  it("does not send invalid governing targets to the configured webhook", async () => {
+    const webhookSender = vi.fn<WebhookSender>(async () => ({ ok: true, status: 204 }));
+    const report = await deliverMaterialAction(manifest(), action({ governingTarget: "not-a-github-target" }), {
+      githubClient: new GitHubClient({ runner: async () => ({ stdout: "{}", stderr: "", exitCode: 0 }) }),
+      environment: { BOOTSTRAP_NOTIFICATION_WEBHOOK_URL: "https://notifications.example.test/hooks/material" },
+      webhookSender
+    });
+
+    expect(report.governingTarget).toBe("[INVALID:GOVERNING-TARGET]");
+    expect(report.notification.status).toBe("blocking");
+    expect(report.notification.destinations).toContainEqual(
+      expect.objectContaining({ destination: "configured-webhook", status: "failed", detail: expect.stringContaining("skipped") })
+    );
+    expect(webhookSender).not.toHaveBeenCalled();
+    expect(JSON.stringify(report)).not.toContain("not-a-github-target");
+    for (const governingTarget of ["acme/repo?x#55", "#9007199254740993"]) {
+      const planned = planMaterialAction(manifest(), action({ governingTarget }));
+      expect(planned.governingTarget).toBe("[INVALID:GOVERNING-TARGET]");
+      expect(planned.notification.status).toBe("blocking");
+      expect(planned.continueAfterNotification).toBe(false);
+      expect(planned.exitCode).toBe(1);
+    }
+  });
+
+  it("fails closed when the configured mechanism is absent or rejects delivery", async () => {
+    const runner: CommandRunner = async () => ({ stdout: "{}", stderr: "", exitCode: 0 });
+    const webhookSender: WebhookSender = async () => ({ ok: false, status: 503 });
+    const missingConfiguration = planMaterialAction(manifest(false), action());
+    const rejected = await deliverMaterialAction(manifest(), action(), {
+      githubClient: new GitHubClient({ runner }),
+      environment: { BOOTSTRAP_NOTIFICATION_WEBHOOK_URL: "https://notifications.example.test/hooks/material" },
+      webhookSender
+    });
+
+    expect(missingConfiguration.notification.status).toBe("blocking");
+    expect(missingConfiguration.continueAfterNotification).toBe(false);
+    expect(missingConfiguration.exitCode).toBe(1);
+    expect(rejected.notification).toMatchObject({ status: "blocking", ruleId: "PRS-NOTIFY-001" });
+    expect(rejected.continueAfterNotification).toBe(false);
+    expect(rejected.exitCode).toBe(1);
+    expect(JSON.stringify(rejected)).not.toContain("notifications.example.test");
+  });
+
+  it("serializes only the webhook environment-variable reference", () => {
+    const serialized = stringifyManifest(manifest());
+
+    expect(serialized).toContain("webhookUrlEnv: BOOTSTRAP_NOTIFICATION_WEBHOOK_URL");
+    expect(serialized).not.toContain("https://");
+  });
+
+  it("plans and delivers expiring-exception intents from the resolved manifest", async () => {
+    const expiringManifest = normalizeManifest({
+      project: { name: "notifications", owner: "acme" },
+      notifications: { webhookUrlEnv: "BOOTSTRAP_NOTIFICATION_WEBHOOK_URL" },
+      archetype: { kind: "generic-empty" },
+      exceptions: [
+        {
+          id: "runner-migration",
+          policy: "runner-policy",
+          scope: ".github/workflows/release.yml",
+          rationale: "Migration in progress.",
+          approvedBy: "maintainer",
+          issue: "#55",
+          expiresAt: "2026-07-20"
+        }
+      ]
+    });
+    const now = new Date("2026-07-16T12:00:00.000Z");
+    const runner = vi.fn<CommandRunner>(async () => ({ stdout: "{}", stderr: "", exitCode: 0 }));
+    const webhookSender = vi.fn<WebhookSender>(async () => ({ ok: true, status: 204 }));
+    const planned = planExceptionNotifications(expiringManifest, now);
+    const delivered = await deliverExceptionNotifications(expiringManifest, {
+      now,
+      githubClient: new GitHubClient({ runner }),
+      environment: { BOOTSTRAP_NOTIFICATION_WEBHOOK_URL: "https://notifications.example.test/hooks/material" },
+      webhookSender
+    });
+
+    expect(exceptionNotificationReportSchema.parse(planned)).toEqual(planned);
+    expect(planned).toMatchObject({ mode: "plan", blockingExceptions: false, exitCode: 0 });
+    expect(planned.notifications).toHaveLength(1);
+    expect(planned.notifications[0]).toMatchObject({
+      action: "policy-exception",
+      governingTarget: "acme/notifications#55",
+      notification: { status: "ready" }
+    });
+    expect(delivered).toMatchObject({ mode: "deliver", blockingExceptions: false, exitCode: 0 });
+    expect(delivered.notifications[0]?.notification.status).toBe("delivered");
+  });
+
+  it("keeps blocking exception validation fail-closed when no expiry notification is due", () => {
+    const blockedManifest = normalizeManifest({
+      project: { name: "notifications", owner: "acme" },
+      notifications: { webhookUrlEnv: "BOOTSTRAP_NOTIFICATION_WEBHOOK_URL" },
+      archetype: { kind: "generic-empty" },
+      exceptions: [
+        {
+          id: "expired",
+          policy: "runner-policy",
+          scope: ".github/workflows/release.yml",
+          rationale: "Migration stalled.",
+          approvedBy: "maintainer",
+          issue: "#55",
+          expiresAt: "2026-07-15"
+        }
+      ]
+    });
+
+    const report = planExceptionNotifications(blockedManifest, new Date("2026-07-16T12:00:00.000Z"));
+
+    expect(report.notifications).toEqual([]);
+    expect(report.blockingExceptions).toBe(true);
+    expect(report.exitCode).toBe(1);
+  });
+
+  it("normalizes unconstrained exception IDs into stable redacted notification reports", () => {
+    const unsafeId = `${githubPat}\n${"x".repeat(2_100)}`;
+    const expiringManifest = normalizeManifest({
+      project: { name: "notifications", owner: "acme" },
+      notifications: { webhookUrlEnv: "BOOTSTRAP_NOTIFICATION_WEBHOOK_URL" },
+      archetype: { kind: "generic-empty" },
+      exceptions: [
+        {
+          id: unsafeId,
+          policy: "runner-policy",
+          scope: "repo",
+          rationale: "Migration in progress.",
+          approvedBy: "maintainer",
+          issue: "#55",
+          expiresAt: "2026-07-20"
+        }
+      ]
+    });
+
+    const report = planExceptionNotifications(expiringManifest, new Date("2026-07-16T12:00:00.000Z"));
+
+    expect(report.notifications).toHaveLength(1);
+    expect(report.notifications[0]?.actionId).toMatch(/^exception-[0-9a-f]{12}-expiring$/);
+    expect(report.notifications[0]?.actionId.length).toBeLessThan(100);
+    expect(JSON.stringify(report)).not.toContain(githubPat);
+    expect(report.notifications[0]?.webhookPayload.summary).not.toContain("\n");
+    expect(report.exitCode).toBe(0);
+  });
+});

--- a/tests/notifications.test.ts
+++ b/tests/notifications.test.ts
@@ -8,22 +8,11 @@ import {
   exceptionNotificationReportSchema,
   materialActionPlanSchema,
   planExceptionNotifications,
-  planMaterialAction,
-  type WebhookResolver,
-  type WebhookSender
+  planMaterialAction
 } from "../src/notifications.js";
 import type { CommandRunner } from "../src/lib/process.js";
 
 const githubPat = ["github", "pat"].join("_") + "_abcdefghijklmnopqrstuvwxyz123456";
-const publicWebhookResolver: WebhookResolver = async () => [{ address: "8.8.8.8", family: 4 }];
-
-function webhookEnvironment(url = "https://notifications.example.test/hooks/material"): NodeJS.ProcessEnv {
-  const hostname = new URL(url).hostname.replace(/^\[|\]$/g, "").replace(/\.$/, "").toLowerCase();
-  return {
-    BOOTSTRAP_NOTIFICATION_WEBHOOK_URL: url,
-    BOOTSTRAP_NOTIFICATION_WEBHOOK_ALLOWED_HOSTS: hostname
-  };
-}
 
 function manifest(withNotifications = true) {
   return normalizeManifest({
@@ -76,7 +65,7 @@ describe("material-action notifications", () => {
     expect(report.exitCode).toBe(1);
   });
 
-  it("delivers to GitHub and the configured webhook before allowing work to continue", async () => {
+  it("delivers to GitHub but fails closed while secure webhook transport is deferred", async () => {
     const approvalEvidence = "https://github.com/ACME/Notifications/issues/55#issuecomment-1";
     const actionInput = action({
       action: "license-change",
@@ -98,26 +87,18 @@ describe("material-action notifications", () => {
       stderr: "",
       exitCode: 0
     }));
-    const webhookSender = vi.fn<WebhookSender>(async () => ({ ok: true, status: 204 }));
-    const report = await deliverMaterialAction(
-      manifest(),
-      actionInput,
-      {
-        githubClient: new GitHubClient({ runner }),
-        environment: webhookEnvironment(),
-        webhookSender,
-        webhookResolver: publicWebhookResolver
-      }
-    );
+    const report = await deliverMaterialAction(manifest(), actionInput, {
+      githubClient: new GitHubClient({ runner })
+    });
 
     expect(planned.hardStop.status).toBe("verification-required");
     expect(planned.approvalDigest).toMatch(/^[0-9a-f]{64}$/);
     expect(planned.continueAfterNotification).toBe(false);
     expect(planned.exitCode).toBe(1);
-    expect(report.notification.status).toBe("delivered");
+    expect(report.notification.status).toBe("blocking");
     expect(report.hardStop.status).toBe("approved");
-    expect(report.continueAfterNotification).toBe(true);
-    expect(report.exitCode).toBe(0);
+    expect(report.continueAfterNotification).toBe(false);
+    expect(report.exitCode).toBe(1);
     expect(report.commentBody).toContain("- Approval evidence: ");
     expect(report.commentBody).toContain("(verified)");
     expect(report.commentBody).toContain("- Decision: continue after required notifications are delivered");
@@ -126,9 +107,12 @@ describe("material-action notifications", () => {
       expect.arrayContaining(["/repos/acme/notifications/issues/55/comments"]),
       expect.objectContaining({ input: expect.stringContaining("PRS-NOTIFY-001") })
     );
-    expect(webhookSender).toHaveBeenCalledWith(
-      "https://notifications.example.test/hooks/material",
-      expect.objectContaining({ ruleId: "PRS-NOTIFY-001", actionId: "action-55", hardStopCategory: "license-change" })
+    expect(report.notification.destinations).toContainEqual(
+      expect.objectContaining({
+        destination: "configured-webhook",
+        status: "failed",
+        detail: expect.stringContaining("secure transport follow-up")
+      })
     );
   });
 
@@ -150,18 +134,11 @@ describe("material-action notifications", () => {
       stderr: "",
       exitCode: 0
     });
-    const report = await deliverMaterialAction(
-      manifest(),
-      actionInput,
-      {
-        githubClient: new GitHubClient({ runner }),
-        environment: webhookEnvironment(),
-        webhookSender: async () => ({ ok: true, status: 204 }),
-        webhookResolver: publicWebhookResolver
-      }
-    );
+    const report = await deliverMaterialAction(manifest(), actionInput, {
+      githubClient: new GitHubClient({ runner })
+    });
 
-    expect(report.notification.status).toBe("delivered");
+    expect(report.notification.status).toBe("blocking");
     expect(report.hardStop).toMatchObject({ status: "blocking", category: "license-change" });
     expect(report.continueAfterNotification).toBe(false);
     expect(report.exitCode).toBe(1);
@@ -195,10 +172,7 @@ describe("material-action notifications", () => {
     });
 
     const report = await deliverMaterialAction(manifest(), changedInput, {
-      githubClient: new GitHubClient({ runner }),
-      environment: webhookEnvironment(),
-      webhookSender: async () => ({ ok: true, status: 204 }),
-      webhookResolver: publicWebhookResolver
+      githubClient: new GitHubClient({ runner })
     });
 
     expect(planMaterialAction(manifest(), changedInput).approvalDigest).not.toBe(approvedPlan.approvalDigest);
@@ -240,12 +214,9 @@ describe("material-action notifications", () => {
     expect(report.commentBody).toContain("- Decision: continue after required notifications are delivered");
   });
 
-  it("does not send invalid governing targets to the configured webhook", async () => {
-    const webhookSender = vi.fn<WebhookSender>(async () => ({ ok: true, status: 204 }));
+  it("does not attempt webhook delivery for invalid governing targets", async () => {
     const report = await deliverMaterialAction(manifest(), action({ governingTarget: "not-a-github-target" }), {
-      githubClient: new GitHubClient({ runner: async () => ({ stdout: "{}", stderr: "", exitCode: 0 }) }),
-      environment: webhookEnvironment(),
-      webhookSender
+      githubClient: new GitHubClient({ runner: async () => ({ stdout: "{}", stderr: "", exitCode: 0 }) })
     });
 
     expect(report.governingTarget).toBe("[INVALID:GOVERNING-TARGET]");
@@ -253,7 +224,6 @@ describe("material-action notifications", () => {
     expect(report.notification.destinations).toContainEqual(
       expect.objectContaining({ destination: "configured-webhook", status: "failed", detail: expect.stringContaining("skipped") })
     );
-    expect(webhookSender).not.toHaveBeenCalled();
     expect(JSON.stringify(report)).not.toContain("not-a-github-target");
     for (const governingTarget of ["acme/repo?x#55", "#9007199254740993"]) {
       const planned = planMaterialAction(manifest(), action({ governingTarget }));
@@ -264,128 +234,20 @@ describe("material-action notifications", () => {
     }
   });
 
-  it("rejects allowlisted literal loopback, link-local, and private webhook addresses", async () => {
+  it("fails closed when the configured mechanism is absent or transport is deferred", async () => {
     const runner: CommandRunner = async () => ({ stdout: "{}", stderr: "", exitCode: 0 });
-    for (const url of [
-      "https://127.0.0.1/hooks/material",
-      "https://169.254.169.254/hooks/material",
-      "https://10.0.0.7/hooks/material",
-      "https://[::1]/hooks/material",
-      "https://[::ffff:127.0.0.1]/hooks/material",
-      "https://[fe80::1]/hooks/material"
-    ]) {
-      const webhookSender = vi.fn<WebhookSender>(async () => ({ ok: true, status: 204 }));
-      const report = await deliverMaterialAction(manifest(), action(), {
-        githubClient: new GitHubClient({ runner }),
-        environment: webhookEnvironment(url),
-        webhookSender
-      });
-
-      expect(report.notification).toMatchObject({ status: "blocking" });
-      expect(report.notification.destinations).toContainEqual(
-        expect.objectContaining({ destination: "configured-webhook", status: "failed" })
-      );
-      expect(webhookSender).not.toHaveBeenCalled();
-      expect(JSON.stringify(report)).not.toContain(new URL(url).hostname);
-    }
-  });
-
-  it("rejects an allowlisted hostname when any DNS answer is private", async () => {
-    const runner: CommandRunner = async () => ({ stdout: "{}", stderr: "", exitCode: 0 });
-    const webhookSender = vi.fn<WebhookSender>(async () => ({ ok: true, status: 204 }));
-    const webhookResolver = vi.fn<WebhookResolver>(async () => [
-      { address: "8.8.8.8", family: 4 },
-      { address: "10.0.0.7", family: 4 }
-    ]);
-    const report = await deliverMaterialAction(manifest(), action(), {
-      githubClient: new GitHubClient({ runner }),
-      environment: webhookEnvironment("https://internal.example.test/hooks/material"),
-      webhookSender,
-      webhookResolver
-    });
-
-    expect(webhookResolver).toHaveBeenCalledWith("internal.example.test");
-    expect(report.notification).toMatchObject({ status: "blocking" });
-    expect(webhookSender).not.toHaveBeenCalled();
-    expect(JSON.stringify(report)).not.toContain("internal.example.test");
-    expect(JSON.stringify(report)).not.toContain("10.0.0.7");
-  });
-
-  it("rejects allowlisted hostnames that resolve to reserved IPv6 documentation ranges", async () => {
-    const runner: CommandRunner = async () => ({ stdout: "{}", stderr: "", exitCode: 0 });
-    for (const address of ["2001:db8::1", "3fff::1"]) {
-      const webhookSender = vi.fn<WebhookSender>(async () => ({ ok: true, status: 204 }));
-      const report = await deliverMaterialAction(manifest(), action(), {
-        githubClient: new GitHubClient({ runner }),
-        environment: webhookEnvironment("https://reserved.example.test/hooks/material"),
-        webhookSender,
-        webhookResolver: async () => [{ address, family: 6 }]
-      });
-
-      expect(report.notification).toMatchObject({ status: "blocking" });
-      expect(webhookSender).not.toHaveBeenCalled();
-      expect(JSON.stringify(report)).not.toContain(address);
-    }
-  });
-
-  it("rejects a public webhook hostname that is absent from the executor allowlist", async () => {
-    const runner: CommandRunner = async () => ({ stdout: "{}", stderr: "", exitCode: 0 });
-    const webhookSender = vi.fn<WebhookSender>(async () => ({ ok: true, status: 204 }));
-    const webhookResolver = vi.fn(publicWebhookResolver);
-    const report = await deliverMaterialAction(manifest(), action(), {
-      githubClient: new GitHubClient({ runner }),
-      environment: {
-        BOOTSTRAP_NOTIFICATION_WEBHOOK_URL: "https://notifications.example.test/hooks/material",
-        BOOTSTRAP_NOTIFICATION_WEBHOOK_ALLOWED_HOSTS: "approved.example.test"
-      },
-      webhookSender,
-      webhookResolver
-    });
-
-    expect(report.notification).toMatchObject({ status: "blocking" });
-    expect(webhookResolver).not.toHaveBeenCalled();
-    expect(webhookSender).not.toHaveBeenCalled();
-  });
-
-  it("fails closed when allowlisted-host DNS resolution exceeds the delivery deadline", async () => {
-    vi.useFakeTimers();
-    const runner: CommandRunner = async () => ({ stdout: "{}", stderr: "", exitCode: 0 });
-    const webhookSender = vi.fn<WebhookSender>(async () => ({ ok: true, status: 204 }));
-    const delivery = deliverMaterialAction(manifest(), action(), {
-      githubClient: new GitHubClient({ runner }),
-      environment: webhookEnvironment(),
-      webhookSender,
-      webhookResolver: async () => new Promise<never>(() => undefined)
-    });
-
-    try {
-      await vi.advanceTimersByTimeAsync(10_000);
-      const report = await delivery;
-      expect(report.notification).toMatchObject({ status: "blocking" });
-      expect(webhookSender).not.toHaveBeenCalled();
-    } finally {
-      vi.useRealTimers();
-    }
-  });
-
-  it("fails closed when the configured mechanism is absent or rejects delivery", async () => {
-    const runner: CommandRunner = async () => ({ stdout: "{}", stderr: "", exitCode: 0 });
-    const webhookSender: WebhookSender = async () => ({ ok: false, status: 503 });
     const missingConfiguration = planMaterialAction(manifest(false), action());
-    const rejected = await deliverMaterialAction(manifest(), action(), {
-      githubClient: new GitHubClient({ runner }),
-      environment: webhookEnvironment(),
-      webhookSender,
-      webhookResolver: publicWebhookResolver
+    const deferred = await deliverMaterialAction(manifest(), action(), {
+      githubClient: new GitHubClient({ runner })
     });
 
     expect(missingConfiguration.notification.status).toBe("blocking");
     expect(missingConfiguration.continueAfterNotification).toBe(false);
     expect(missingConfiguration.exitCode).toBe(1);
-    expect(rejected.notification).toMatchObject({ status: "blocking", ruleId: "PRS-NOTIFY-001" });
-    expect(rejected.continueAfterNotification).toBe(false);
-    expect(rejected.exitCode).toBe(1);
-    expect(JSON.stringify(rejected)).not.toContain("notifications.example.test");
+    expect(deferred.notification).toMatchObject({ status: "blocking", ruleId: "PRS-NOTIFY-001" });
+    expect(deferred.continueAfterNotification).toBe(false);
+    expect(deferred.exitCode).toBe(1);
+    expect(JSON.stringify(deferred)).not.toContain("notifications.example.test");
   });
 
   it("serializes only the webhook environment-variable reference", () => {
@@ -414,14 +276,10 @@ describe("material-action notifications", () => {
     });
     const now = new Date("2026-07-16T12:00:00.000Z");
     const runner = vi.fn<CommandRunner>(async () => ({ stdout: "{}", stderr: "", exitCode: 0 }));
-    const webhookSender = vi.fn<WebhookSender>(async () => ({ ok: true, status: 204 }));
     const planned = planExceptionNotifications(expiringManifest, now);
     const delivered = await deliverExceptionNotifications(expiringManifest, {
       now,
-      githubClient: new GitHubClient({ runner }),
-      environment: webhookEnvironment(),
-      webhookSender,
-      webhookResolver: publicWebhookResolver
+      githubClient: new GitHubClient({ runner })
     });
 
     expect(exceptionNotificationReportSchema.parse(planned)).toEqual(planned);
@@ -432,8 +290,8 @@ describe("material-action notifications", () => {
       governingTarget: "acme/notifications#55",
       notification: { status: "ready" }
     });
-    expect(delivered).toMatchObject({ mode: "deliver", blockingExceptions: false, exitCode: 0 });
-    expect(delivered.notifications[0]?.notification.status).toBe("delivered");
+    expect(delivered).toMatchObject({ mode: "deliver", blockingExceptions: false, exitCode: 1 });
+    expect(delivered.notifications[0]?.notification.status).toBe("blocking");
   });
 
   it("keeps blocking exception validation fail-closed when no expiry notification is due", () => {

--- a/tests/notifications.test.ts
+++ b/tests/notifications.test.ts
@@ -9,11 +9,21 @@ import {
   materialActionPlanSchema,
   planExceptionNotifications,
   planMaterialAction,
+  type WebhookResolver,
   type WebhookSender
 } from "../src/notifications.js";
 import type { CommandRunner } from "../src/lib/process.js";
 
 const githubPat = ["github", "pat"].join("_") + "_abcdefghijklmnopqrstuvwxyz123456";
+const publicWebhookResolver: WebhookResolver = async () => [{ address: "8.8.8.8", family: 4 }];
+
+function webhookEnvironment(url = "https://notifications.example.test/hooks/material"): NodeJS.ProcessEnv {
+  const hostname = new URL(url).hostname.replace(/^\[|\]$/g, "").replace(/\.$/, "").toLowerCase();
+  return {
+    BOOTSTRAP_NOTIFICATION_WEBHOOK_URL: url,
+    BOOTSTRAP_NOTIFICATION_WEBHOOK_ALLOWED_HOSTS: hostname
+  };
+}
 
 function manifest(withNotifications = true) {
   return normalizeManifest({
@@ -94,8 +104,9 @@ describe("material-action notifications", () => {
       actionInput,
       {
         githubClient: new GitHubClient({ runner }),
-        environment: { BOOTSTRAP_NOTIFICATION_WEBHOOK_URL: "https://notifications.example.test/hooks/material" },
-        webhookSender
+        environment: webhookEnvironment(),
+        webhookSender,
+        webhookResolver: publicWebhookResolver
       }
     );
 
@@ -144,8 +155,9 @@ describe("material-action notifications", () => {
       actionInput,
       {
         githubClient: new GitHubClient({ runner }),
-        environment: { BOOTSTRAP_NOTIFICATION_WEBHOOK_URL: "https://notifications.example.test/hooks/material" },
-        webhookSender: async () => ({ ok: true, status: 204 })
+        environment: webhookEnvironment(),
+        webhookSender: async () => ({ ok: true, status: 204 }),
+        webhookResolver: publicWebhookResolver
       }
     );
 
@@ -184,8 +196,9 @@ describe("material-action notifications", () => {
 
     const report = await deliverMaterialAction(manifest(), changedInput, {
       githubClient: new GitHubClient({ runner }),
-      environment: { BOOTSTRAP_NOTIFICATION_WEBHOOK_URL: "https://notifications.example.test/hooks/material" },
-      webhookSender: async () => ({ ok: true, status: 204 })
+      environment: webhookEnvironment(),
+      webhookSender: async () => ({ ok: true, status: 204 }),
+      webhookResolver: publicWebhookResolver
     });
 
     expect(planMaterialAction(manifest(), changedInput).approvalDigest).not.toBe(approvedPlan.approvalDigest);
@@ -231,7 +244,7 @@ describe("material-action notifications", () => {
     const webhookSender = vi.fn<WebhookSender>(async () => ({ ok: true, status: 204 }));
     const report = await deliverMaterialAction(manifest(), action({ governingTarget: "not-a-github-target" }), {
       githubClient: new GitHubClient({ runner: async () => ({ stdout: "{}", stderr: "", exitCode: 0 }) }),
-      environment: { BOOTSTRAP_NOTIFICATION_WEBHOOK_URL: "https://notifications.example.test/hooks/material" },
+      environment: webhookEnvironment(),
       webhookSender
     });
 
@@ -251,14 +264,119 @@ describe("material-action notifications", () => {
     }
   });
 
+  it("rejects allowlisted literal loopback, link-local, and private webhook addresses", async () => {
+    const runner: CommandRunner = async () => ({ stdout: "{}", stderr: "", exitCode: 0 });
+    for (const url of [
+      "https://127.0.0.1/hooks/material",
+      "https://169.254.169.254/hooks/material",
+      "https://10.0.0.7/hooks/material",
+      "https://[::1]/hooks/material",
+      "https://[::ffff:127.0.0.1]/hooks/material",
+      "https://[fe80::1]/hooks/material"
+    ]) {
+      const webhookSender = vi.fn<WebhookSender>(async () => ({ ok: true, status: 204 }));
+      const report = await deliverMaterialAction(manifest(), action(), {
+        githubClient: new GitHubClient({ runner }),
+        environment: webhookEnvironment(url),
+        webhookSender
+      });
+
+      expect(report.notification).toMatchObject({ status: "blocking" });
+      expect(report.notification.destinations).toContainEqual(
+        expect.objectContaining({ destination: "configured-webhook", status: "failed" })
+      );
+      expect(webhookSender).not.toHaveBeenCalled();
+      expect(JSON.stringify(report)).not.toContain(new URL(url).hostname);
+    }
+  });
+
+  it("rejects an allowlisted hostname when any DNS answer is private", async () => {
+    const runner: CommandRunner = async () => ({ stdout: "{}", stderr: "", exitCode: 0 });
+    const webhookSender = vi.fn<WebhookSender>(async () => ({ ok: true, status: 204 }));
+    const webhookResolver = vi.fn<WebhookResolver>(async () => [
+      { address: "8.8.8.8", family: 4 },
+      { address: "10.0.0.7", family: 4 }
+    ]);
+    const report = await deliverMaterialAction(manifest(), action(), {
+      githubClient: new GitHubClient({ runner }),
+      environment: webhookEnvironment("https://internal.example.test/hooks/material"),
+      webhookSender,
+      webhookResolver
+    });
+
+    expect(webhookResolver).toHaveBeenCalledWith("internal.example.test");
+    expect(report.notification).toMatchObject({ status: "blocking" });
+    expect(webhookSender).not.toHaveBeenCalled();
+    expect(JSON.stringify(report)).not.toContain("internal.example.test");
+    expect(JSON.stringify(report)).not.toContain("10.0.0.7");
+  });
+
+  it("rejects allowlisted hostnames that resolve to reserved IPv6 documentation ranges", async () => {
+    const runner: CommandRunner = async () => ({ stdout: "{}", stderr: "", exitCode: 0 });
+    for (const address of ["2001:db8::1", "3fff::1"]) {
+      const webhookSender = vi.fn<WebhookSender>(async () => ({ ok: true, status: 204 }));
+      const report = await deliverMaterialAction(manifest(), action(), {
+        githubClient: new GitHubClient({ runner }),
+        environment: webhookEnvironment("https://reserved.example.test/hooks/material"),
+        webhookSender,
+        webhookResolver: async () => [{ address, family: 6 }]
+      });
+
+      expect(report.notification).toMatchObject({ status: "blocking" });
+      expect(webhookSender).not.toHaveBeenCalled();
+      expect(JSON.stringify(report)).not.toContain(address);
+    }
+  });
+
+  it("rejects a public webhook hostname that is absent from the executor allowlist", async () => {
+    const runner: CommandRunner = async () => ({ stdout: "{}", stderr: "", exitCode: 0 });
+    const webhookSender = vi.fn<WebhookSender>(async () => ({ ok: true, status: 204 }));
+    const webhookResolver = vi.fn(publicWebhookResolver);
+    const report = await deliverMaterialAction(manifest(), action(), {
+      githubClient: new GitHubClient({ runner }),
+      environment: {
+        BOOTSTRAP_NOTIFICATION_WEBHOOK_URL: "https://notifications.example.test/hooks/material",
+        BOOTSTRAP_NOTIFICATION_WEBHOOK_ALLOWED_HOSTS: "approved.example.test"
+      },
+      webhookSender,
+      webhookResolver
+    });
+
+    expect(report.notification).toMatchObject({ status: "blocking" });
+    expect(webhookResolver).not.toHaveBeenCalled();
+    expect(webhookSender).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when allowlisted-host DNS resolution exceeds the delivery deadline", async () => {
+    vi.useFakeTimers();
+    const runner: CommandRunner = async () => ({ stdout: "{}", stderr: "", exitCode: 0 });
+    const webhookSender = vi.fn<WebhookSender>(async () => ({ ok: true, status: 204 }));
+    const delivery = deliverMaterialAction(manifest(), action(), {
+      githubClient: new GitHubClient({ runner }),
+      environment: webhookEnvironment(),
+      webhookSender,
+      webhookResolver: async () => new Promise<never>(() => undefined)
+    });
+
+    try {
+      await vi.advanceTimersByTimeAsync(10_000);
+      const report = await delivery;
+      expect(report.notification).toMatchObject({ status: "blocking" });
+      expect(webhookSender).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("fails closed when the configured mechanism is absent or rejects delivery", async () => {
     const runner: CommandRunner = async () => ({ stdout: "{}", stderr: "", exitCode: 0 });
     const webhookSender: WebhookSender = async () => ({ ok: false, status: 503 });
     const missingConfiguration = planMaterialAction(manifest(false), action());
     const rejected = await deliverMaterialAction(manifest(), action(), {
       githubClient: new GitHubClient({ runner }),
-      environment: { BOOTSTRAP_NOTIFICATION_WEBHOOK_URL: "https://notifications.example.test/hooks/material" },
-      webhookSender
+      environment: webhookEnvironment(),
+      webhookSender,
+      webhookResolver: publicWebhookResolver
     });
 
     expect(missingConfiguration.notification.status).toBe("blocking");
@@ -301,8 +419,9 @@ describe("material-action notifications", () => {
     const delivered = await deliverExceptionNotifications(expiringManifest, {
       now,
       githubClient: new GitHubClient({ runner }),
-      environment: { BOOTSTRAP_NOTIFICATION_WEBHOOK_URL: "https://notifications.example.test/hooks/material" },
-      webhookSender
+      environment: webhookEnvironment(),
+      webhookSender,
+      webhookResolver: publicWebhookResolver
     });
 
     expect(exceptionNotificationReportSchema.parse(planned)).toEqual(planned);

--- a/tests/notifications.test.ts
+++ b/tests/notifications.test.ts
@@ -8,11 +8,22 @@ import {
   exceptionNotificationReportSchema,
   materialActionPlanSchema,
   planExceptionNotifications,
-  planMaterialAction
+  planMaterialAction,
+  type WebhookResolver,
+  type WebhookSender
 } from "../src/notifications.js";
 import type { CommandRunner } from "../src/lib/process.js";
 
 const githubPat = ["github", "pat"].join("_") + "_abcdefghijklmnopqrstuvwxyz123456";
+const publicWebhookResolver: WebhookResolver = async () => [{ address: "8.8.8.8", family: 4 }];
+
+function webhookEnvironment(url = "https://notifications.example.test/hooks/material"): NodeJS.ProcessEnv {
+  const hostname = new URL(url).hostname.replace(/^\[|\]$/g, "").replace(/\.$/, "").toLowerCase();
+  return {
+    BOOTSTRAP_NOTIFICATION_WEBHOOK_URL: url,
+    BOOTSTRAP_NOTIFICATION_WEBHOOK_ALLOWED_HOSTS: hostname
+  };
+}
 
 function manifest(withNotifications = true) {
   return normalizeManifest({
@@ -65,7 +76,7 @@ describe("material-action notifications", () => {
     expect(report.exitCode).toBe(1);
   });
 
-  it("delivers to GitHub but fails closed while secure webhook transport is deferred", async () => {
+  it("delivers to GitHub and the configured webhook before allowing work to continue", async () => {
     const approvalEvidence = "https://github.com/ACME/Notifications/issues/55#issuecomment-1";
     const actionInput = action({
       action: "license-change",
@@ -87,18 +98,26 @@ describe("material-action notifications", () => {
       stderr: "",
       exitCode: 0
     }));
-    const report = await deliverMaterialAction(manifest(), actionInput, {
-      githubClient: new GitHubClient({ runner })
-    });
+    const webhookSender = vi.fn<WebhookSender>(async () => ({ ok: true, status: 204 }));
+    const report = await deliverMaterialAction(
+      manifest(),
+      actionInput,
+      {
+        githubClient: new GitHubClient({ runner }),
+        environment: webhookEnvironment(),
+        webhookSender,
+        webhookResolver: publicWebhookResolver
+      }
+    );
 
     expect(planned.hardStop.status).toBe("verification-required");
     expect(planned.approvalDigest).toMatch(/^[0-9a-f]{64}$/);
     expect(planned.continueAfterNotification).toBe(false);
     expect(planned.exitCode).toBe(1);
-    expect(report.notification.status).toBe("blocking");
+    expect(report.notification.status).toBe("delivered");
     expect(report.hardStop.status).toBe("approved");
-    expect(report.continueAfterNotification).toBe(false);
-    expect(report.exitCode).toBe(1);
+    expect(report.continueAfterNotification).toBe(true);
+    expect(report.exitCode).toBe(0);
     expect(report.commentBody).toContain("- Approval evidence: ");
     expect(report.commentBody).toContain("(verified)");
     expect(report.commentBody).toContain("- Decision: continue after required notifications are delivered");
@@ -107,12 +126,9 @@ describe("material-action notifications", () => {
       expect.arrayContaining(["/repos/acme/notifications/issues/55/comments"]),
       expect.objectContaining({ input: expect.stringContaining("PRS-NOTIFY-001") })
     );
-    expect(report.notification.destinations).toContainEqual(
-      expect.objectContaining({
-        destination: "configured-webhook",
-        status: "failed",
-        detail: expect.stringContaining("secure transport follow-up")
-      })
+    expect(webhookSender).toHaveBeenCalledWith(
+      "https://notifications.example.test/hooks/material",
+      expect.objectContaining({ ruleId: "PRS-NOTIFY-001", actionId: "action-55", hardStopCategory: "license-change" })
     );
   });
 
@@ -134,11 +150,18 @@ describe("material-action notifications", () => {
       stderr: "",
       exitCode: 0
     });
-    const report = await deliverMaterialAction(manifest(), actionInput, {
-      githubClient: new GitHubClient({ runner })
-    });
+    const report = await deliverMaterialAction(
+      manifest(),
+      actionInput,
+      {
+        githubClient: new GitHubClient({ runner }),
+        environment: webhookEnvironment(),
+        webhookSender: async () => ({ ok: true, status: 204 }),
+        webhookResolver: publicWebhookResolver
+      }
+    );
 
-    expect(report.notification.status).toBe("blocking");
+    expect(report.notification.status).toBe("delivered");
     expect(report.hardStop).toMatchObject({ status: "blocking", category: "license-change" });
     expect(report.continueAfterNotification).toBe(false);
     expect(report.exitCode).toBe(1);
@@ -172,7 +195,10 @@ describe("material-action notifications", () => {
     });
 
     const report = await deliverMaterialAction(manifest(), changedInput, {
-      githubClient: new GitHubClient({ runner })
+      githubClient: new GitHubClient({ runner }),
+      environment: webhookEnvironment(),
+      webhookSender: async () => ({ ok: true, status: 204 }),
+      webhookResolver: publicWebhookResolver
     });
 
     expect(planMaterialAction(manifest(), changedInput).approvalDigest).not.toBe(approvedPlan.approvalDigest);
@@ -214,9 +240,12 @@ describe("material-action notifications", () => {
     expect(report.commentBody).toContain("- Decision: continue after required notifications are delivered");
   });
 
-  it("does not attempt webhook delivery for invalid governing targets", async () => {
+  it("does not send invalid governing targets to the configured webhook", async () => {
+    const webhookSender = vi.fn<WebhookSender>(async () => ({ ok: true, status: 204 }));
     const report = await deliverMaterialAction(manifest(), action({ governingTarget: "not-a-github-target" }), {
-      githubClient: new GitHubClient({ runner: async () => ({ stdout: "{}", stderr: "", exitCode: 0 }) })
+      githubClient: new GitHubClient({ runner: async () => ({ stdout: "{}", stderr: "", exitCode: 0 }) }),
+      environment: webhookEnvironment(),
+      webhookSender
     });
 
     expect(report.governingTarget).toBe("[INVALID:GOVERNING-TARGET]");
@@ -224,6 +253,7 @@ describe("material-action notifications", () => {
     expect(report.notification.destinations).toContainEqual(
       expect.objectContaining({ destination: "configured-webhook", status: "failed", detail: expect.stringContaining("skipped") })
     );
+    expect(webhookSender).not.toHaveBeenCalled();
     expect(JSON.stringify(report)).not.toContain("not-a-github-target");
     for (const governingTarget of ["acme/repo?x#55", "#9007199254740993"]) {
       const planned = planMaterialAction(manifest(), action({ governingTarget }));
@@ -234,20 +264,128 @@ describe("material-action notifications", () => {
     }
   });
 
-  it("fails closed when the configured mechanism is absent or transport is deferred", async () => {
+  it("rejects allowlisted literal loopback, link-local, and private webhook addresses", async () => {
     const runner: CommandRunner = async () => ({ stdout: "{}", stderr: "", exitCode: 0 });
+    for (const url of [
+      "https://127.0.0.1/hooks/material",
+      "https://169.254.169.254/hooks/material",
+      "https://10.0.0.7/hooks/material",
+      "https://[::1]/hooks/material",
+      "https://[::ffff:127.0.0.1]/hooks/material",
+      "https://[fe80::1]/hooks/material"
+    ]) {
+      const webhookSender = vi.fn<WebhookSender>(async () => ({ ok: true, status: 204 }));
+      const report = await deliverMaterialAction(manifest(), action(), {
+        githubClient: new GitHubClient({ runner }),
+        environment: webhookEnvironment(url),
+        webhookSender
+      });
+
+      expect(report.notification).toMatchObject({ status: "blocking" });
+      expect(report.notification.destinations).toContainEqual(
+        expect.objectContaining({ destination: "configured-webhook", status: "failed" })
+      );
+      expect(webhookSender).not.toHaveBeenCalled();
+      expect(JSON.stringify(report)).not.toContain(new URL(url).hostname);
+    }
+  });
+
+  it("rejects an allowlisted hostname when any DNS answer is private", async () => {
+    const runner: CommandRunner = async () => ({ stdout: "{}", stderr: "", exitCode: 0 });
+    const webhookSender = vi.fn<WebhookSender>(async () => ({ ok: true, status: 204 }));
+    const webhookResolver = vi.fn<WebhookResolver>(async () => [
+      { address: "8.8.8.8", family: 4 },
+      { address: "10.0.0.7", family: 4 }
+    ]);
+    const report = await deliverMaterialAction(manifest(), action(), {
+      githubClient: new GitHubClient({ runner }),
+      environment: webhookEnvironment("https://internal.example.test/hooks/material"),
+      webhookSender,
+      webhookResolver
+    });
+
+    expect(webhookResolver).toHaveBeenCalledWith("internal.example.test");
+    expect(report.notification).toMatchObject({ status: "blocking" });
+    expect(webhookSender).not.toHaveBeenCalled();
+    expect(JSON.stringify(report)).not.toContain("internal.example.test");
+    expect(JSON.stringify(report)).not.toContain("10.0.0.7");
+  });
+
+  it("rejects allowlisted hostnames that resolve to reserved IPv6 documentation ranges", async () => {
+    const runner: CommandRunner = async () => ({ stdout: "{}", stderr: "", exitCode: 0 });
+    for (const address of ["2001:db8::1", "3fff::1"]) {
+      const webhookSender = vi.fn<WebhookSender>(async () => ({ ok: true, status: 204 }));
+      const report = await deliverMaterialAction(manifest(), action(), {
+        githubClient: new GitHubClient({ runner }),
+        environment: webhookEnvironment("https://reserved.example.test/hooks/material"),
+        webhookSender,
+        webhookResolver: async () => [{ address, family: 6 }]
+      });
+
+      expect(report.notification).toMatchObject({ status: "blocking" });
+      expect(webhookSender).not.toHaveBeenCalled();
+      expect(JSON.stringify(report)).not.toContain(address);
+    }
+  });
+
+  it("rejects a public webhook hostname that is absent from the executor allowlist", async () => {
+    const runner: CommandRunner = async () => ({ stdout: "{}", stderr: "", exitCode: 0 });
+    const webhookSender = vi.fn<WebhookSender>(async () => ({ ok: true, status: 204 }));
+    const webhookResolver = vi.fn(publicWebhookResolver);
+    const report = await deliverMaterialAction(manifest(), action(), {
+      githubClient: new GitHubClient({ runner }),
+      environment: {
+        BOOTSTRAP_NOTIFICATION_WEBHOOK_URL: "https://notifications.example.test/hooks/material",
+        BOOTSTRAP_NOTIFICATION_WEBHOOK_ALLOWED_HOSTS: "approved.example.test"
+      },
+      webhookSender,
+      webhookResolver
+    });
+
+    expect(report.notification).toMatchObject({ status: "blocking" });
+    expect(webhookResolver).not.toHaveBeenCalled();
+    expect(webhookSender).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when allowlisted-host DNS resolution exceeds the delivery deadline", async () => {
+    vi.useFakeTimers();
+    const runner: CommandRunner = async () => ({ stdout: "{}", stderr: "", exitCode: 0 });
+    const webhookSender = vi.fn<WebhookSender>(async () => ({ ok: true, status: 204 }));
+    const delivery = deliverMaterialAction(manifest(), action(), {
+      githubClient: new GitHubClient({ runner }),
+      environment: webhookEnvironment(),
+      webhookSender,
+      webhookResolver: async () => new Promise<never>(() => undefined)
+    });
+
+    try {
+      await vi.advanceTimersByTimeAsync(10_000);
+      const report = await delivery;
+      expect(report.notification).toMatchObject({ status: "blocking" });
+      expect(webhookSender).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("fails closed when the configured mechanism is absent or rejects delivery", async () => {
+    const runner: CommandRunner = async () => ({ stdout: "{}", stderr: "", exitCode: 0 });
+    const webhookSender: WebhookSender = async () => ({ ok: false, status: 503 });
     const missingConfiguration = planMaterialAction(manifest(false), action());
-    const deferred = await deliverMaterialAction(manifest(), action(), {
-      githubClient: new GitHubClient({ runner })
+    const rejected = await deliverMaterialAction(manifest(), action(), {
+      githubClient: new GitHubClient({ runner }),
+      environment: webhookEnvironment(),
+      webhookSender,
+      webhookResolver: publicWebhookResolver
     });
 
     expect(missingConfiguration.notification.status).toBe("blocking");
     expect(missingConfiguration.continueAfterNotification).toBe(false);
     expect(missingConfiguration.exitCode).toBe(1);
-    expect(deferred.notification).toMatchObject({ status: "blocking", ruleId: "PRS-NOTIFY-001" });
-    expect(deferred.continueAfterNotification).toBe(false);
-    expect(deferred.exitCode).toBe(1);
-    expect(JSON.stringify(deferred)).not.toContain("notifications.example.test");
+    expect(rejected.notification).toMatchObject({ status: "blocking", ruleId: "PRS-NOTIFY-001" });
+    expect(rejected.continueAfterNotification).toBe(false);
+    expect(rejected.exitCode).toBe(1);
+    expect(JSON.stringify(rejected)).not.toContain("notifications.example.test");
   });
 
   it("serializes only the webhook environment-variable reference", () => {
@@ -276,10 +414,14 @@ describe("material-action notifications", () => {
     });
     const now = new Date("2026-07-16T12:00:00.000Z");
     const runner = vi.fn<CommandRunner>(async () => ({ stdout: "{}", stderr: "", exitCode: 0 }));
+    const webhookSender = vi.fn<WebhookSender>(async () => ({ ok: true, status: 204 }));
     const planned = planExceptionNotifications(expiringManifest, now);
     const delivered = await deliverExceptionNotifications(expiringManifest, {
       now,
-      githubClient: new GitHubClient({ runner })
+      githubClient: new GitHubClient({ runner }),
+      environment: webhookEnvironment(),
+      webhookSender,
+      webhookResolver: publicWebhookResolver
     });
 
     expect(exceptionNotificationReportSchema.parse(planned)).toEqual(planned);
@@ -290,8 +432,8 @@ describe("material-action notifications", () => {
       governingTarget: "acme/notifications#55",
       notification: { status: "ready" }
     });
-    expect(delivered).toMatchObject({ mode: "deliver", blockingExceptions: false, exitCode: 1 });
-    expect(delivered.notifications[0]?.notification.status).toBe("blocking");
+    expect(delivered).toMatchObject({ mode: "deliver", blockingExceptions: false, exitCode: 0 });
+    expect(delivered.notifications[0]?.notification.status).toBe("delivered");
   });
 
   it("keeps blocking exception validation fail-closed when no expiry notification is due", () => {


### PR DESCRIPTION
## Summary

- Restore the canonical conformance fixture after ownership-sidecar validation began failing closed on newly introduced managed files.
- Apply and evaluate the same archetype, then remove its expected language marker to preserve the warning-only profile-conflict scenario.
- Integrate the resolved publisher key, ISO 4217 spending threshold, and explicit repository-class migration/exception defaults from merged stack PR #90.
- Integrate plan-first material notifications, verified hard-stop approvals, and expiring-exception delivery from merged stack PR #91.
- Fail the configured webhook destination closed until the secure transport follow-up lands, keeping this PR below the 800-line review threshold without restoring the rejected SSRF path.

## Governing Issue

Refs #55
Closes #56
Refs #58

## Validation

- [x] Relevant local checks passed
- [x] Agent-authored changes passed `autoreview` against the intended PR diff with no accepted/actionable findings
- Autoreview command and result: `/Users/johnteneyckjr./.codex/skills/autoreview/scripts/autoreview --mode local --parallel-tests "npm run check && npm run build && git diff --check"` — clean, no accepted/actionable findings; patch correct (0.96)
- [x] Required PR checks are expected to satisfy `CI Gate`
- [x] Skipped checks are explained below

Local checks on commit `2bf5b77` (tree-identical to reviewed commit `2627828`):

- `npm run check` — 20 test files, 113 tests passed
- `npm run build` — passed
- `git diff --check` — passed
- PR governance accounting — 732 counted production lines, below the 800-line threshold
- No local checks were skipped.

## Bootstrap Governance

- [x] Changes are scoped to the linked issues
- [x] Contributor or PR guidance changes are reflected in `CONTRIBUTING.md`, `.github/PULL_REQUEST_TEMPLATE.md`, and `docs/bootstrap/onboarding.md` when applicable
- [x] PR author enabled auto-merge where GitHub allows it, or GitHub plan-limit evidence/unavailable reason is recorded and the fallback merge-readiness policy applies
- [x] No real secrets, runtime auth, or machine-local env files are committed

Material change: no
ADR: not required

## Merge Automation

- [x] PR author enabled auto-merge with `gh pr merge --auto --squash`, or the reason it is unavailable/unsafe is noted below

Squash auto-merge is enabled; protected `main` still requires independent approval.

## Notes

- PR #90 squash-merged into this integration branch, so #89 is now the protected-main carrier for the completed #56 work.
- PR #91 squash-merged into this integration branch, but #55 remains open until the secure webhook follow-up merges after #89.
- Notification foundations include digest-bound approvals, governing-target validation, verified maintainer permissions, Markdown escaping, credential-safe exception identifiers, and fail-closed partial delivery.
- PR #92 demonstrated the secure webhook transport as a 258-line review lane, but GitHub immediately merged it into the unprotected integration base; commit `2bf5b77` reverted that merge so #89 remains at 732 counted production lines.
- The reviewed secure transport will be reopened against `main` after #89 lands; auto-merge will not be armed while its base is an integration branch.
- The fixture repair does not complete the broader conformance-engine scope in #58.
