### PR TITLE
feat: add report-first issue hygiene

### DIFF
--- a/.github/workflows/issue-hygiene.yml
+++ b/.github/workflows/issue-hygiene.yml
@@ -1,0 +1,37 @@
+name: Issue Hygiene Report
+
+on:
+  schedule:
+    - cron: '17 9 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: read
+
+jobs:
+  report:
+    name: Report Aging Issues
+    runs-on: ['self-hosted', 'linux', 'shell-only', 'public']
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: '20'
+      - name: Build deterministic issue hygiene report
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          node scripts/ci/report-issue-hygiene.mjs \
+            --repo "$GITHUB_REPOSITORY" \
+            --json-output issue-hygiene-report.json \
+            | tee "$RUNNER_TEMP/issue-hygiene-summary.md"
+          cat "$RUNNER_TEMP/issue-hygiene-summary.md" >> "$GITHUB_STEP_SUMMARY"
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: issue-hygiene-report
+          path: issue-hygiene-report.json
+          if-no-files-found: error
+          retention-days: 30

--- a/docs/bootstrap/issue-hygiene.md
+++ b/docs/bootstrap/issue-hygiene.md
@@ -1,0 +1,31 @@
+# Report-First Issue Hygiene
+
+`.github/workflows/issue-hygiene.yml` inventories open issues every Monday and on manual dispatch. It uses only `contents: read` and `issues: read`, writes a complete versioned JSON artifact, and appends a Markdown report capped at 900 KiB to the workflow summary.
+
+## Aging Rules
+
+- Fewer than 30 inactive days: current; no report entry.
+- At least 30 inactive days: review proposal.
+- At least 90 inactive days without a credible next action: close-or-rescope proposal that requires a maintainer decision.
+- Automation never comments, labels, closes, reschedules, or otherwise mutates an issue.
+
+GitHub's `updated_at` timestamp is the inactivity source. Pull requests returned by the issues API are excluded.
+
+## Preserve A Stale Issue
+
+Add one structured marker to the issue body. `outcome` or an evidence-shaped `dependency` is required, `checkpoint` must be a future ISO date, and `evidence` must be a canonical public GitHub issue, pull-request, or Actions-run URL without query or fragment data, or a positive numeric `issue:`, `pr:`, or `run:` reference.
+
+```html
+<!-- prs-next-action {"outcome":"Ship resolver","dependency":"issue:54","checkpoint":"2026-08-01","evidence":"issue:10"} -->
+```
+
+The report publishes only the issue number, single-line title, URL, timestamps, checkpoint, and evidence reference. It never emits the issue body or the next-action outcome.
+
+## Local Fixture
+
+```sh
+node scripts/ci/report-issue-hygiene.mjs \
+  --fixture /path/to/issues.json \
+  --as-of 2026-07-18T12:00:00Z \
+  --json-output issue-hygiene-report.json
+```

--- a/docs/bootstrap/onboarding.md
+++ b/docs/bootstrap/onboarding.md
@@ -15,6 +15,7 @@ Use this checklist after the first bootstrap render or whenever `project.bootstr
 - Confirm `CONTRIBUTING.md` and `.github/PULL_REQUEST_TEMPLATE.md` are present as the required contributor and PR guidance surfaces.
 - Confirm `AGENTS.md` requires the `autoreview` skill against the intended PR diff before an agent opens or updates a PR, and that the PR template records the final command and result.
 - Confirm the pull request template is present and PR Fast CI validates the required PR description sections before CI Gate can pass.
+- Confirm `Issue Hygiene Report` runs weekly with read-only issue permission and retains its JSON evidence artifact.
 - Confirm PR Fast CI uses the fork-safe `pull_request` event with only read permissions. It must validate Conventional titles, contributed-commit DCO trailers, changed-line accounting, and material-change ADR/reviewer evidence without accessing repository secrets.
 - Confirm every third-party `uses:` entry is a 40-character commit SHA followed by readable tag metadata. The `Validate Action Pins` check fails closed on mutable references and silently ignores local or Bootstrap-owned reusable workflows.
 - Confirm `delete branch on merge` and `allow auto-merge` are enabled when the GitHub plan supports them; otherwise record the plan-limit evidence and use the fallback merge-readiness policy.
@@ -48,6 +49,12 @@ Use this checklist after the first bootstrap render or whenever `project.bootstr
 - `.github/PULL_REQUEST_TEMPLATE.md` defines the standard PR shape: summary, governing issue link, validation notes, and bootstrap governance checklist.
 - To retrofit an existing bootstrapped repo, add `CONTRIBUTING.md` and `.github/PULL_REQUEST_TEMPLATE.md` to `repo.managedPaths` when that repo restricts managed paths, then run `bootstrap apply repo --manifest ./project.bootstrap.yaml`.
 - Keep these files repo-generic unless project metadata or the manifest requires a stricter local rule.
+
+## Issue Hygiene
+
+- Review `docs/bootstrap/issue-hygiene.md` before acting on a 30-day review or 90-day close-or-rescope proposal.
+- The scheduled workflow is report-only: it never comments, labels, closes, or reschedules issues.
+- A 90-day proposal always requires a maintainer decision. Record a structured, evidenced future action when the issue should remain open.
 
 ## Licensing
 

