### PR TITLE
fix: handle empty staged files in pre-commit hook

### DIFF
--- a/src/archetypes.ts
+++ b/src/archetypes.ts
@@ -584,7 +584,8 @@ function preCommitHook(): string {
       staged_files+=("$staged_file")
     done < <(git diff --cached --name-only --diff-filter=ACMR -z)
 
-    for f in "\${staged_files[@]}"; do
+    for f in "\${staged_files[@]:-}"; do
+      [[ -n "$f" ]] || continue
       case "$f" in
         *.env|.env.*)
           if [[ "$f" != *.example ]]; then

--- a/tests/smoke.test.ts
+++ b/tests/smoke.test.ts
@@ -469,4 +469,23 @@ describe("repo smoke", () => {
     ).resolves.toBeUndefined();
     await expect(access(path.join(targetDir, ".bootstrap/bootstrap-state.json"))).rejects.toThrow();
   });
+
+  it("runs the generated pre-commit hook with no staged files", async () => {
+    const targetDir = await makeTempDir();
+    await execFileAsync("git", ["init", "-b", "feature/pre-commit"], { cwd: targetDir });
+
+    const manifest = normalizeManifest({
+      project: {
+        name: "empty-pre-commit",
+        owner: "acme"
+      },
+      archetype: {
+        kind: "generic-empty"
+      }
+    });
+
+    await applyRepo(manifest, targetDir);
+
+    await expect(execFileAsync("bash", [".githooks/pre-commit"], { cwd: targetDir })).resolves.toBeDefined();
+  });
 });


### PR DESCRIPTION
## Summary

- Make the generated pre-commit hook safe when its staged-file list is empty under Bash `set -u`.
- Add a smoke test that invokes the generated hook from a clean feature branch.

## Governing Issue

Closes #109.

## Validation

- [x] `TMPDIR=/tmp npm run check` (23 test files, 194 tests passed)
- [x] `npm run build`
- [x] `bash scripts/ci/check-action-pins.sh` (42 pins passed)
- [x] `git diff --check origin/main...HEAD`
- [x] Original exact-head `autoreview` reported no accepted/actionable findings; rebased patch retains stable patch-id `e3edfd4aeee202498289c2bebca2054ac119432c`.
- [x] Required PR checks are expected to satisfy `CI Gate`.

## Bootstrap Governance

- [x] Changes remain scoped to Bootstrap's generated hook and its regression coverage.
- [x] Contributor guidance and managed-repository policy are unchanged.
- [x] No secrets, credentials, or machine-local state are introduced.
- [x] The placeholder commit identity was replaced with the repository maintainer's verified GitHub no-reply identity during rebase.

Material change: no

## Merge Automation

- [x] Auto-merge is armed with squash merge for the current head.

## Notes

Current head: `9ae56f973d32c49cf12f4f51c48c176fe039a678`.

The previous head `0addaae10a44cce10fff99651631a882b774cf7f` and rebased head carry the same stable patch-id. The rebase changes only ancestry and commit identity; behavior remains the previously reviewed two-file fix.
