### PR TITLE
feat: report stable license conformance

### DIFF
--- a/docs/bootstrap/licensing.md
+++ b/docs/bootstrap/licensing.md
@@ -10,7 +10,7 @@ Bootstrap copies an approved repository-local template into `LICENSE`, substitut
 | --- | --- | --- | --- |
 | New open-source repository | `spdx` with one identifier | Projects the approved SPDX template and reports local recognition as unverified | Confirm template and verify GitHub detection after publication |
 | New private commercial repository | `proprietary` | Projects the counsel-approved proprietary template | Confirm holder, years, and template approval reference |
-| Private repository without a license decision | omitted | Does not create or infer a license | Legal/stewardship decision |
+| Private repository without a license decision | omitted | Does not create or infer a license; conformance blocks | Legal/stewardship decision |
 | Existing license matches the configured template | explicit matching mode | Adopts it without rewriting legal text | Review the manifest and template provenance |
 | Existing license would change | explicit replacement mode | Hard-stops until transition evidence is present | Legal approval plus ownership, contributor, and distribution-history evidence |
 | License policy is removed after Bootstrap managed it | omitted | Hard-stops; Bootstrap will not delete the license | Choose an explicit replacement mode and complete legal review |
@@ -61,7 +61,7 @@ Bootstrap records the managed license mode and exact content hash in the tracked
 
 Existing `LICENSE` and `THIRD_PARTY_NOTICES.md` outputs must be regular, singly linked files that physically remain in the repository. Bootstrap rejects symlinks, dangling links, hard links, devices, and other non-regular output aliases before reading or planning changes.
 
-`bootstrap plan` prints the exact before/after mode and every file mutation. Proprietary notices are always reported as non-SPDX and non-OSI; SPDX recognition remains unverified until GitHub's published community profile is checked.
+`bootstrap plan` prints the exact before/after mode and every file mutation. `bootstrap conform` reports stable license, template, encoding, notice, transition, and recognition rule IDs. Proprietary notices are always reported as non-SPDX and non-OSI; SPDX recognition remains a warning until GitHub's published community profile is checked.
 
 ## Migration fixtures
 

--- a/src/conformance.ts
+++ b/src/conformance.ts
@@ -2,10 +2,18 @@ import path from "node:path";
 
 import { z } from "zod";
 
+import { renderManagedFiles } from "./archetypes.js";
 import { validatePolicyExceptions } from "./exceptions.js";
 import { readTextIfExists } from "./lib/fs.js";
+import { sha256 } from "./lib/hash.js";
 import { resolveLanguageProfiles } from "./language-profiles.js";
-import { planRepo } from "./render.js";
+import {
+  LICENSE_PATH,
+  THIRD_PARTY_NOTICES_PATH,
+  projectLicensePolicy,
+  readManagedLegalOutputTextIfExists
+} from "./licensing.js";
+import { BOOTSTRAP_STATE_OUTPUT_PATHS, loadEffectiveRepoState, planRepo, selectManagedFiles } from "./render.js";
 import { OWNERSHIP_SIDECAR_PATH } from "./state.js";
 import type { BootstrapManifest } from "./types.js";
 