--- a/docs/decisions/ADR-0003-report-first-issue-hygiene.md
+++ b/docs/decisions/ADR-0003-report-first-issue-hygiene.md
@@ -1,0 +1,65 @@
+# ADR-0003: Keep issue hygiene report-first and human-decided
+
+Status: Accepted
+
+Date: 2026-07-18
+
+Decision owners: Bootstrap maintainers
+
+Decision record: [Bootstrap issue #59](https://github.com/OMT-Global/bootstrap/issues/59)
+
+## Context
+
+Long-lived issue backlogs need regular review, but automated closure can destroy context, hide unresolved dependencies, and turn an inactivity heuristic into a product decision. Repositories also need durable evidence that issue-lifecycle checks ran without granting scheduled automation mutation privileges.
+
+Bootstrap already projects fork-safe pull-request governance. It needs a compatible issue-hygiene policy that reports aging consistently while preserving maintainer authority over closure and rescoping.
+
+## Decision
+
+Bootstrap will project a weekly and manually dispatchable issue-hygiene workflow with read-only repository permissions.
+
+The workflow and reporter will:
+
+1. Inventory every open issue through GitHub's paginated REST API and exclude pull requests returned by the issues endpoint.
+2. Treat fewer than 30 inactive days as current, at least 30 days as a review proposal, and at least 90 days without a credible next action as a close-or-rescope proposal.
+3. Recognize a next action only when its structured issue-body marker contains an outcome or evidence-shaped dependency, a valid future checkpoint, and a safe evidence reference.
+4. Never comment, label, close, reschedule, or otherwise mutate an issue. Every close-or-rescope proposal requires a maintainer decision.
+5. Retain a complete versioned JSON report for 30 days while bounding the human Markdown summary below GitHub's step-summary limit.
+6. Exclude issue bodies and next-action outcomes from reports, escape untrusted Markdown fields, and reject evidence references that could retain credentials.
+7. Fail closed when inventory, parsing, report generation, or artifact production fails.
+
+## Consequences
+
+- Aging is a review signal, not authority to discard work.
+- Maintainers must explicitly close, rescope, or record a credible evidenced next action for old issues.
+- Large repositories retain complete machine-readable evidence even when the human summary is truncated.
+- Issue activity remains based on GitHub's `updated_at` timestamp; repositories can revisit that source if product-specific lifecycle signals become necessary.
+- The workflow requires only `contents: read` and `issues: read` and is safe to schedule without write credentials.
+
+## Alternatives considered
+
+### Automatically close issues after 90 inactive days
+
+Rejected because inactivity does not establish that an outcome is obsolete, a dependency is resolved, or retained context has no value.
+
+### Add labels or reminder comments automatically
+
+Rejected because report-first enforcement does not need mutation privileges, and automated comments or labels would change the issue timeline and its inactivity timestamp.
+
+### Emit only a workflow summary
+
+Rejected because GitHub bounds step summaries and a truncated human view is not complete audit evidence.
+
+## Rollout
+
+1. Project the workflow, reporter, and operator documentation only for repositories with issues enabled.
+2. Run the report on schedule or by manual dispatch and inspect the retained JSON before acting on proposals.
+3. Keep all mutation decisions manual until a later Accepted ADR explicitly changes this boundary.
+
+## Security and privacy
+
+The workflow uses no write permission and no untrusted-code execution. Reports contain only issue metadata, inactivity calculations, checkpoints, and validated evidence references; they omit bodies and outcomes. External evidence is restricted to canonical public GitHub issue, pull-request, and Actions-run URLs without userinfo, query strings, or fragments, preventing arbitrary capability URLs from entering retained artifacts.
+
+## Revisit conditions
+
+Revisit if GitHub changes issue pagination or step-summary limits, if repositories need a different inactivity source, or before granting any issue mutation permission.

--- a/scripts/ci/report-issue-hygiene.mjs
+++ b/scripts/ci/report-issue-hygiene.mjs
@@ -1,0 +1,252 @@
+#!/usr/bin/env node
+import { readFile, writeFile } from "node:fs/promises";
+import { pathToFileURL } from "node:url";
+
+const INACTIVE_REVIEW_DAYS = 30;
+const CLOSE_OR_RESCOPE_DAYS = 90;
+const MARKDOWN_SUMMARY_BYTE_LIMIT = 900 * 1024;
+const NEXT_ACTION_PATTERN = /<!--\s*prs-next-action\s+([\s\S]*?)-->/gi;
+
+function parseArgs(argv) {
+  const options = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    if (!["--fixture", "--repo", "--as-of", "--json-output"].includes(argument)) {
+      throw new Error(`Unknown argument: ${argument}`);
+    }
+    const value = argv[index + 1];
+    if (!value || value.startsWith("--")) throw new Error(`${argument} requires a value.`);
+    options[argument.slice(2).replace("-", "_")] = value;
+    index += 1;
+  }
+  if (Boolean(options.fixture) === Boolean(options.repo)) {
+    throw new Error("Provide exactly one of --fixture or --repo.");
+  }
+  return options;
+}
+
+function parseTimestamp(value, label) {
+  if (typeof value !== "string") throw new Error(`${label} must be an ISO-8601 timestamp.`);
+  const match = value.match(/^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.\d+)?(Z|[+-](\d{2}):(\d{2}))$/);
+  if (!match) throw new Error(`${label} must be an ISO-8601 timestamp.`);
+  const [, yearText, monthText, dayText, hourText, minuteText, secondText, zone, offsetHourText, offsetMinuteText] = match;
+  const year = Number(yearText);
+  const month = Number(monthText);
+  const day = Number(dayText);
+  const leapYear = year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);
+  const daysInMonth = [31, leapYear ? 29 : 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+  const validDate = month >= 1 && month <= 12 && day >= 1 && day <= daysInMonth[month - 1];
+  const validTime = Number(hourText) <= 23 && Number(minuteText) <= 59 && Number(secondText) <= 59;
+  const offsetHour = Number(offsetHourText ?? 0);
+  const offsetMinute = Number(offsetMinuteText ?? 0);
+  const validOffset = zone === "Z" || (offsetHour <= 14 && offsetMinute <= 59 && (offsetHour < 14 || offsetMinute === 0));
+  if (!validDate || !validTime || !validOffset) throw new Error(`${label} must be an ISO-8601 timestamp.`);
+  const timestamp = Date.parse(value);
+  if (!Number.isFinite(timestamp)) throw new Error(`${label} must be an ISO-8601 timestamp.`);
+  return timestamp;
+}
+
+function normalizeIssue(raw) {
+  if (!raw || typeof raw !== "object") throw new Error("Issue records must be objects.");
+  const number = raw.number;
+  const title = raw.title;
+  const url = raw.html_url ?? raw.url;
+  const updatedAt = raw.updated_at ?? raw.updatedAt;
+  if (!Number.isInteger(number) || number <= 0) throw new Error("Issue number must be a positive integer.");
+  if (typeof title !== "string" || !title.trim()) throw new Error(`Issue #${number} title is required.`);
+  if (typeof url !== "string" || !/^https:\/\//.test(url)) throw new Error(`Issue #${number} URL must use HTTPS.`);
+  parseTimestamp(updatedAt, `Issue #${number} updatedAt`);
+  return {
+    number,
+    title: title.replace(/\s+/g, " ").trim(),
+    url,
+    updatedAt,
+    body: typeof raw.body === "string" ? raw.body : "",
+    isPullRequest: raw.pull_request !== undefined || raw.isPullRequest === true
+  };
+}
+
+function parseCheckpoint(value) {
+  if (typeof value !== "string" || !/^\d{4}-\d{2}-\d{2}$/.test(value)) return Number.NaN;
+  const [year, month, day] = value.split("-").map(Number);
+  const timestamp = Date.UTC(year, month - 1, day);
+  const parsed = new Date(timestamp);
+  return parsed.getUTCFullYear() === year && parsed.getUTCMonth() === month - 1 && parsed.getUTCDate() === day
+    ? timestamp
+    : Number.NaN;
+}
+
+function escapeMarkdownText(value) {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/\\/g, "\\\\")
+    .replace(/([`*_[\]{}()#+.!|])/g, "\\$1");
+}
+
+function validEvidenceReference(value) {
+  if (typeof value !== "string" || /\s/.test(value)) return false;
+  if (/^(?:issue|pr|run):[1-9]\d*$/.test(value)) return true;
+  try {
+    const url = new URL(value);
+    const publicGitHubEvidence = /^\/[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+\/(?:issues\/[1-9]\d*|pull\/[1-9]\d*|actions\/runs\/[1-9]\d*)$/.test(url.pathname);
+    return url.origin === "https://github.com" && !url.username && !url.password && !url.search && !url.hash && publicGitHubEvidence;
+  } catch {
+    return false;
+  }
+}
+
+function credibleNextAction(body, asOfTimestamp) {
+  let credible;
+  for (const match of body.matchAll(NEXT_ACTION_PATTERN)) {
+    try {
+      const value = JSON.parse(match[1]);
+      const outcome = typeof value.outcome === "string" && value.outcome.trim().length > 0;
+      const dependency = validEvidenceReference(value.dependency);
+      const checkpoint = parseCheckpoint(value.checkpoint);
+      const evidence = validEvidenceReference(value.evidence);
+      if ((outcome || dependency) && Number.isFinite(checkpoint) && checkpoint > asOfTimestamp && evidence) {
+        credible = { checkpoint: value.checkpoint, evidence: value.evidence };
+      }
+    } catch {
+      // Malformed markers are not evidence and remain reportable at the normal aging threshold.
+    }
+  }
+  return credible;
+}
+
+export function buildIssueHygieneReport(rawIssues, asOf = new Date().toISOString()) {
+  const asOfTimestamp = parseTimestamp(asOf, "asOf");
+  const issues = rawIssues.map(normalizeIssue).filter((issue) => !issue.isPullRequest).sort((left, right) => left.number - right.number);
+  const results = [];
+  let current = 0;
+  let review = 0;
+  let closeOrRescope = 0;
+
+  for (const issue of issues) {
+    const inactiveDays = Math.max(0, Math.floor((asOfTimestamp - parseTimestamp(issue.updatedAt, `Issue #${issue.number} updatedAt`)) / 86_400_000));
+    if (inactiveDays < INACTIVE_REVIEW_DAYS) {
+      current += 1;
+      continue;
+    }
+
+    const nextAction = credibleNextAction(issue.body, asOfTimestamp);
+    const proposedAction = inactiveDays >= CLOSE_OR_RESCOPE_DAYS && !nextAction ? "close-or-rescope" : "review";
+    const humanDecisionRequired = proposedAction === "close-or-rescope";
+    if (humanDecisionRequired) closeOrRescope += 1;
+    else review += 1;
+
+    results.push({
+      ruleId: "PRS-ISSUE-AGING-001",
+      severity: "warning",
+      issue: { number: issue.number, title: issue.title, url: issue.url },
+      inactiveDays,
+      proposedAction,
+      humanDecisionRequired,
+      mutationAllowed: false,
+      evidence: [
+        `updatedAt=${issue.updatedAt}`,
+        ...(nextAction ? [`nextActionCheckpoint=${nextAction.checkpoint}`, `nextActionEvidence=${nextAction.evidence}`] : [])
+      ],
+      remediation: humanDecisionRequired
+        ? "A maintainer must close or rescope this issue, or record a credible evidenced next action with a future checkpoint."
+        : "Review the issue and record a credible evidenced next action with a future checkpoint when work remains."
+    });
+  }
+
+  return {
+    schemaVersion: 1,
+    asOf: new Date(asOfTimestamp).toISOString(),
+    thresholds: { inactiveReviewDays: INACTIVE_REVIEW_DAYS, closeOrRescopeDays: CLOSE_OR_RESCOPE_DAYS },
+    summary: { scanned: issues.length, current, review, closeOrRescope },
+    results
+  };
+}
+
+export function formatIssueHygieneReport(report) {
+  const lines = [
+    `# Issue Hygiene Report`,
+    "",
+    `Scanned ${report.summary.scanned} open issues: ${report.summary.current} current, ${report.summary.review} review, ${report.summary.closeOrRescope} close-or-rescope proposal(s).`,
+    "",
+    "This report never mutates, closes, labels, or reschedules an issue. Every close-or-rescope proposal requires a maintainer decision."
+  ];
+  let omitted = 0;
+  for (let index = 0; index < report.results.length; index += 1) {
+    const result = report.results[index];
+    const entry = `- [${result.proposedAction}] [#${result.issue.number}](${result.issue.url}) ${escapeMarkdownText(result.issue.title)} — ${result.inactiveDays} inactive days; ${result.remediation}`;
+    const omittedIfRejected = report.results.length - index;
+    const reservedNotice = `\n\n${omittedIfRejected} additional report entries omitted from Markdown; see the complete JSON artifact.`;
+    const candidate = `${[...lines, "", entry].join("\n")}${reservedNotice}\n`;
+    if (Buffer.byteLength(candidate, "utf8") > MARKDOWN_SUMMARY_BYTE_LIMIT) {
+      omitted = report.results.length - index;
+      break;
+    }
+    lines.push("", entry);
+  }
+  if (omitted > 0) lines.push("", `${omitted} additional report entries omitted from Markdown; see the complete JSON artifact.`);
+  return `${lines.join("\n")}\n`;
+}
+
+function nextPageUrl(linkHeader, repo) {
+  if (!linkHeader) return undefined;
+  for (const link of linkHeader.split(",")) {
+    const match = link.match(/^\s*<([^>]+)>\s*;\s*rel="([^"]+)"\s*$/);
+    if (match?.[2].split(/\s+/).includes("next")) {
+      const url = new URL(match[1]);
+      const expectedNamedPath = `/repos/${repo}/issues`;
+      const isCanonicalIdPath = /^\/repositories\/\d+\/issues$/.test(url.pathname);
+      if (url.origin !== "https://api.github.com" || (url.pathname !== expectedNamedPath && !isCanonicalIdPath)) {
+        throw new Error("GitHub issue inventory returned an invalid next-page URL.");
+      }
+      return url.href;
+    }
+  }
+  return undefined;
+}
+
+export async function fetchOpenIssues(repo, token, fetchImplementation = fetch) {
+  if (!/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(repo)) throw new Error("--repo must be owner/name.");
+  if (!token) throw new Error("GITHUB_TOKEN is required with --repo.");
+  const issues = [];
+  const visited = new Set();
+  let url = `https://api.github.com/repos/${repo}/issues?state=open&per_page=100`;
+  while (url) {
+    if (visited.has(url)) throw new Error("GitHub issue inventory returned a pagination loop.");
+    visited.add(url);
+    const response = await fetchImplementation(url, {
+      headers: {
+        Accept: "application/vnd.github+json",
+        Authorization: `Bearer ${token}`,
+        "X-GitHub-Api-Version": "2022-11-28"
+      }
+    });
+    if (!response.ok) throw new Error(`GitHub issue inventory failed with HTTP ${response.status}.`);
+    const pageIssues = await response.json();
+    if (!Array.isArray(pageIssues)) throw new Error("GitHub issue inventory returned a non-array response.");
+    issues.push(...pageIssues);
+    url = nextPageUrl(response.headers.get("link"), repo);
+  }
+  return issues;
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const asOf = options.as_of ?? new Date().toISOString();
+  const raw = options.fixture
+    ? JSON.parse(await readFile(options.fixture, "utf8"))
+    : await fetchOpenIssues(options.repo, process.env.GITHUB_TOKEN);
+  const issues = Array.isArray(raw) ? raw : raw?.issues;
+  if (!Array.isArray(issues)) throw new Error("Issue fixture must be an array or an object with an issues array.");
+  const report = buildIssueHygieneReport(issues, asOf);
+  if (options.json_output) await writeFile(options.json_output, `${JSON.stringify(report, null, 2)}\n`);
+  process.stdout.write(formatIssueHygieneReport(report));
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/src/archetypes.ts
+++ b/src/archetypes.ts
@@ -1,4 +1,5 @@
 import path from "node:path";
+import { readFileSync } from "node:fs";
 
 import { dedent, indentBlock, yamlList } from "./lib/text.js";
 import { stringifyManifest } from "./manifest.js";
@@ -2615,6 +2616,54 @@ ${indentBlock(setupSteps(manifest), 6)}
   `;
 }
 
+function issueHygieneWorkflow(manifest: BootstrapManifest): string {
+  const shellRunner = formatRunsOn(resolveRunsOn(manifest.ci.runnerPolicy, manifest.project.visibility, ["shell"]));
+
+  return dedent`
+    name: Issue Hygiene Report
+
+    on:
+      schedule:
+        - cron: '17 9 * * 1'
+      workflow_dispatch:
+
+    permissions:
+      contents: read
+      issues: read
+
+    jobs:
+      report:
+        name: Report Aging Issues
+        runs-on: ${shellRunner}
+        timeout-minutes: 10
+        steps:
+          - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+          - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+            with:
+              node-version: '${manifest.ci.nodeVersion}'
+          - name: Build deterministic issue hygiene report
+            shell: bash
+            env:
+              GITHUB_TOKEN: \${{ github.token }}
+            run: |
+              node scripts/ci/report-issue-hygiene.mjs \\
+                --repo "$GITHUB_REPOSITORY" \\
+                --json-output issue-hygiene-report.json \\
+                | tee "$RUNNER_TEMP/issue-hygiene-summary.md"
+              cat "$RUNNER_TEMP/issue-hygiene-summary.md" >> "$GITHUB_STEP_SUMMARY"
+          - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+            with:
+              name: issue-hygiene-report
+              path: issue-hygiene-report.json
+              if-no-files-found: error
+              retention-days: 30
+  `;
+}
+
+function issueHygieneScript(): string {
+  return readFileSync(new URL("../scripts/ci/report-issue-hygiene.mjs", import.meta.url), "utf8");
+}
+
 function extendedWorkflow(manifest: BootstrapManifest): string {
   const paths = workflowPaths(manifest);
   const shellRunner = formatRunsOn(resolveRunsOn(manifest.ci.runnerPolicy, manifest.project.visibility, ["shell"]));
@@ -2765,6 +2814,7 @@ ${indentBlock(projectIdentityLines(manifest), 4)}
     - Confirm \`CONTRIBUTING.md\` and \`.github/PULL_REQUEST_TEMPLATE.md\` are present as the required contributor and PR guidance surfaces.
     - Confirm \`AGENTS.md\` requires the \`autoreview\` skill against the intended PR diff before an agent opens or updates a PR, and that the PR template records the final command and result.
     - Confirm the pull request template is present and PR Fast CI validates the required PR description sections before ${primaryRequiredStatusCheck(manifest)} can pass.
+    ${manifest.github.repoFeatures.hasIssues ? "- Confirm `Issue Hygiene Report` runs weekly with read-only issue permission and retains its JSON evidence artifact." : ""}
     - ${autoMergeOnboardingConfirmation()}
     - Fallback merge readiness requires passing or intentionally skipped required checks, satisfied approvals, resolved conversations, no blocking review state, and a manual maintainer merge.
 
@@ -2795,6 +2845,19 @@ ${indentBlock(additionalWorkflowSection(manifest), 4)}
     - \`.github/PULL_REQUEST_TEMPLATE.md\` defines the standard PR shape: summary, governing issue link, validation notes, and bootstrap governance checklist.
     - To retrofit an existing bootstrapped repo, add \`CONTRIBUTING.md\` and \`.github/PULL_REQUEST_TEMPLATE.md\` to \`repo.managedPaths\` when that repo restricts managed paths, then run \`bootstrap apply repo --manifest ./project.bootstrap.yaml\`.
     - Keep these files repo-generic unless project metadata or the manifest requires a stricter local rule.
+
+${manifest.github.repoFeatures.hasIssues
+  ? indentBlock(
+      dedent`
+        ## Issue Hygiene
+
+        - Review \`docs/bootstrap/issue-hygiene.md\` before acting on a 30-day review or 90-day close-or-rescope proposal.
+        - The scheduled workflow is report-only: it never comments, labels, closes, or reschedules issues.
+        - A 90-day proposal always requires a maintainer decision. Record a structured, evidenced future action when the issue should remain open.
+      `,
+      4
+    )
+  : ""}
 
     ## Licensing
 
