### PR TITLE
feat: resolve publisher and class deviations

### DIFF
--- a/docs/bootstrap/repository-class-migration.md
+++ b/docs/bootstrap/repository-class-migration.md
@@ -23,3 +23,26 @@ to `infrastructure` instead.
 `project.maturity` describes the product lifecycle (`experimental` through
 `archived`). It is intentionally independent from `release.maturity`, which
 selects the release-automation profile.
+
+## Publisher defaults and class deviations
+
+The resolved publisher key defaults to `project.owner`. A publisher can set a
+different stable key and an explicit spending approval threshold with a
+non-negative amount and three-letter ISO currency code:
+
+```yaml
+publisher:
+  key: acme-public
+  spendingApprovalThreshold:
+    amount: 500
+    currency: USD
+```
+
+Bootstrap does not invent a monetary threshold when the publisher omits one.
+Callers must treat that state as an unresolved human decision rather than as
+permission to spend.
+
+A repository that cannot yet declare one of the seven canonical classes must
+carry a currently valid policy exception with `policy:
+repository-classification` and `scope: repo.class`. Missing, expired, or
+otherwise invalid exceptions remain blocking conformance violations.

--- a/src/conformance.ts
+++ b/src/conformance.ts
@@ -47,10 +47,27 @@ function summary(results: ConformanceResult[]): ConformanceReport["summary"] {
 
 export async function runConformance(manifest: BootstrapManifest, targetDir: string): Promise<ConformanceReport> {
   const results: ConformanceResult[] = [];
+  const exceptionReport = validatePolicyExceptions(manifest.exceptions);
+  const validExceptionIds = new Set(
+    exceptionReport.results.filter((entry) => entry.status !== "block").map((entry) => entry.exceptionId)
+  );
+  const classException = manifest.exceptions.find(
+    (entry) =>
+      entry.policy === "repository-classification" &&
+      entry.scope === "repo.class" &&
+      validExceptionIds.has(entry.id)
+  );
 
   results.push(
     manifest.repo.class
       ? result("PRS-CLASS-001", "pass", [manifest.repo.class], "Keep the canonical repository class current.")
+      : classException
+        ? result(
+            "PRS-CLASS-001",
+            "pass",
+            [`approved exception ${classException.id}`],
+            "Keep the approved repository-classification exception current until a canonical class is declared."
+          )
       : result("PRS-CLASS-001", "blocking", ["repo.class is absent"], "Declare a canonical repo.class or complete an explicit legacy migration.")
   );
   results.push(
@@ -75,7 +92,7 @@ export async function runConformance(manifest: BootstrapManifest, targetDir: str
     }
   }
 
-  for (const exception of validatePolicyExceptions(manifest.exceptions).results) {
+  for (const exception of exceptionReport.results) {
     results.push(
       result(
         exception.ruleId,

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -196,6 +196,18 @@ const policySchema = z.object({
   })
 });
 
+const publisherSchema = z.object({
+  key: z.string().min(1).optional(),
+  spendingApprovalThreshold: z
+    .object({
+      amount: z.number().finite().nonnegative(),
+      currency: z
+        .string()
+        .refine((value) => Intl.supportedValuesOf("currency").includes(value), "Use a supported ISO 4217 currency code.")
+    })
+    .optional()
+});
+
 const exceptionSchema = z.object({
   id: z.string().min(1),
   policy: z.string().min(1),
@@ -289,6 +301,7 @@ const manifestSchema = z.object({
     owner: z.string().min(1),
     defaultBranch: z.string().min(1).optional()
   }),
+  publisher: publisherSchema.optional(),
   repo: z
     .object({
       class: z
@@ -418,7 +431,7 @@ const manifestSchema = z.object({
 }).passthrough();
 
 const KNOWN_MANIFEST_SETTINGS = new Set([
-  "version", "project", "repo", "archetype", "github", "ci", "release", "agents", "capabilities", "policy", "exceptions", "environments"
+  "version", "project", "publisher", "repo", "archetype", "github", "ci", "release", "agents", "capabilities", "policy", "exceptions", "environments"
 ]);
 
 function slugify(value: string): string {
@@ -757,6 +770,12 @@ export function normalizeManifest(raw: z.input<typeof manifestSchema>): Bootstra
       owner: parsed.project.owner,
       defaultBranch
     },
+    publisher: {
+      key: parsed.publisher?.key ?? parsed.project.owner,
+      ...(parsed.publisher?.spendingApprovalThreshold
+        ? { spendingApprovalThreshold: { ...parsed.publisher.spendingApprovalThreshold } }
+        : {})
+    },
     repo: normalizeRepo(parsed.repo),
     archetype: {
       kind: parsed.archetype.kind,
@@ -924,6 +943,7 @@ export async function loadManifest(manifestPath: string): Promise<BootstrapManif
 
 interface ManifestOverrides {
   project?: Partial<BootstrapManifest["project"]>;
+  publisher?: Partial<BootstrapManifest["publisher"]>;
   repo?: Partial<BootstrapManifest["repo"]>;
   archetype?: Partial<BootstrapManifest["archetype"]>;
   github?: Partial<BootstrapManifest["github"]>;
@@ -946,6 +966,7 @@ export function createSampleManifest(overrides?: ManifestOverrides): string {
       owner: overrides?.project?.owner ?? "your-org",
       defaultBranch: overrides?.project?.defaultBranch ?? "main"
     },
+    publisher: overrides?.publisher,
     repo: overrides?.repo,
     archetype: {
       kind: overrides?.archetype?.kind ?? "node-ts-service",
@@ -964,7 +985,11 @@ export function createSampleManifest(overrides?: ManifestOverrides): string {
 }
 
 function serializableManifest(manifest: BootstrapManifest): BootstrapManifest | Record<string, unknown> {
-  const { unknownSettings: _unknownSettings, ...serializable } = manifest;
+  const { unknownSettings: _unknownSettings, publisher, ...withoutInternalSettings } = manifest;
+  const serializable =
+    publisher.key === manifest.project.owner && publisher.spendingApprovalThreshold === undefined
+      ? withoutInternalSettings
+      : { ...withoutInternalSettings, publisher };
   if (manifest.version !== 2 || !manifest.capabilities?.release) {
     return serializable;
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,6 +27,16 @@ export interface PolicyException {
   adr?: string;
 }
 
+export interface SpendingApprovalThreshold {
+  amount: number;
+  currency: string;
+}
+
+export interface PublisherConfig {
+  key: string;
+  spendingApprovalThreshold?: SpendingApprovalThreshold;
+}
+
 export interface CodeownerRule {
   pattern: string;
   owners: string[];
@@ -175,6 +185,7 @@ export interface BootstrapManifest {
     owner: string;
     defaultBranch: string;
   };
+  publisher: PublisherConfig;
   repo: RepoConfig;
   archetype: {
     kind: ArchetypeKind;

--- a/tests/conformance.test.ts
+++ b/tests/conformance.test.ts
@@ -1,7 +1,7 @@
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { conformanceReportSchema, formatConformanceReport, runConformance } from "../src/conformance.js";
 import { normalizeManifest } from "../src/manifest.js";
@@ -45,5 +45,43 @@ describe("runConformance", () => {
     expect(report.summary.warning).toBe(1);
     expect(report.results).toContainEqual(expect.objectContaining({ ruleId: "PRS-PROFILE-001", severity: "warning" }));
     expect(formatConformanceReport(report)).toContain("Conformance: 0 blocking, 1 warning");
+  });
+
+  it("accepts a missing canonical class with a valid scoped exception that is nearing expiry", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-16T12:00:00.000Z"));
+    const directory = await fixtureDirectory();
+    const manifest = normalizeManifest({
+      project: { name: "class-exception", owner: "acme", maturity: "maintenance" },
+      archetype: { kind: "generic-empty" },
+      exceptions: [
+        {
+          id: "legacy-class",
+          policy: "repository-classification",
+          scope: "repo.class",
+          rationale: "Class selection is pending owner review.",
+          approvedBy: "alice",
+          issue: "#56",
+          expiresAt: "2026-07-20"
+        }
+      ]
+    });
+
+    try {
+      const report = await runConformance(manifest, directory);
+
+      expect(report.results).toContainEqual(
+        expect.objectContaining({
+          ruleId: "PRS-CLASS-001",
+          severity: "pass",
+          evidence: ["approved exception legacy-class"]
+        })
+      );
+      expect(report.results).toContainEqual(
+        expect.objectContaining({ ruleId: "PRS-EXCEPTION-001", severity: "warning" })
+      );
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/tests/manifest.test.ts
+++ b/tests/manifest.test.ts
@@ -82,6 +82,38 @@ describe("normalizeManifest", () => {
     expect(manifest.release.maturity).toBe("regulated");
   });
 
+  it("resolves publisher identity without inventing a spending threshold", () => {
+    const defaultPublisher = normalizeManifest({
+      project: { name: "publisher-default", owner: "acme" },
+      archetype: { kind: "generic-empty" }
+    });
+
+    expect(defaultPublisher.publisher).toEqual({ key: "acme" });
+    expect(stringifyManifest(defaultPublisher)).not.toContain("publisher:");
+
+    const configuredPublisher = normalizeManifest({
+      project: { name: "publisher-configured", owner: "acme" },
+      publisher: {
+        key: "acme-public",
+        spendingApprovalThreshold: { amount: 500, currency: "USD" }
+      },
+      archetype: { kind: "generic-empty" }
+    });
+
+    expect(configuredPublisher.publisher).toEqual({
+      key: "acme-public",
+      spendingApprovalThreshold: { amount: 500, currency: "USD" }
+    });
+    expect(stringifyManifest(configuredPublisher)).toContain("spendingApprovalThreshold:");
+    expect(() =>
+      normalizeManifest({
+        project: { name: "invalid-currency", owner: "acme" },
+        publisher: { spendingApprovalThreshold: { amount: 500, currency: "ZZZ" } },
+        archetype: { kind: "generic-empty" }
+      })
+    ).toThrow();
+  });
+
   it("applies defaults and reviewer-derived governance", () => {
     const manifest = normalizeManifest({
       project: {


### PR DESCRIPTION
## Summary

- Resolve a publisher key from `project.owner` while supporting an explicit publisher-neutral spending approval threshold with validated ISO 4217 currency.
- Preserve existing manifest rendering when only the implicit publisher default is present.
- Allow a missing canonical repository class only when a currently valid `repository-classification` exception is scoped to `repo.class`.
- Document the publisher and class-deviation contract.

## Governing Issue

Closes #56.

## Validation

- [x] Relevant local checks passed
- [x] Agent-authored changes passed `autoreview` against the intended PR diff with no accepted/actionable findings
- Autoreview command and result: `/Users/johnteneyckjr./.codex/skills/autoreview/scripts/autoreview --mode local` — clean, patch correct (0.89 confidence)
- [x] Required PR checks are expected to satisfy `CI Gate`
- [x] Skipped checks are explained below

Local checks:

- `npm test -- --run tests/manifest.test.ts tests/conformance.test.ts tests/language-profiles.test.ts tests/exceptions.test.ts` — 26 tests passed before review fixes
- `npm test -- --run tests/conformance.test.ts tests/exceptions.test.ts` — 6 tests passed after the near-expiry exception fix
- `npm run check` — 19 files, 99 tests passed
- `git diff --check` — passed

Autoreview identified two in-scope defects that were fixed before the clean run: arbitrary three-letter currencies were replaced with supported ISO 4217 validation, and warning-level unexpired exceptions now remain valid for class deviations. No checks were skipped.

## Bootstrap Governance

- [x] Changes are scoped to the linked issue
- [x] Contributor or PR guidance changes are reflected in `CONTRIBUTING.md`, `.github/PULL_REQUEST_TEMPLATE.md`, and `docs/bootstrap/onboarding.md` when applicable
- [x] PR author enabled auto-merge where GitHub allows it, or GitHub plan-limit evidence/unavailable reason is recorded and the fallback merge-readiness policy applies
- [x] No real secrets, runtime auth, or machine-local env files are committed

Material change: no
ADR: not required

## Merge Automation

- [x] PR author enabled auto-merge with `gh pr merge --auto --squash`, or the reason it is unavailable/unsafe is noted below

This PR is stacked on #89 so CI and review see only the #56 diff. Squash auto-merge is enabled; independent approval remains required.

## Notes

- A missing spending threshold remains an unresolved human decision and is never treated as implicit permission to spend.