@@ -35,6 +43,22 @@ function result(
   remediation: string
 ): ConformanceResult {
   return { ruleId, severity, evidence: [...evidence].sort(), remediation };
+}
+
+function pushUnique(results: ConformanceResult[], entry: ConformanceResult): void {
+  const ownershipDriftKey = (evidence: string): string | undefined => {
+    const match = evidence.match(/managed(?: file)? (\S+) was (deleted|directly modified)/i);
+    return match ? `${match[1]!.toLowerCase()}:${match[2]!.toLowerCase()}` : undefined;
+  };
+  const entryDriftKey = entry.ruleId === "PRS-OWNERSHIP-001" ? ownershipDriftKey(entry.evidence.join("\n")) : undefined;
+  if (!results.some((existing) =>
+    existing.ruleId === entry.ruleId &&
+    existing.severity === entry.severity &&
+    (existing.evidence.join("\n") === entry.evidence.join("\n") ||
+      (entryDriftKey !== undefined && ownershipDriftKey(existing.evidence.join("\n")) === entryDriftKey))
+  )) {
+    results.push(entry);
+  }
 }
 
 function summary(results: ConformanceResult[]): ConformanceReport["summary"] {
@@ -75,6 +99,90 @@ export async function runConformance(manifest: BootstrapManifest, targetDir: str
       ? result("PRS-MATURITY-001", "pass", [manifest.project.maturity], "Keep product maturity separate from release automation maturity.")
       : result("PRS-MATURITY-001", "blocking", ["project.maturity is absent"], "Declare project.maturity from experimental through archived.")
   );
+
+  if (!manifest.license) {
+    try {
+      const existingLicense = await readManagedLegalOutputTextIfExists(targetDir, LICENSE_PATH);
+      results.push(
+        result(
+          "PRS-LICENSE-001",
+          "blocking",
+          [existingLicense === undefined ? "license policy and LICENSE are absent" : "LICENSE exists without an explicit license policy"],
+          "Declare an explicit SPDX or proprietary license policy; repository visibility never selects a license."
+        )
+      );
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error);
+      const ruleId = detail.match(/^(PRS-[A-Z][A-Z-]*-\d{3}):/)?.[1] ?? "PRS-LICENSE-001";
+      results.push(result(ruleId, "blocking", [detail], "Restore the legal output as a regular repository file before conforming."));
+    }
+  } else {
+    try {
+      const selectedManagedFiles = selectManagedFiles(manifest, renderManagedFiles(manifest));
+      const { state: effectiveState } = await loadEffectiveRepoState(targetDir, selectedManagedFiles);
+      for (const [managedPath, managedHash] of Object.entries(effectiveState?.managedFiles ?? {})) {
+        const existing = managedPath === LICENSE_PATH || managedPath === THIRD_PARTY_NOTICES_PATH
+          ? await readManagedLegalOutputTextIfExists(targetDir, managedPath)
+          : await readTextIfExists(path.join(targetDir, managedPath));
+        const detail = existing === undefined
+          ? `Managed file ${managedPath} was deleted.`
+          : sha256(existing) !== managedHash
+            ? `Managed file ${managedPath} was directly modified.`
+            : undefined;
+        if (detail) {
+          pushUnique(
+            results,
+            result("PRS-OWNERSHIP-001", "blocking", [detail], "Restore the managed file or use an explicit migration before applying Bootstrap changes.")
+          );
+        }
+      }
+      const projection = await projectLicensePolicy(
+        manifest,
+        targetDir,
+        effectiveState,
+        [
+          ...selectedManagedFiles.map((file) => file.path),
+          ...Object.keys(effectiveState?.managedFiles ?? {}),
+          ...BOOTSTRAP_STATE_OUTPUT_PATHS
+        ]
+      );
+      const expectedLicense = projection?.files.find((file) => file.path === LICENSE_PATH)?.contents;
+      const expectedNotices = projection?.files.find((file) => file.path === THIRD_PARTY_NOTICES_PATH)?.contents;
+      const [existingLicense, existingNotices] = await Promise.all([
+        readManagedLegalOutputTextIfExists(targetDir, LICENSE_PATH),
+        readManagedLegalOutputTextIfExists(targetDir, THIRD_PARTY_NOTICES_PATH)
+      ]);
+      results.push(
+        existingLicense === expectedLicense
+          ? result("PRS-LICENSE-001", "pass", [`mode=${projection?.summary.afterMode}`], "Keep the approved license template and declared mode current.")
+          : result("PRS-LICENSE-001", "blocking", [LICENSE_PATH], "Run bootstrap apply repo after satisfying any legal transition hard stop.")
+      );
+      results.push(
+        existingNotices === expectedNotices
+          ? result("PRS-LICENSE-NOTICES-001", "pass", [THIRD_PARTY_NOTICES_PATH], "Keep dependency, asset, font, media, and incorporated-source obligations current.")
+          : result("PRS-LICENSE-NOTICES-001", "blocking", [THIRD_PARTY_NOTICES_PATH], "Generate or reconcile the separate third-party notice inventory.")
+      );
+      results.push(
+        manifest.license.mode === "proprietary"
+          ? result(
+              "PRS-LICENSE-RECOGNITION-001",
+              "pass",
+              ["proprietary notice; SPDX and OSI recognition not claimed"],
+              "Do not present the proprietary notice as an open-source license."
+            )
+          : result(
+              "PRS-LICENSE-RECOGNITION-001",
+              "warning",
+              [`declared SPDX identifier ${manifest.license.identifier}; GitHub recognition not verified locally`],
+              "Verify GitHub's detected license/community profile after publication."
+            )
+      );
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error);
+      const ruleId = detail.match(/^(PRS-[A-Z][A-Z-]*-\d{3}):/)?.[1] ?? "PRS-LICENSE-001";
+      pushUnique(results, result(ruleId, "blocking", [detail], "Resolve the declared license policy or required legal evidence before applying."));
+    }
+  }
 
   const profiles = await resolveLanguageProfiles(manifest, targetDir);
   if (profiles.conflicts.length === 0) {
@@ -125,7 +233,11 @@ export async function runConformance(manifest: BootstrapManifest, targetDir: str
     await planRepo(manifest, targetDir);
   } catch (error) {
     const detail = error instanceof Error ? error.message : String(error);
-    results.push(result("PRS-OWNERSHIP-001", "blocking", [detail], "Restore the managed file or use an explicit migration before applying Bootstrap changes."));
+    const ruleId = detail.match(/^(PRS-[A-Z][A-Z-]*-\d{3}):/)?.[1] ?? "PRS-OWNERSHIP-001";
+    pushUnique(
+      results,
+      result(ruleId, "blocking", [detail], "Restore the managed file or use an explicit migration before applying Bootstrap changes.")
+    );
   }
 
   const sorted = results.sort((left, right) => left.ruleId.localeCompare(right.ruleId) || left.evidence.join("\n").localeCompare(right.evidence.join("\n")));

--- a/tests/conformance.test.ts
+++ b/tests/conformance.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
@@ -6,6 +6,9 @@ import { describe, expect, it, vi } from "vitest";
 import { conformanceReportSchema, formatConformanceReport, runConformance } from "../src/conformance.js";
 import { normalizeManifest } from "../src/manifest.js";
 import { applyRepo } from "../src/render.js";
+import { sha256 } from "../src/lib/hash.js";
+
+const proprietaryTemplate = "Copyright {{copyright_years}} {{copyright_holder}}\nApproved proprietary terms.\n";
 
 async function fixtureDirectory(): Promise<string> {
   return mkdtemp(path.join(os.tmpdir(), "bootstrap-conformance-"));
@@ -22,29 +25,39 @@ describe("runConformance", () => {
     expect(report.exitCode).toBe(1);
     expect(report.results.map((entry) => entry.ruleId)).toEqual([
       "PRS-CLASS-001",
+      "PRS-LICENSE-001",
       "PRS-MATURITY-001",
       "PRS-OWNERSHIP-001",
       "PRS-PROFILE-001"
     ]);
   });
 
-  it("passes the core for an applied canonical contract and keeps warning semantics distinct", async () => {
+  it("passes the core for an applied canonical contract", async () => {
     const directory = await fixtureDirectory();
     await writeFile(path.join(directory, "pyproject.toml"), "[project]\nname = 'service'\n");
+    await writeFile(path.join(directory, "proprietary.txt"), proprietaryTemplate);
     const manifest = normalizeManifest({
       project: { name: "canonical-contract", owner: "acme", maturity: "stable" },
+      license: {
+        mode: "proprietary",
+        holder: "Acme LLC",
+        holderVerification: "legal-entity:acme-llc",
+        years: "2026",
+        template: { path: "proprietary.txt", sha256: sha256(proprietaryTemplate), approval: "counsel:P-1" },
+        thirdPartyNotices: []
+      },
       repo: { class: "service" },
       archetype: { kind: "node-ts-service" }
     });
     await applyRepo(manifest, directory);
-    await rm(path.join(directory, "src/index.ts"));
 
     const report = await runConformance(manifest, directory);
 
     expect(report.exitCode).toBe(0);
-    expect(report.summary.warning).toBe(1);
-    expect(report.results).toContainEqual(expect.objectContaining({ ruleId: "PRS-PROFILE-001", severity: "warning" }));
-    expect(formatConformanceReport(report)).toContain("Conformance: 0 blocking, 1 warning");
+    expect(report.summary.warning).toBe(0);
+    expect(report.results).toContainEqual(expect.objectContaining({ ruleId: "PRS-PROFILE-001", severity: "pass" }));
+    expect(report.results).toContainEqual(expect.objectContaining({ ruleId: "PRS-LICENSE-RECOGNITION-001", severity: "pass" }));
+    expect(formatConformanceReport(report)).toContain("Conformance: 0 blocking, 0 warning");
   });
 
   it("accepts a missing canonical class with a valid scoped exception that is nearing expiry", async () => {
@@ -83,5 +96,165 @@ describe("runConformance", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it("reports an existing-license replacement as a stable legal hard stop", async () => {
+    const directory = await fixtureDirectory();
+    await writeFile(path.join(directory, "proprietary.txt"), proprietaryTemplate);
+    await writeFile(path.join(directory, "LICENSE"), "MIT License\nCopyright prior holder\n");
+    const manifest = normalizeManifest({
+      project: { name: "license-transition", owner: "acme", maturity: "stable" },
+      repo: { class: "service" },
+      license: {
+        mode: "proprietary",
+        holder: "Acme LLC",
+        holderVerification: "legal-entity:acme-llc",
+        years: "2026",
+        template: { path: "proprietary.txt", sha256: sha256(proprietaryTemplate), approval: "counsel:P-1" },
+        thirdPartyNotices: []
+      },
+      archetype: { kind: "generic-empty" }
+    });
+
+    const report = await runConformance(manifest, directory);
+    expect(report.results).toContainEqual(expect.objectContaining({ ruleId: "PRS-LICENSE-TRANSITION-001", severity: "blocking" }));
+    expect(report.results).not.toContainEqual(expect.objectContaining({
+      ruleId: "PRS-OWNERSHIP-001",
+      severity: "blocking",
+      evidence: [expect.stringContaining("PRS-LICENSE-TRANSITION-001")]
+    }));
+  });
+
+  it("fails closed with a stable template rule when approved content does not match its pin", async () => {
+    const directory = await fixtureDirectory();
+    await writeFile(path.join(directory, "proprietary.txt"), proprietaryTemplate);
+    const manifest = normalizeManifest({
+      project: { name: "template-drift", owner: "acme", maturity: "stable" },
+      repo: { class: "service" },
+      license: {
+        mode: "proprietary",
+        holder: "Acme LLC",
+        holderVerification: "legal-entity:acme-llc",
+        years: "2026",
+        template: { path: "proprietary.txt", sha256: "0".repeat(64), approval: "counsel:P-1" },
+        thirdPartyNotices: []
+      },
+      archetype: { kind: "generic-empty" }
+    });
+
+    const report = await runConformance(manifest, directory);
+    expect(report.results).toContainEqual(expect.objectContaining({ ruleId: "PRS-LICENSE-TEMPLATE-001", severity: "blocking" }));
+  });
+
+  it("reports independent ownership drift alongside a license-policy failure", async () => {
+    const directory = await fixtureDirectory();
+    await writeFile(path.join(directory, "proprietary.txt"), proprietaryTemplate);
+    const configured = normalizeManifest({
+      project: { name: "combined-failures", owner: "acme", maturity: "stable" },
+      repo: { class: "service" },
+      license: {
+        mode: "proprietary",
+        holder: "Acme LLC",
+        holderVerification: "legal-entity:acme-llc",
+        years: "2026",
+        template: { path: "proprietary.txt", sha256: sha256(proprietaryTemplate), approval: "counsel:P-1" },
+        thirdPartyNotices: []
+      },
+      archetype: { kind: "generic-empty" }
+    });
+    await applyRepo(configured, directory);
+    await writeFile(path.join(directory, "AGENTS.md"), "direct edit\n");
+    await writeFile(path.join(directory, "LICENSE"), "direct edit\n");
+    await rm(path.join(directory, "README.md"));
+    await rm(path.join(directory, "THIRD_PARTY_NOTICES.md"));
+
+    const invalidTemplate = normalizeManifest({
+      ...configured,
+      license: {
+        ...configured.license!,
+        template: { ...configured.license!.template, sha256: "0".repeat(64) }
+      }
+    });
+    const report = await runConformance(invalidTemplate, directory);
+
+    expect(report.results).toContainEqual(expect.objectContaining({
+      ruleId: "PRS-LICENSE-TEMPLATE-001",
+      severity: "blocking"
+    }));
+    expect(report.results).toContainEqual(expect.objectContaining({
+      ruleId: "PRS-OWNERSHIP-001",
+      severity: "blocking",
+      evidence: ["Managed file AGENTS.md was directly modified."]
+    }));
+    expect(report.results).toContainEqual(expect.objectContaining({
+      ruleId: "PRS-OWNERSHIP-001",
+      severity: "blocking",
+      evidence: ["Managed file README.md was deleted."]
+    }));
+    expect(report.results).toContainEqual(expect.objectContaining({
+      ruleId: "PRS-OWNERSHIP-001",
+      severity: "blocking",
+      evidence: ["Managed file LICENSE was directly modified."]
+    }));
+    expect(report.results).toContainEqual(expect.objectContaining({
+      ruleId: "PRS-OWNERSHIP-001",
+      severity: "blocking",
+      evidence: ["Managed file THIRD_PARTY_NOTICES.md was deleted."]
+    }));
+  });
+
+  it("preserves the ownership rule when a managed license is edited or deleted", async () => {
+    const directory = await fixtureDirectory();
+    await writeFile(path.join(directory, "proprietary.txt"), proprietaryTemplate);
+    const manifest = normalizeManifest({
+      project: { name: "managed-license-drift", owner: "acme", maturity: "stable" },
+      repo: { class: "service" },
+      license: {
+        mode: "proprietary",
+        holder: "Acme LLC",
+        holderVerification: "legal-entity:acme-llc",
+        years: "2026",
+        template: { path: "proprietary.txt", sha256: sha256(proprietaryTemplate), approval: "counsel:P-1" },
+        thirdPartyNotices: []
+      },
+      archetype: { kind: "generic-empty" }
+    });
+    await applyRepo(manifest, directory);
+
+    await writeFile(path.join(directory, "LICENSE"), "direct edit\n");
+    const editedReport = await runConformance(manifest, directory);
+    expect(editedReport.results).toContainEqual(expect.objectContaining({
+      ruleId: "PRS-OWNERSHIP-001",
+      severity: "blocking",
+      evidence: ["Managed file LICENSE was directly modified."]
+    }));
+    expect(editedReport.results.filter((entry) =>
+      entry.ruleId === "PRS-OWNERSHIP-001" && entry.evidence.some((item) => /managed(?: file)? LICENSE was directly modified/i.test(item))
+    ).length).toBe(1);
+
+    await rm(path.join(directory, "LICENSE"));
+    const deletedReport = await runConformance(manifest, directory);
+    expect(deletedReport.results).toContainEqual(expect.objectContaining({
+      ruleId: "PRS-OWNERSHIP-001",
+      severity: "blocking",
+      evidence: ["Managed file LICENSE was deleted."]
+    }));
+  });
+
+  it("validates LICENSE path safety before reading it without a declared policy", async () => {
+    const directory = await fixtureDirectory();
+    await symlink(path.join(directory, "missing-license-target"), path.join(directory, "LICENSE"));
+    const manifest = normalizeManifest({
+      project: { name: "unsafe-unlicensed-output", owner: "acme", maturity: "stable" },
+      repo: { class: "service" },
+      archetype: { kind: "generic-empty" }
+    });
+
+    const report = await runConformance(manifest, directory);
+    expect(report.results).toContainEqual(expect.objectContaining({
+      ruleId: "PRS-OWNERSHIP-001",
+      severity: "blocking",
+      evidence: [expect.stringContaining("LICENSE must be a regular, non-linked repository file")]
+    }));
   });
 });


### PR DESCRIPTION
## Summary

- Add stable conformance rule IDs for explicit license policy, template, transition, notice, recognition, and ownership failures.
- Preserve independent managed-file drift findings even when license projection fails, including symlink-safe checks for legal outputs.
- Document the blocking behavior for missing policy and stable machine-readable licensing results.

## Governing Issue

Refs #86

## Validation

- [x] Relevant local checks passed
- [x] Agent-authored changes passed `autoreview` against the intended PR diff with no accepted/actionable findings
- Autoreview command and result: `autoreview --mode branch --base origin/main --engine codex --parallel-tests 'TMPDIR=/tmp npm run check'` — clean; 22 test files and 152 tests passed
- [x] Required PR checks are expected to satisfy `CI Gate`
- [x] Skipped checks are explained below

No relevant checks were skipped. `npm run build` also passed on the exact rebased head.

## Bootstrap Governance

- [x] Changes are scoped to the linked issue
- [x] Contributor or PR guidance changes are reflected in `CONTRIBUTING.md`, `.github/PULL_REQUEST_TEMPLATE.md`, and `docs/bootstrap/onboarding.md` when applicable
- [x] PR author enabled auto-merge where GitHub allows it, or GitHub plan-limit evidence/unavailable reason is recorded and the fallback merge-readiness policy applies
- [x] No real secrets, runtime auth, or machine-local env files are committed

Material change: yes
ADR: docs/decisions/ADR-0002-explicit-license-modes.md

## Merge Automation

- [x] PR author enabled auto-merge with `gh pr merge --auto --squash`, or the reason it is unavailable/unsafe is noted below

## Notes

- Bootstrap issue #86 was closed by the foundation PR #96; this follow-up completes the conformance projection described by ADR-0002.