@@ -2843,6 +2906,42 @@ ${manifest.ci.aiAttestation.enabled
 
     - Run \`bootstrap apply home --manifest ./project.bootstrap.yaml\` after reviewing the bundled profile content.
     - The bootstrap manages portable Codex assets only. Auth, sessions, caches, and machine-local state stay unmanaged.
+  `;
+}
+
+function issueHygieneDoc(): string {
+  return dedent`
+    # Report-First Issue Hygiene
+
+    \`.github/workflows/issue-hygiene.yml\` inventories open issues every Monday and on manual dispatch. It uses only \`contents: read\` and \`issues: read\`, writes a complete versioned JSON artifact, and appends a Markdown report capped at 900 KiB to the workflow summary.
+
+    ## Aging Rules
+
+    - Fewer than 30 inactive days: current; no report entry.
+    - At least 30 inactive days: review proposal.
+    - At least 90 inactive days without a credible next action: close-or-rescope proposal that requires a maintainer decision.
+    - Automation never comments, labels, closes, reschedules, or otherwise mutates an issue.
+
+    GitHub's \`updated_at\` timestamp is the inactivity source. Pull requests returned by the issues API are excluded.
+
+    ## Preserve A Stale Issue
+
+    Add one structured marker to the issue body. \`outcome\` or an evidence-shaped \`dependency\` is required, \`checkpoint\` must be a future ISO date, and \`evidence\` must be a canonical public GitHub issue, pull-request, or Actions-run URL without query or fragment data, or a positive numeric \`issue:\`, \`pr:\`, or \`run:\` reference.
+
+    \`\`\`html
+    <!-- prs-next-action {"outcome":"Ship resolver","dependency":"issue:54","checkpoint":"2026-08-01","evidence":"issue:10"} -->
+    \`\`\`
+
+    The report publishes only the issue number, single-line title, URL, timestamps, checkpoint, and evidence reference. It never emits the issue body or the next-action outcome.
+
+    ## Local Fixture
+
+    \`\`\`sh
+    node scripts/ci/report-issue-hygiene.mjs \\
+      --fixture /path/to/issues.json \\
+      --as-of 2026-07-18T12:00:00Z \\
+      --json-output issue-hygiene-report.json
+    \`\`\`
   `;
 }
 
@@ -3324,6 +3423,15 @@ export function renderManagedFiles(manifest: BootstrapManifest): RenderedFile[] 
       reason: "Extended validation workflow",
       contents: `${extendedWorkflow(manifest)}\n`
     },
+    ...(manifest.github.repoFeatures.hasIssues
+      ? [
+          {
+            path: ".github/workflows/issue-hygiene.yml",
+            reason: "Read-only scheduled issue aging report",
+            contents: `${issueHygieneWorkflow(manifest)}\n`
+          }
+        ]
+      : []),
     ...(manifest.ci.dependabot.enabled && manifest.ci.dependabot.versionUpdates
       ? [
           {
@@ -3443,6 +3551,16 @@ export function renderManagedFiles(manifest: BootstrapManifest): RenderedFile[] 
       contents: `${actionPinScript()}\n`,
       executable: true
     },
+    ...(manifest.github.repoFeatures.hasIssues
+      ? [
+          {
+            path: "scripts/ci/report-issue-hygiene.mjs",
+            reason: "Deterministic report-first issue aging evaluator",
+            contents: issueHygieneScript(),
+            executable: true
+          }
+        ]
+      : []),
     ...(manifest.release.enabled
       ? [
           {
@@ -3514,6 +3632,15 @@ export function renderManagedFiles(manifest: BootstrapManifest): RenderedFile[] 
       reason: "Operator onboarding checklist",
       contents: `${onboardingDoc(manifest)}\n`
     },
+    ...(manifest.github.repoFeatures.hasIssues
+      ? [
+          {
+            path: "docs/bootstrap/issue-hygiene.md",
+            reason: "Report-first issue aging operator guide",
+            contents: `${issueHygieneDoc()}\n`
+          }
+        ]
+      : []),
     {
       path: "docs/bootstrap/codex-cloud-environment.md",
       reason: "Codex web environment setup guide",

--- a/src/render.ts
+++ b/src/render.ts
@@ -152,6 +152,10 @@ const managedPathDependencies = [
   {
     path: ".github/PULL_REQUEST_TEMPLATE.md",
     requires: ["docs/bootstrap/onboarding.md"]
+  },
+  {
+    path: ".github/workflows/issue-hygiene.yml",
+    requires: ["scripts/ci/report-issue-hygiene.mjs", "docs/bootstrap/issue-hygiene.md"]
   }
 ];
 

--- a/tests/__snapshots__/render.test.ts.snap
+++ b/tests/__snapshots__/render.test.ts.snap
@@ -48,6 +48,10 @@ exports[`renderManagedFiles > renders a stable managed file set for generic-empt
   },
   {
     "executable": false,
+    "path": ".github/workflows/issue-hygiene.yml",
+  },
+  {
+    "executable": false,
     "path": ".github/dependabot.yml",
   },
   {
@@ -80,6 +84,10 @@ exports[`renderManagedFiles > renders a stable managed file set for generic-empt
   },
   {
     "executable": true,
+    "path": "scripts/ci/report-issue-hygiene.mjs",
+  },
+  {
+    "executable": true,
     "path": "scripts/ci/run-release-verification.sh",
   },
   {
@@ -105,6 +113,10 @@ exports[`renderManagedFiles > renders a stable managed file set for generic-empt
   {
     "executable": false,
     "path": "docs/bootstrap/onboarding.md",
+  },
+  {
+    "executable": false,
+    "path": "docs/bootstrap/issue-hygiene.md",
   },
   {
     "executable": false,
@@ -169,6 +181,10 @@ exports[`renderManagedFiles > renders a stable managed file set for nextjs-web 1
   },
   {
     "executable": false,
+    "path": ".github/workflows/issue-hygiene.yml",
+  },
+  {
+    "executable": false,
     "path": ".github/dependabot.yml",
   },
   {
@@ -201,6 +217,10 @@ exports[`renderManagedFiles > renders a stable managed file set for nextjs-web 1
   },
   {
     "executable": true,
+    "path": "scripts/ci/report-issue-hygiene.mjs",
+  },
+  {
+    "executable": true,
     "path": "scripts/ci/run-release-verification.sh",
   },
   {
@@ -226,6 +246,10 @@ exports[`renderManagedFiles > renders a stable managed file set for nextjs-web 1
   {
     "executable": false,
     "path": "docs/bootstrap/onboarding.md",
+  },
+  {
+    "executable": false,
+    "path": "docs/bootstrap/issue-hygiene.md",
   },
   {
     "executable": false,
@@ -298,6 +322,10 @@ exports[`renderManagedFiles > renders a stable managed file set for node-ts-serv
   },
   {
     "executable": false,
+    "path": ".github/workflows/issue-hygiene.yml",
+  },
+  {
+    "executable": false,
     "path": ".github/dependabot.yml",
   },
   {
@@ -330,6 +358,10 @@ exports[`renderManagedFiles > renders a stable managed file set for node-ts-serv
   },
   {
     "executable": true,
+    "path": "scripts/ci/report-issue-hygiene.mjs",
+  },
+  {
+    "executable": true,
     "path": "scripts/ci/run-release-verification.sh",
   },
   {
@@ -355,6 +387,10 @@ exports[`renderManagedFiles > renders a stable managed file set for node-ts-serv
   {
     "executable": false,
     "path": "docs/bootstrap/onboarding.md",
+  },
+  {
+    "executable": false,
+    "path": "docs/bootstrap/issue-hygiene.md",
   },
   {
     "executable": false,
@@ -419,6 +455,10 @@ exports[`renderManagedFiles > renders a stable managed file set for python-servi
   },
   {
     "executable": false,
+    "path": ".github/workflows/issue-hygiene.yml",
+  },
+  {
+    "executable": false,
     "path": ".github/dependabot.yml",
   },
   {
@@ -451,6 +491,10 @@ exports[`renderManagedFiles > renders a stable managed file set for python-servi
   },
   {
     "executable": true,
+    "path": "scripts/ci/report-issue-hygiene.mjs",
+  },
+  {
+    "executable": true,
     "path": "scripts/ci/run-release-verification.sh",
   },
   {
@@ -476,6 +520,10 @@ exports[`renderManagedFiles > renders a stable managed file set for python-servi
   {
     "executable": false,
     "path": "docs/bootstrap/onboarding.md",
+  },
+  {
+    "executable": false,
+    "path": "docs/bootstrap/issue-hygiene.md",
   },
   {
     "executable": false,

--- a/tests/issue-hygiene.test.ts
+++ b/tests/issue-hygiene.test.ts
@@ -1,0 +1,182 @@
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { spawn } from "node:child_process";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { parse } from "yaml";
+import { buildIssueHygieneReport, fetchOpenIssues, formatIssueHygieneReport } from "../scripts/ci/report-issue-hygiene.mjs";
+
+const script = path.resolve("scripts/ci/report-issue-hygiene.mjs");
+
+async function runReport(issues: unknown[], asOf = "2026-07-18T12:00:00.000Z") {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "bootstrap-issue-hygiene-"));
+  const fixture = path.join(directory, "issues.json");
+  const output = path.join(directory, "report.json");
+  await writeFile(fixture, JSON.stringify(issues));
+  const execution = await new Promise<{ code: number; stdout: string; stderr: string }>((resolve, reject) => {
+    const child = spawn(process.execPath, [script, "--fixture", fixture, "--as-of", asOf, "--json-output", output]);
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk) => (stdout += chunk));
+    child.stderr.on("data", (chunk) => (stderr += chunk));
+    child.on("error", reject);
+    child.on("close", (code) => resolve({ code: code ?? 1, stdout, stderr }));
+  });
+  const report = JSON.parse(await readFile(output, "utf8"));
+  return { ...execution, report };
+}
+
+function issue(number: number, updatedAt: string, body = "") {
+  return {
+    number,
+    title: `Issue ${number}`,
+    html_url: `https://github.com/acme/repo/issues/${number}`,
+    updated_at: updatedAt,
+    body
+  };
+}
+
+describe("issue hygiene report", () => {
+  it("uses the 30/90-day clocks and never authorizes mutation", async () => {
+    const { code, stdout, report } = await runReport([
+      issue(3, "2026-04-19T12:00:00.000Z"),
+      issue(1, "2026-06-19T12:00:00.000Z"),
+      issue(2, "2026-06-18T12:00:00.000Z")
+    ]);
+
+    expect(code).toBe(0);
+    expect(report).toMatchObject({
+      schemaVersion: 1,
+      thresholds: { inactiveReviewDays: 30, closeOrRescopeDays: 90 },
+      summary: { scanned: 3, current: 1, review: 1, closeOrRescope: 1 }
+    });
+    expect(report.results.map((entry: any) => entry.issue.number)).toEqual([2, 3]);
+    expect(report.results[0]).toMatchObject({ proposedAction: "review", humanDecisionRequired: false, mutationAllowed: false });
+    expect(report.results[1]).toMatchObject({ proposedAction: "close-or-rescope", humanDecisionRequired: true, mutationAllowed: false });
+    expect(stdout).toContain("never mutates, closes, labels, or reschedules an issue");
+  });
+
+  it("preserves a stale issue with a credible evidenced future action", async () => {
+    const body = `<!-- prs-next-action {"outcome":"Handle } tokens","dependency":"issue:54","checkpoint":"2026-08-01","evidence":"issue:10"} -->`;
+    const { report } = await runReport([issue(9, "2026-01-01T00:00:00.000Z", body)]);
+
+    expect(report.results[0]).toMatchObject({ proposedAction: "review", humanDecisionRequired: false, mutationAllowed: false });
+    expect(report.results[0].evidence).toContain("nextActionCheckpoint=2026-08-01");
+    expect(JSON.stringify(report)).not.toContain("Handle } tokens");
+  });
+
+  it("rejects impossible or non-ISO timestamps instead of normalizing them", () => {
+    expect(() => buildIssueHygieneReport([issue(1, "2026-02-31T00:00:00Z")])).toThrow("ISO-8601 timestamp");
+    expect(() => buildIssueHygieneReport([issue(1, "2026-01-01T00:00:00Z")], "July 18, 2026")).toThrow(
+      "ISO-8601 timestamp"
+    );
+  });
+
+  it("does not accept malformed or expired action markers and excludes pull requests", async () => {
+    const expired = `<!-- prs-next-action {"outcome":"Later","checkpoint":"2026-07-01","evidence":"issue:10#comment"} -->`;
+    const pullRequest = { ...issue(5, "2026-01-01T00:00:00.000Z"), pull_request: { url: "https://api.github.com/repos/acme/repo/pulls/5" } };
+    const { report } = await runReport([pullRequest, issue(4, "2026-01-01T00:00:00.000Z", expired)]);
+
+    expect(report.summary.scanned).toBe(1);
+    expect(report.results[0]).toMatchObject({ proposedAction: "close-or-rescope", humanDecisionRequired: true, mutationAllowed: false });
+  });
+
+  it("rejects nonexistent checkpoint dates and non-HTTPS evidence", async () => {
+    const impossibleDate = `<!-- prs-next-action {"outcome":"Later","checkpoint":"2026-02-31","evidence":"issue:10"} -->`;
+    const insecureEvidence = `<!-- prs-next-action {"outcome":"Later","checkpoint":"2026-08-01","evidence":"http://example.invalid/comment"} -->`;
+    const emptyHttpsEvidence = `<!-- prs-next-action {"outcome":"Later","checkpoint":"2026-08-01","evidence":"https://?"} -->`;
+    const malformedTypedEvidence = `<!-- prs-next-action {"outcome":"Later","checkpoint":"2026-08-01","evidence":"issue:not-an-issue"} -->`;
+    const credentialQuery = `<!-- prs-next-action {"outcome":"Later","checkpoint":"2026-08-01","evidence":"https://example.invalid/report?access_token=secret"} -->`;
+    const credentialFragment = `<!-- prs-next-action {"outcome":"Later","checkpoint":"2026-08-01","evidence":"https://example.invalid/report#secret"} -->`;
+    const arbitraryCapabilityPath = `<!-- prs-next-action {"outcome":"Later","checkpoint":"2026-08-01","evidence":"https://example.invalid/reset/secret"} -->`;
+    const githubCapabilityPath = `<!-- prs-next-action {"outcome":"Later","checkpoint":"2026-08-01","evidence":"https://github.com/password_reset/secret"} -->`;
+    const { report } = await runReport([
+      issue(7, "2026-01-01T00:00:00.000Z", impossibleDate),
+      issue(8, "2026-01-01T00:00:00.000Z", insecureEvidence),
+      issue(9, "2026-01-01T00:00:00.000Z", emptyHttpsEvidence),
+      issue(10, "2026-01-01T00:00:00.000Z", malformedTypedEvidence),
+      issue(11, "2026-01-01T00:00:00.000Z", credentialQuery),
+      issue(12, "2026-01-01T00:00:00.000Z", credentialFragment),
+      issue(13, "2026-01-01T00:00:00.000Z", arbitraryCapabilityPath),
+      issue(14, "2026-01-01T00:00:00.000Z", githubCapabilityPath)
+    ]);
+
+    expect(report.results).toHaveLength(8);
+    expect(report.results.every((entry: any) => entry.proposedAction === "close-or-rescope")).toBe(true);
+  });
+
+  it("accepts a public credential-free HTTPS evidence URL", async () => {
+    const body = `<!-- prs-next-action {"outcome":"Later","checkpoint":"2026-08-01","evidence":"https://github.com/acme/repo/issues/10"} -->`;
+    const { report } = await runReport([issue(15, "2026-01-01T00:00:00.000Z", body)]);
+
+    expect(report.results[0]).toMatchObject({ proposedAction: "review", humanDecisionRequired: false });
+  });
+
+  it("keeps JSON complete while bounding the Markdown workflow summary", () => {
+    const issues = Array.from({ length: 2_000 }, (_, index) => ({
+      ...issue(index + 1, "2026-01-01T00:00:00.000Z"),
+      title: `Issue ${index + 1} ${"x".repeat(1_000)}`
+    }));
+    const report = buildIssueHygieneReport(issues, "2026-07-18T12:00:00.000Z");
+    const markdown = formatIssueHygieneReport(report);
+
+    expect(report.results).toHaveLength(2_000);
+    expect(Buffer.byteLength(markdown, "utf8")).toBeLessThanOrEqual(900 * 1024);
+    expect(markdown).toContain("additional report entries omitted from Markdown; see the complete JSON artifact");
+  });
+
+  it("escapes untrusted issue titles in the Markdown workflow summary", async () => {
+    const malicious = {
+      ...issue(12, "2026-01-01T00:00:00.000Z"),
+      title: "[click](https://evil.invalid) <img src=x>"
+    };
+    const { stdout, report } = await runReport([malicious]);
+
+    expect(report.results[0].issue.title).toBe(malicious.title);
+    expect(stdout).not.toContain(malicious.title);
+    expect(stdout).toContain("\\[click\\]\\(https://evil\\.invalid\\) &lt;img src=x&gt;");
+  });
+
+  it("follows GitHub pagination without imposing an inventory cap", async () => {
+    const firstPage = Array.from({ length: 100 }, (_, index) => issue(index + 1, "2026-07-18T00:00:00.000Z"));
+    const secondPage = [issue(101, "2026-07-18T00:00:00.000Z")];
+    const requests: string[] = [];
+    const fetchImplementation = async (url: string | URL | Request) => {
+      requests.push(String(url));
+      const body = requests.length === 1 ? firstPage : secondPage;
+      const headers = new Headers();
+      if (requests.length === 1) {
+        headers.set("link", '<https://api.github.com/repositories/123456/issues?state=open&per_page=100&page=2>; rel="next", <https://api.github.com/repositories/123456/issues?state=open&per_page=100&page=2>; rel="last"');
+      }
+      return new Response(JSON.stringify(body), { status: 200, headers });
+    };
+
+    const issues = await fetchOpenIssues("acme/repo", "token", fetchImplementation as typeof fetch);
+
+    expect(requests).toHaveLength(2);
+    expect(requests[1]).toContain("/repositories/123456/issues");
+    expect(issues).toHaveLength(101);
+    expect(issues.at(-1)?.number).toBe(101);
+  });
+
+  it("never sends the workflow token to an off-origin pagination link", async () => {
+    const fetchImplementation = async () => {
+      const headers = new Headers({ link: '<https://evil.invalid/issues?page=2>; rel="next"' });
+      return new Response("[]", { status: 200, headers });
+    };
+
+    await expect(fetchOpenIssues("acme/repo", "token", fetchImplementation as typeof fetch)).rejects.toThrow(
+      "invalid next-page URL"
+    );
+  });
+
+  it("projects a read-only scheduled workflow with retained report evidence", async () => {
+    const workflow = parse(await readFile(path.resolve(".github/workflows/issue-hygiene.yml"), "utf8"));
+
+    expect(workflow.permissions).toEqual({ contents: "read", issues: "read" });
+    expect(workflow.on.schedule[0].cron).toBe("17 9 * * 1");
+    expect(workflow.jobs.report.steps.find((step: any) => step.name === "Build deterministic issue hygiene report")?.shell).toBe("bash");
+    expect(workflow.jobs.report.steps.some((step: any) => step.uses === "actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02")).toBe(true);
+    expect(JSON.stringify(workflow)).not.toMatch(/issues:\s*write|pull-requests:\s*write/);
+  });
+});

--- a/tests/render.test.ts
+++ b/tests/render.test.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 
 import { renderManagedFiles } from "../src/archetypes.js";
@@ -63,6 +64,13 @@ describe("renderManagedFiles", () => {
       expect(files.find((file) => file.path === "scripts/ci/check-pr-governance.sh")?.contents).toContain("PRS-DCO-001");
       expect(prWorkflow?.contents).toContain("validate-action-pins:");
       expect(files.find((file) => file.path === "scripts/ci/check-action-pins.sh")?.contents).toContain("SA-ACTION-PIN-001");
+      const issueHygieneWorkflow = files.find((file) => file.path === ".github/workflows/issue-hygiene.yml");
+      const issueHygieneScript = files.find((file) => file.path === "scripts/ci/report-issue-hygiene.mjs");
+      expect(issueHygieneWorkflow?.contents).toContain("name: Issue Hygiene Report");
+      expect(issueHygieneWorkflow?.contents).toContain("issues: read");
+      expect(issueHygieneWorkflow?.contents).not.toContain("issues: write");
+      expect(issueHygieneScript?.contents).toBe(readFileSync("scripts/ci/report-issue-hygiene.mjs", "utf8"));
+      expect(files.find((file) => file.path === "docs/bootstrap/issue-hygiene.md")?.contents).toContain("Automation never comments, labels, closes, reschedules");
 
       const prTemplate = files.find((file) => file.path === ".github/PULL_REQUEST_TEMPLATE.md");
       const dependabot = files.find((file) => file.path === ".github/dependabot.yml");
@@ -109,6 +117,19 @@ describe("renderManagedFiles", () => {
     const files = renderManagedFiles(manifest);
     expect(files.some((file) => file.path === ".github/dependabot.yml")).toBe(false);
     expect(manifest.ci.dependabot.securityUpdates).toBe(true);
+  });
+
+  it("does not project issue hygiene when repository issues are disabled", () => {
+    const manifest = normalizeManifest({
+      project: { name: "issue-free", owner: "acme" },
+      archetype: { kind: "generic-empty" },
+      github: { repoFeatures: { hasIssues: false } }
+    });
+
+    const files = renderManagedFiles(manifest);
+    expect(files.some((file) => file.path === ".github/workflows/issue-hygiene.yml")).toBe(false);
+    expect(files.some((file) => file.path === "scripts/ci/report-issue-hygiene.mjs")).toBe(false);
+    expect(files.some((file) => file.path === "docs/bootstrap/issue-hygiene.md")).toBe(false);
   });
 
   it("uses the primary required status check name in the generated PR workflow", () => {


### PR DESCRIPTION
## Summary

- Add a read-only weekly/manual issue-hygiene workflow with deterministic 30/90-day aging proposals, complete retained JSON evidence, and a bounded Markdown summary.
- Validate timestamps, structured next-action markers, canonical evidence references, GitHub pagination, and untrusted Markdown while excluding pull requests and retaining no issue bodies or outcomes.
- Project the workflow, reporter, and lifecycle guidance only when issues are enabled, with managed-path dependencies and focused renderer/workflow/security coverage.
- Record ADR-0003: aging automation remains report-first and every close-or-rescope decision remains human.

## Governing Issue

Closes #59

## Validation

- [x] Relevant local checks passed
- [x] Agent-authored changes passed `autoreview` against the intended PR diff with no accepted/actionable findings
- Autoreview command and result: `/Users/johnteneyckjr./.codex/skills/autoreview/scripts/autoreview --mode branch --base origin/main --engine codex --parallel-tests 'TMPDIR=/tmp npm run check'` — clean on head `0600872`; 23 test files and 164 tests passed
- [x] Required PR checks are expected to satisfy `CI Gate`
- [x] Skipped checks are explained below

Local validation on the exact head:

- `npm run check` — 23 test files and 164 tests passed
- `npm run build` — passed
- `bash scripts/ci/check-action-pins.sh` — 35 pinned third-party actions passed
- `git diff --check origin/main...HEAD` — passed
- Skipped checks: none

## Bootstrap Governance

- [x] Changes are scoped to the linked issue
- [x] Contributor or PR guidance changes are reflected in `CONTRIBUTING.md`, `.github/PULL_REQUEST_TEMPLATE.md`, and `docs/bootstrap/onboarding.md` when applicable
- [x] PR author enabled auto-merge where GitHub allows it, or GitHub plan-limit evidence/unavailable reason is recorded and the fallback merge-readiness policy applies
- [x] No real secrets, runtime auth, or machine-local env files are committed

Material change: yes
ADR: docs/decisions/ADR-0003-report-first-issue-hygiene.md

## Merge Automation

- [x] PR author enabled auto-merge with `gh pr merge --auto --squash`, or the reason it is unavailable/unsafe is noted below

## Notes

- The reporter never comments, labels, closes, reschedules, or otherwise mutates issues.
- Independent review remains required; the author will not approve their own pull request.
