### PR TITLE
feat: project public security controls

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,58 @@
+name: Public Security Baseline
+
+on:
+  pull_request:
+  push:
+    branches: ["main"]
+  schedule:
+    - cron: '23 6 * * 1'
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    if: github.event_name == 'pull_request' && vars.DEPENDENCY_REVIEW_ENABLED == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
+        with:
+          fail-on-severity: high
+
+  codeql:
+    if: github.event_name == 'push' || github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        language: ["javascript-typescript"]
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a # v4
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: none
+      - uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a # v4
+        with:
+          category: "/language:${{ matrix.language }}"
+
+  sbom:
+    if: github.event_name == 'push' || github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        with:
+          path: .
+          format: spdx-json
+          artifact-name: sbom.spdx.json
+          upload-release-assets: false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,7 @@
 - Always work on a feature branch. Hooks block commits to `main` and `master`; enable them with `git config core.hooksPath .githooks`.
 - Stack baseline: Generic polyglot.
 - CI baseline: fast PR checks stay cheap and shell-safe; extended validation runs on `main`, nightly, or manual dispatch.
-- Self-hosted runner policy: shell-safe jobs must use `[self-hosted, linux, shell-only, public]`; native repos must use self-hosted runners for required automation, with Docker, service-container, browser, or `container:` workloads routed to dedicated self-hosted capability pools.
+- Self-hosted runner policy: private-repository trusted jobs may use their matching capability pool. Public repository security workflows use GitHub-hosted isolation; fork pull-request jobs always remain read-only and GitHub-hosted.
 - Add or update tests for every interactive, branching, or operator-facing behavior change.
 - Before opening or updating a PR, use the `autoreview` skill to review the intended PR diff against its actual base. Verify every finding, fix accepted in-scope findings, and rerun affected tests and autoreview after changes. Proceed only when no accepted/actionable findings remain, and record the final command and result in the PR validation evidence. If the skill is unavailable or cannot complete, stop and report the blocker instead of bypassing the gate.
 - PRs must use the generated pull request template. The required PR gate validates summary, issue linkage, validation evidence, and risk notes.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,22 @@
+# Security Policy
+
+## Supported Surface
+
+This repository follows the bootstrap-managed security baseline for OMT-Global/bootstrap.
+
+## Reporting
+
+Report suspected vulnerabilities through [GitHub private vulnerability reporting](https://github.com/OMT-Global/bootstrap/security/advisories/new). If that form is unavailable, open a public issue titled `Private security contact requested` without vulnerability details; maintainers will establish a confidential channel before accepting the report. Never include exploit details in public issues or discussions.
+
+## Response Targets
+
+- Acknowledge a complete report within 3 business days.
+- Provide a status update within 10 business days, even when investigation is ongoing.
+- Target remediation within 7 days for critical findings, 30 days for high findings, and 90 days for moderate findings. Low-severity findings are scheduled by maintainers.
+- Coordinate disclosure timing with the reporter after a fix or documented mitigation is available.
+
+## Baseline
+
+- Dependabot policy: enabled
+- Secret scanning hints: enabled
+- Generated hooks and CI helpers must not require committed secrets or machine-local environment files.

--- a/docs/bootstrap/onboarding.md
+++ b/docs/bootstrap/onboarding.md
@@ -28,6 +28,13 @@ Use this checklist after the first bootstrap render or whenever `project.bootstr
 - Confirm new-repo security defaults keep dependency graph, Dependabot alerts, Dependabot security updates, secret scanning, push protection enabled.
 - Treat upstream-aligned forks as explicit exceptions; keep them aligned with the source fork unless you intentionally manage their GitHub policy here.
 
+## Public Security Baseline
+
+- Review `docs/bootstrap/security.md` before changing security workflow events, permissions, or runner labels.
+- Confirm dependency review is the only security job reachable from fork pull requests and runs on GitHub-hosted isolation; CodeQL and SBOM jobs must remain trusted-event only and GitHub-hosted.
+- Capture the seven required GitHub capability observations before treating remote security controls as verified.
+- Confirm `SECURITY.md` private reporting and response targets match the maintained operational policy.
+
 
 ## Environments
 
@@ -37,8 +44,9 @@ Use this checklist after the first bootstrap render or whenever `project.bootstr
 
 ## Runner Policy
 
-- Shell-safe jobs must use `[self-hosted, linux, shell-only, public]`.
-- Native repos must use self-hosted runners for required automation; Docker, service-container, browser, and `container:` workloads require a dedicated self-hosted runner pool with matching capability labels.
+- Private-repository trusted shell-safe jobs use `[self-hosted, linux, shell-only, private]`.
+- Public repository security workflows use GitHub-hosted isolation. Fork pull-request jobs always remain read-only and GitHub-hosted.
+- Native repos must use self-hosted runners for trusted required automation; Docker, service-container, browser, and `container:` workloads require a dedicated self-hosted runner pool with matching capability labels.
 - Keep PR checks cheap. Add heavy validation to `scripts/ci/run-extended-validation.sh` instead of the PR lane.
 
 - Consume shared security, release, and AI attestation workflows from the control-plane repo once those contracts are pinned for production use.

--- a/docs/bootstrap/security.md
+++ b/docs/bootstrap/security.md
@@ -1,0 +1,22 @@
+# Public Repository Security Model
+
+## Trust Boundaries
+
+- Pull requests, including forks, are untrusted input. The pull-request lane runs on GitHub-hosted isolation with read-only repository permissions, does not read GitHub Actions secrets, and runs only dependency review after GitHub provisioning enables the dependency graph and sets `DEPENDENCY_REVIEW_ENABLED=true`.
+- Code scanning and SBOM generation run only for trusted default-branch pushes and schedules on GitHub-hosted isolation.
+- GitHub-hosted security capabilities are evaluated from a versioned capability snapshot so unsupported plan features remain distinct from repository misconfiguration.
+
+## Required Controls
+
+- Dependency graph, Dependabot alerts and security updates, secret scanning, push protection, code scanning, and private vulnerability reporting are required capability observations for public repositories. Dependency review stays skipped until provisioning enables its prerequisite and activation variable.
+- `.github/dependabot.yml` keeps both dependency and GitHub Actions pins updateable.
+- `.github/workflows/security.yml` performs dependency review, CodeQL analysis for `javascript-typescript`, and SPDX JSON SBOM generation using immutable action SHAs.
+- `SECURITY.md` directs reporters to a private advisory and defines acknowledgement, update, remediation, and coordinated-disclosure targets.
+
+## Fork Safety
+
+The security workflow uses `pull_request`, never `pull_request_target`. Its top-level permission is `contents: read`; the only job reachable from a pull request uses a GitHub-hosted runner, has read-only permissions, and has no secret references. Jobs needing `security-events: write` are explicitly excluded from pull-request events.
+
+## Capability Evidence
+
+Capture authorized observations for these controls and pass them to `bootstrap conform --github-capabilities <path>`: `dependency-graph`, `dependabot-alerts`, `dependabot-security-updates`, `secret-scanning`, `push-protection`, `code-scanning`, and `private-vulnerability-reporting`. Unsupported controls remain warnings with remediation; available but disabled controls are blocking misconfigurations. Current typed exceptions may waive only their matching `github.<control>` scope.

--- a/docs/decisions/ADR-0005-public-repository-security-baseline.md
+++ b/docs/decisions/ADR-0005-public-repository-security-baseline.md
@@ -1,0 +1,69 @@
+# ADR-0005: Project a fork-safe public repository security baseline
+
+Status: Accepted
+
+Date: 2026-07-18
+
+Decision owners: Bootstrap maintainers
+
+Decision record: [Bootstrap issue #60](https://github.com/OMT-Global/bootstrap/issues/60)
+
+## Context
+
+Bootstrap already projects basic dependency updates, a vulnerability-reporting document, and organization-level security defaults. Those pieces do not guarantee that every public repository receives dependency review, code scanning, an SBOM, actionable response targets, or a fork-safe permission boundary. Remote GitHub controls also vary by plan and repository configuration, so local files alone cannot prove that scanning and private reporting are active.
+
+Security automation for pull requests must treat fork content as untrusted. Workflows that use `pull_request_target`, expose a secret expression, or grant write permissions to a pull-request-reachable job can turn a routine contribution into a repository or external-service credential boundary.
+
+## Decision
+
+Every public repository receives these Bootstrap-managed surfaces:
+
+1. `SECURITY.md` with a private-advisory route, acknowledgement and update targets, severity-based remediation targets, and coordinated disclosure guidance.
+2. `.github/dependabot.yml` with security updates plus the `github-actions` ecosystem so immutable action pins remain updateable.
+3. `.github/workflows/security.yml` with dependency review on an unfiltered `pull_request` trigger after the dependency graph prerequisite is provisioned and activated through `DEPENDENCY_REVIEW_ENABLED`, plus CodeQL and SPDX JSON SBOM generation only on trusted default-branch push or scheduled events. Trusted jobs default to GitHub-hosted isolation; a configured self-hosted group must restrict workflow access to this file pinned to the protected default branch.
+4. `docs/bootstrap/security.md` describing trust boundaries, required controls, fork safety, and capability evidence.
+
+All third-party actions remain pinned to immutable commits with readable release metadata. The public security workflow uses read-only top-level permissions and contains no secret references. Every job uses GitHub-hosted isolation. Jobs that require `security-events: write` or `contents: write` are explicitly unreachable from pull requests.
+
+Conformance adds stable local baseline and fork-safety rules. It also expects authorized observations for dependency graph, Dependabot alerts and security updates, secret scanning, push protection, code scanning, and private vulnerability reporting. A missing observation is `unverified`, an unsupported plan capability is `unsupported`, and an available but disabled capability is `misconfigured`. Only a current typed exception matching `security-baseline` / `repo.security` or `github-capability` / `github.<control>` can waive the corresponding deviation.
+
+## Consequences
+
+- Public repositories gain an additional scheduled and trusted-push workflow.
+- Fork pull requests run dependency review on GitHub-hosted isolation without repository secrets or write permissions; CodeQL and SBOM jobs do not run in that event lane.
+- Public security jobs use GitHub-hosted runners. Any future self-hosted activation requires a separate design that verifies the remote authorization boundary before workflow projection.
+- Capability capture remains an authorized external step; conformance does not infer plan support from ambiguous API failures.
+- An explicit public-repository opt-out is visible as a blocking conformance result unless a current security waiver governs it.
+
+## Alternatives considered
+
+### Run every security job on fork pull requests
+
+Rejected because code scanning and artifact publication require permissions that are unnecessary for untrusted pull-request validation and behave inconsistently across fork boundaries.
+
+### Use `pull_request_target` to gain permissions
+
+Rejected because it moves untrusted contribution data into a privileged workflow context and is unnecessary for dependency review.
+
+### Use mutable action tags for automatic updates
+
+Rejected because mutable tags weaken reproducibility. Dependabot can update immutable SHAs while retaining readable version metadata.
+
+### Treat missing remote capability evidence as success
+
+Rejected because absence of evidence does not prove a control is enabled. Missing observations remain explicitly `unverified`.
+
+## Rollout
+
+1. Land the projection and conformance rules in Bootstrap.
+2. Apply the new managed files to Bootstrap and verify the first trusted security run.
+3. Dogfood the same projection in Flow through issue #63.
+4. Capture authorized capability snapshots and resolve or waive each unsupported or misconfigured control.
+
+## Security and privacy
+
+The generated reporting route uses GitHub private vulnerability reporting. When that form is unavailable, reporters request a confidential channel through a detail-free public issue, so no maintainer email address or vulnerability detail is published. Capability snapshots are schema-bounded and should stay outside the repository when they contain operational detail. The fork lane never references GitHub Actions secrets, and privileged jobs are gated away from pull-request events.
+
+## Revisit conditions
+
+Revisit if GitHub offers a stable plan-capability API, if a projected scanner requires a dedicated runner capability pool, or if CodeQL can safely provide equivalent fork coverage without widening permissions.

--- a/project.bootstrap.yaml
+++ b/project.bootstrap.yaml
@@ -15,7 +15,7 @@ repo:
   docs:
     readme: true
     contributing: false
-    security: false
+    security: true
   templates:
     pullRequest: standard
     issueTemplates: []
@@ -171,6 +171,8 @@ ci:
     - integration
     - release-readiness
   nightlyCron: 0 7 * * *
+  codeqlLanguages:
+    - javascript-typescript
   prGovernance:
     enforceAfter: 2026-07-13T23:00:00Z
   additionalWorkflows: []

--- a/src/archetypes.ts
+++ b/src/archetypes.ts
@@ -196,7 +196,7 @@ function repoAgents(manifest: BootstrapManifest): string {
     - Always work on a feature branch. Hooks block commits to \`main\` and \`master\`; enable them with \`git config core.hooksPath .githooks\`.
     - Stack baseline: ${stack}.
     - CI baseline: fast PR checks stay cheap and shell-safe; extended validation runs on \`main\`, nightly, or manual dispatch.
-    - Self-hosted runner policy: shell-safe jobs must use \`[self-hosted, linux, shell-only, ${manifest.project.visibility === "public" ? "public" : "private"}]\`; native repos must use self-hosted runners for required automation, with Docker, service-container, browser, or \`container:\` workloads routed to dedicated self-hosted capability pools.
+    - Self-hosted runner policy: private-repository trusted jobs may use their matching capability pool. Public repository security workflows use GitHub-hosted isolation; fork pull-request jobs always remain read-only and GitHub-hosted.
     - Add or update tests for every interactive, branching, or operator-facing behavior change.
     - For a task that may open or update a PR, handle autoreview access before implementation: request required network access immediately and, for a private repository, explicit authorization to send the forthcoming intended PR diff to the external reviewer. At closeout, use the \`autoreview\` skill against the actual base. Verify every finding, fix accepted in-scope findings, and rerun affected tests and autoreview after changes. Proceed only when no accepted/actionable findings remain, and record the final command and result in the PR validation evidence. If authorization is declined or the skill is unavailable or cannot complete, stop and report the blocker instead of bypassing the gate.
     - PRs must use the generated pull request template. The required PR gate validates summary, issue linkage, validation evidence, and risk notes.
@@ -1534,6 +1534,78 @@ function dependabotConfig(manifest: BootstrapManifest): string {
   ].join("\n");
 }
 
+function codeQlLanguages(manifest: BootstrapManifest): string {
+  if (manifest.ci.codeqlLanguages.length === 0) {
+    throw new Error(
+      "Public repositories using the generic-empty archetype must configure ci.codeqlLanguages before Bootstrap can project a CodeQL baseline."
+    );
+  }
+  return manifest.ci.codeqlLanguages.join(",");
+}
+
+function publicSecurityWorkflow(manifest: BootstrapManifest): string {
+  return dedent`
+    name: Public Security Baseline
+
+    on:
+      pull_request:
+      push:
+        branches: [${JSON.stringify(manifest.project.defaultBranch)}]
+      schedule:
+        - cron: '23 6 * * 1'
+
+    permissions:
+      contents: read
+
+    jobs:
+      dependency-review:
+        if: github.event_name == 'pull_request' && vars.DEPENDENCY_REVIEW_ENABLED == 'true'
+        runs-on: ubuntu-latest
+        permissions:
+          contents: read
+          pull-requests: read
+        steps:
+          - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+          - uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
+            with:
+              fail-on-severity: high
+
+      codeql:
+        if: github.event_name == 'push' || github.event_name == 'schedule'
+        runs-on: ubuntu-latest
+        strategy:
+          fail-fast: false
+          matrix:
+            language: ${JSON.stringify(manifest.ci.codeqlLanguages)}
+        permissions:
+          contents: read
+          security-events: write
+        steps:
+          - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+          - uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a # v4
+            with:
+              languages: \${{ matrix.language }}
+              build-mode: none
+          - uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a # v4
+            with:
+              category: "/language:\${{ matrix.language }}"
+
+      sbom:
+        if: github.event_name == 'push' || github.event_name == 'schedule'
+        runs-on: ubuntu-latest
+        permissions:
+          contents: write
+        steps:
+          - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+          - uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+            with:
+              path: .
+              format: spdx-json
+              artifact-name: sbom.spdx.json
+              upload-release-assets: false
+  `;
+}
+
 function aiAttestationCallerWorkflow(manifest: BootstrapManifest): string {
   const config = manifest.ci.aiAttestation;
   const reusableWorkflow =
@@ -2820,6 +2892,19 @@ ${indentBlock(projectIdentityLines(manifest), 4)}
 
 ${indentBlock(organizationGovernanceSection(manifest), 4)}
 ${indentBlock(additionalWorkflowSection(manifest), 4)}
+${manifest.project.visibility === "public"
+  ? indentBlock(
+      dedent`
+        ## Public Security Baseline
+
+        - Review \`docs/bootstrap/security.md\` before changing security workflow events, permissions, or runner labels.
+        - Confirm dependency review is the only security job reachable from fork pull requests and runs on GitHub-hosted isolation; CodeQL and SBOM jobs must remain trusted-event only and GitHub-hosted.
+        - Capture the seven required GitHub capability observations before treating remote security controls as verified.
+        - Confirm \`SECURITY.md\` private reporting and response targets match the maintained operational policy.
+      `,
+      4
+    )
+  : ""}
 
     ## Environments
 
@@ -2829,8 +2914,9 @@ ${indentBlock(additionalWorkflowSection(manifest), 4)}
 
     ## Runner Policy
 
-    - Shell-safe jobs must use \`[self-hosted, linux, shell-only, ${manifest.project.visibility === "public" ? "public" : "private"}]\`.
-    - Native repos must use self-hosted runners for required automation; Docker, service-container, browser, and \`container:\` workloads require a dedicated self-hosted runner pool with matching capability labels.
+    - Private-repository trusted shell-safe jobs use \`[self-hosted, linux, shell-only, private]\`.
+    - Public repository security workflows use GitHub-hosted isolation. Fork pull-request jobs always remain read-only and GitHub-hosted.
+    - Native repos must use self-hosted runners for trusted required automation; Docker, service-container, browser, and \`container:\` workloads require a dedicated self-hosted runner pool with matching capability labels.
     - Keep PR checks cheap. Add heavy validation to \`scripts/ci/run-extended-validation.sh\` instead of the PR lane.
     ${manifest.ci.additionalWorkflows.length > 0
       ? `- Keep repo-specific workflow lanes (${manifest.ci.additionalWorkflows
@@ -3072,13 +3158,47 @@ function securityDoc(manifest: BootstrapManifest): string {
 
     ## Reporting
 
-    Open a private security advisory or contact the repository maintainers before disclosing a vulnerability publicly.
+    Report suspected vulnerabilities through [GitHub private vulnerability reporting](https://github.com/${manifest.project.owner}/${manifest.project.name}/security/advisories/new). If that form is unavailable, open a public issue titled \`Private security contact requested\` without vulnerability details; maintainers will establish a confidential channel before accepting the report. Never include exploit details in public issues or discussions.
+
+    ## Response Targets
+
+    - Acknowledge a complete report within 3 business days.
+    - Provide a status update within 10 business days, even when investigation is ongoing.
+    - Target remediation within 7 days for critical findings, 30 days for high findings, and 90 days for moderate findings. Low-severity findings are scheduled by maintainers.
+    - Coordinate disclosure timing with the reporter after a fix or documented mitigation is available.
 
     ## Baseline
 
     - Dependabot policy: ${dependabot ? "enabled" : "disabled by manifest"}
     - Secret scanning hints: ${secretHints ? "enabled" : "disabled by manifest"}
     - Generated hooks and CI helpers must not require committed secrets or machine-local environment files.
+  `;
+}
+
+function securityModelDoc(manifest: BootstrapManifest): string {
+  return dedent`
+    # Public Repository Security Model
+
+    ## Trust Boundaries
+
+    - Pull requests, including forks, are untrusted input. The pull-request lane runs on GitHub-hosted isolation with read-only repository permissions, does not read GitHub Actions secrets, and runs only dependency review after GitHub provisioning enables the dependency graph and sets \`DEPENDENCY_REVIEW_ENABLED=true\`.
+    - Code scanning and SBOM generation run only for trusted default-branch pushes and schedules on GitHub-hosted isolation.
+    - GitHub-hosted security capabilities are evaluated from a versioned capability snapshot so unsupported plan features remain distinct from repository misconfiguration.
+
+    ## Required Controls
+
+    - Dependency graph, Dependabot alerts and security updates, secret scanning, push protection, code scanning, and private vulnerability reporting are required capability observations for public repositories. Dependency review stays skipped until provisioning enables its prerequisite and activation variable.
+    - \`.github/dependabot.yml\` keeps both dependency and GitHub Actions pins updateable.
+    - \`.github/workflows/security.yml\` performs dependency review, CodeQL analysis for \`${codeQlLanguages(manifest)}\`, and SPDX JSON SBOM generation using immutable action SHAs.
+    - \`SECURITY.md\` directs reporters to a private advisory and defines acknowledgement, update, remediation, and coordinated-disclosure targets.
+
+    ## Fork Safety
+
+    The security workflow uses \`pull_request\`, never \`pull_request_target\`. Its top-level permission is \`contents: read\`; the only job reachable from a pull request uses a GitHub-hosted runner, has read-only permissions, and has no secret references. Jobs needing \`security-events: write\` are explicitly excluded from pull-request events.
+
+    ## Capability Evidence
+
+    Capture authorized observations for these controls and pass them to \`bootstrap conform --github-capabilities <path>\`: \`dependency-graph\`, \`dependabot-alerts\`, \`dependabot-security-updates\`, \`secret-scanning\`, \`push-protection\`, \`code-scanning\`, and \`private-vulnerability-reporting\`. Unsupported controls remain warnings with remediation; available but disabled controls are blocking misconfigurations. Current typed exceptions may waive only their matching \`github.<control>\` scope.
   `;
 }
 
@@ -3327,6 +3447,15 @@ export function renderManagedFiles(manifest: BootstrapManifest): RenderedFile[] 
           }
         ]
       : []),
+    ...(manifest.project.visibility === "public"
+      ? [
+          {
+            path: "docs/bootstrap/security.md",
+            reason: "Public repository security model and response targets",
+            contents: `${securityModelDoc(manifest)}\n`
+          }
+        ]
+      : []),
     ...(claudeEnabled(manifest)
       ? [
           {
@@ -3423,6 +3552,15 @@ export function renderManagedFiles(manifest: BootstrapManifest): RenderedFile[] 
       reason: "Extended validation workflow",
       contents: `${extendedWorkflow(manifest)}\n`
     },
+    ...(manifest.project.visibility === "public"
+      ? [
+          {
+            path: ".github/workflows/security.yml",
+            reason: "Fork-safe public repository security baseline",
+            contents: `${publicSecurityWorkflow(manifest)}\n`
+          }
+        ]
+      : []),
     ...(manifest.github.repoFeatures.hasIssues
       ? [
           {

--- a/src/github/provision.ts
+++ b/src/github/provision.ts
@@ -13,17 +13,12 @@ interface GitHubRepo {
   };
 }
 
-interface PrivateVulnerabilityReportingState {
-  enabled?: boolean;
-}
-
-interface AutomatedSecurityFixesState {
+interface SecurityFeatureState {
   enabled?: boolean;
   paused?: boolean;
 }
 
 interface ActionsVariableState {
-  name?: string;
   value?: string;
 }
 
@@ -237,8 +232,8 @@ async function planPublicSecurity(
   );
   const [alerts, automatedFixes, privateReporting, dependencyReviewVariable, codeScanningAnalyses] = await Promise.all([
     client.tryApi<Record<string, never>>("GET", publicSecurityEndpoint(manifest, "vulnerability-alerts")),
-    client.tryApi<AutomatedSecurityFixesState>("GET", publicSecurityEndpoint(manifest, "automated-security-fixes")),
-    client.tryApi<PrivateVulnerabilityReportingState>("GET", publicSecurityEndpoint(manifest, "private-vulnerability-reporting")).catch((error) => {
+    client.tryApi<SecurityFeatureState>("GET", publicSecurityEndpoint(manifest, "automated-security-fixes")),
+    client.tryApi<SecurityFeatureState>("GET", publicSecurityEndpoint(manifest, "private-vulnerability-reporting")).catch((error) => {
       if (!isPrivateReportingPlanCapabilityLimit(error)) throw error;
       privateReportingUnavailable = true;
       return undefined;

--- a/src/github/provision.ts
+++ b/src/github/provision.ts
@@ -7,6 +7,29 @@ interface GitHubRepo {
   private: boolean;
   visibility: string;
   allow_auto_merge?: boolean;
+  security_and_analysis?: {
+    secret_scanning?: { status?: string };
+    secret_scanning_push_protection?: { status?: string };
+  };
+}
+
+interface PrivateVulnerabilityReportingState {
+  enabled?: boolean;
+}
+
+interface AutomatedSecurityFixesState {
+  enabled?: boolean;
+  paused?: boolean;
+}
+
+interface ActionsVariableState {
+  name?: string;
+  value?: string;
+}
+
+interface CodeScanningAnalysisState {
+  error?: string;
+  category?: string;
 }
 
 interface GitHubOwner {
@@ -180,6 +203,177 @@ function autoMergeFallbackAction(): PlannedGitHubAction {
   };
 }
 
+function publicSecurityEndpoint(manifest: BootstrapManifest, suffix: string): string {
+  return `/repos/${manifest.project.owner}/${manifest.project.name}/${suffix}`;
+}
+
+function isGitHubCapabilityLimit(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return /billing plan supports|upgrade to GitHub|not available for (?:this|the current) plan|current plan does not (?:support|expose)|feature is unavailable on (?:this|your) plan/i.test(message);
+}
+
+function isPrivateReportingPlanCapabilityLimit(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return isGitHubCapabilityLimit(error) || /private vulnerability reporting is (?:not available|unavailable) (?:for|on) (?:this|the current) plan/i.test(message);
+}
+
+function isCodeScanningPlanCapabilityLimit(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return isGitHubCapabilityLimit(error) || /GitHub Advanced Security (?:must be|is not) enabled|code scanning is not available (?:for|on) (?:this|the current) plan/i.test(message);
+}
+
+async function planPublicSecurity(
+  manifest: BootstrapManifest,
+  repo: GitHubRepo | undefined,
+  client: GitHubClient
+): Promise<PlannedGitHubAction | undefined> {
+  if (manifest.project.visibility !== "public") return undefined;
+  const dependencyReviewVariableEndpoint = publicSecurityEndpoint(manifest, "actions/variables/DEPENDENCY_REVIEW_ENABLED");
+  let privateReportingUnavailable = false;
+  let codeScanningUnavailable = false;
+  const codeScanningEndpoint = publicSecurityEndpoint(
+    manifest,
+    `code-scanning/analyses?ref=${encodeURIComponent(`refs/heads/${manifest.project.defaultBranch}`)}&tool_name=CodeQL&per_page=100`
+  );
+  const [alerts, automatedFixes, privateReporting, dependencyReviewVariable, codeScanningAnalyses] = await Promise.all([
+    client.tryApi<Record<string, never>>("GET", publicSecurityEndpoint(manifest, "vulnerability-alerts")),
+    client.tryApi<AutomatedSecurityFixesState>("GET", publicSecurityEndpoint(manifest, "automated-security-fixes")),
+    client.tryApi<PrivateVulnerabilityReportingState>("GET", publicSecurityEndpoint(manifest, "private-vulnerability-reporting")).catch((error) => {
+      if (!isPrivateReportingPlanCapabilityLimit(error)) throw error;
+      privateReportingUnavailable = true;
+      return undefined;
+    }),
+    client.tryApi<ActionsVariableState>("GET", dependencyReviewVariableEndpoint),
+    client.tryApi<CodeScanningAnalysisState[]>("GET", codeScanningEndpoint).catch((error) => {
+      if (!isCodeScanningPlanCapabilityLimit(error)) throw error;
+      codeScanningUnavailable = true;
+      return undefined;
+    })
+  ]);
+  // GitHub returns 204 with no body when alerts are enabled; GitHubClient.api
+  // normalizes that successful empty response to {}, while only a 404 becomes undefined.
+  const alertsEnabled = alerts !== undefined;
+  const successfulCodeScanningCategories = codeScanningAnalyses
+    ?.filter((analysis) => analysis.error === "")
+    .map((analysis) => analysis.category)
+    .filter((category): category is string => Boolean(category)) ?? [];
+  const codeScanningVerified = manifest.ci.codeqlLanguages.length > 0 &&
+    manifest.ci.codeqlLanguages.every(
+      (language) => successfulCodeScanningCategories.some(
+        (category) => category.startsWith(".github/workflows/security.yml:codeql/") &&
+          category.endsWith(`/language:${language}`)
+      )
+    );
+  const disabled = [
+    !alertsEnabled ? "dependency graph and Dependabot alerts" : null,
+    dependencyReviewVariable?.value !== "true" ? "dependency review activation" : null,
+    automatedFixes?.enabled !== true || automatedFixes.paused === true ? "Dependabot security updates" : null,
+    repo?.security_and_analysis?.secret_scanning?.status !== "enabled" ? "secret scanning" : null,
+    repo?.security_and_analysis?.secret_scanning_push_protection?.status !== "enabled" ? "push protection" : null,
+    !codeScanningVerified ? "code scanning verification" : null,
+    privateReporting?.enabled !== true ? "private vulnerability reporting" : null
+  ].filter((entry): entry is string => Boolean(entry));
+  const unverified = [
+    !codeScanningVerified
+      ? codeScanningUnavailable
+        ? "code scanning is unavailable on the current plan"
+        : "a successful CodeQL analysis for every configured language could not be verified on the default branch"
+      : null,
+    privateReportingUnavailable ? "private vulnerability reporting is unsupported" : null
+  ].filter((entry): entry is string => Boolean(entry));
+
+  return {
+    id: unverified.length > 0
+      ? "security-baseline-unverified"
+      : disabled.length === 0
+        ? "security-baseline-sync"
+        : "security-baseline",
+    description: unverified.length > 0
+      ? `Security capabilities for ${manifest.project.owner}/${manifest.project.name} remain unverified: ${unverified.join("; ")}. Enable ${disabled.filter((entry) => entry !== "private vulnerability reporting" && entry !== "code scanning verification").join(", ") || "the remaining synchronized controls"}, then capture remediation or an approved waiver for every unsupported capability.`
+      : disabled.length === 0
+      ? `Public repository security settings for ${manifest.project.owner}/${manifest.project.name} already match the baseline.`
+      : `Enable ${disabled.join(", ")} for ${manifest.project.owner}/${manifest.project.name}.`
+  };
+}
+
+async function applySecurityCapability(
+  client: GitHubClient,
+  method: "PATCH" | "PUT",
+  endpoint: string,
+  payload: unknown,
+  action: PlannedGitHubAction,
+  unsupportedAction: PlannedGitHubAction,
+  isUnsupported: (error: unknown) => boolean = isGitHubCapabilityLimit
+): Promise<PlannedGitHubAction> {
+  try {
+    await client.api(method, endpoint, payload);
+    return action;
+  } catch (error) {
+    if (!isUnsupported(error)) throw error;
+    return unsupportedAction;
+  }
+}
+
+async function applyPublicSecurity(
+  manifest: BootstrapManifest,
+  client: GitHubClient
+): Promise<PlannedGitHubAction[]> {
+  if (manifest.project.visibility !== "public") return [];
+  const repoEndpoint = `/repos/${manifest.project.owner}/${manifest.project.name}`;
+  const analysis = await applySecurityCapability(
+      client,
+      "PATCH",
+      repoEndpoint,
+      {
+        security_and_analysis: {
+          secret_scanning: { status: "enabled" },
+          secret_scanning_push_protection: { status: "enabled" }
+        }
+      },
+      { id: "security-analysis", description: "Enabled secret scanning and push protection." },
+      { id: "security-analysis-unsupported", description: "GitHub rejected one or more scanning controls for the current plan; capture the unsupported capability and retain remediation or an approved waiver." }
+    );
+  const alerts = await applySecurityCapability(
+      client,
+      "PUT",
+      publicSecurityEndpoint(manifest, "vulnerability-alerts"),
+      undefined,
+      { id: "security-dependabot-alerts", description: "Enabled dependency graph and Dependabot vulnerability alerts." },
+      { id: "security-dependabot-alerts-unsupported", description: "GitHub does not expose dependency graph or Dependabot alerts on the current plan; capture the unsupported capability and remediation." }
+    );
+  let dependencyReviewActivation: PlannedGitHubAction;
+  if (alerts.id === "security-dependabot-alerts") {
+    const variableEndpoint = publicSecurityEndpoint(manifest, "actions/variables/DEPENDENCY_REVIEW_ENABLED");
+    const existingVariable = await client.tryApi<ActionsVariableState>("GET", variableEndpoint);
+    if (existingVariable) {
+      await client.api("PATCH", variableEndpoint, { name: "DEPENDENCY_REVIEW_ENABLED", value: "true" });
+    } else {
+      await client.api("POST", publicSecurityEndpoint(manifest, "actions/variables"), { name: "DEPENDENCY_REVIEW_ENABLED", value: "true" });
+    }
+    dependencyReviewActivation = { id: "security-dependency-review-activation", description: "Activated dependency review after enabling dependency graph and alerts." };
+  } else {
+    dependencyReviewActivation = { id: "security-dependency-review-inactive", description: "Dependency review remains inactive because dependency graph and alerts could not be enabled." };
+  }
+  const automatedFixes = await applySecurityCapability(
+      client,
+      "PUT",
+      publicSecurityEndpoint(manifest, "automated-security-fixes"),
+      undefined,
+      { id: "security-dependabot-fixes", description: "Enabled Dependabot automated security fixes." },
+      { id: "security-dependabot-fixes-unsupported", description: "GitHub does not expose Dependabot automated security fixes on the current plan; capture the unsupported capability and remediation." }
+    );
+  const privateReporting = await applySecurityCapability(
+      client,
+      "PUT",
+      publicSecurityEndpoint(manifest, "private-vulnerability-reporting"),
+      undefined,
+      { id: "security-private-reporting", description: "Enabled private vulnerability reporting." },
+      { id: "security-private-reporting-unsupported", description: "GitHub does not expose private vulnerability reporting on the current plan; capture the unsupported capability and remediation." },
+      isPrivateReportingPlanCapabilityLimit
+    );
+  return [analysis, alerts, dependencyReviewActivation, automatedFixes, privateReporting];
+}
+
 function environmentBranchPolicy(
   manifest: BootstrapManifest,
   environmentName: "dev" | "stage" | "prod"
@@ -323,6 +517,9 @@ export async function planGitHub(
         id: "branch-protection",
         description: `Protect ${manifest.project.defaultBranch} with 1 approval, last-push approval, stale-review dismissal, code owner review, linear history, and required status checks ${requiredStatusChecksLabel(manifest)}.`
       },
+      ...(manifest.project.visibility === "public"
+        ? [{ id: "security-baseline-static", description: "Enable existing-repository scanning, dependency alerts, security updates, push protection, and private vulnerability reporting; report plan limitations explicitly." }]
+        : []),
       {
         id: "environments",
         description: "Ensure dev, stage, and prod environments exist with reviewer gates and self-review prevention."
@@ -365,6 +562,8 @@ export async function planGitHub(
       ? `Update repo settings for ${manifest.project.owner}/${manifest.project.name}.`
       : `Create repo ${manifest.project.owner}/${manifest.project.name}.`
   });
+  const securityPlan = await planPublicSecurity(manifest, repo, client);
+  if (securityPlan) actions.push(securityPlan);
   if (
     repoDisablesAutoMerge(manifest, repo) ||
     organizationPlanDisablesPrivateRepoAutoMerge(manifest, owner, organization)
@@ -476,6 +675,7 @@ export async function applyGitHub(
   ) {
     actions.push(autoMergeFallbackAction());
   }
+  actions.push(...await applyPublicSecurity(manifest, client));
 
   try {
     await client.api(

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -457,6 +457,7 @@ const manifestSchema = z.object({
       fastChecks: z.array(z.string()).optional(),
       extendedChecks: z.array(z.string()).optional(),
       nightlyCron: z.string().optional(),
+      codeqlLanguages: z.array(z.enum(["javascript-typescript", "python", "ruby", "c-cpp", "csharp", "rust"])).optional(),
       prGovernance: z
         .object({
           enforceAfter: z.string().datetime({ offset: true })
@@ -919,6 +920,13 @@ export function normalizeManifest(raw: z.input<typeof manifestSchema>): Bootstra
       fastChecks: parsed.ci?.fastChecks ?? ["lint", "typecheck", "unit", "build", "secrets"],
       extendedChecks: parsed.ci?.extendedChecks ?? ["integration", "release-readiness"],
       nightlyCron: parsed.ci?.nightlyCron ?? "0 7 * * *",
+      codeqlLanguages: parsed.ci?.codeqlLanguages ?? (
+        parsed.archetype.kind === "python-service"
+          ? ["python"]
+          : parsed.archetype.kind === "nextjs-web" || parsed.archetype.kind === "node-ts-service"
+            ? ["javascript-typescript"]
+            : []
+      ),
       ...(parsed.ci?.prGovernance ? { prGovernance: { enforceAfter: parsed.ci.prGovernance.enforceAfter } } : {}),
       additionalWorkflows,
       ...(workflows ? { workflows } : {}),

--- a/src/types.ts
+++ b/src/types.ts
@@ -284,6 +284,7 @@ export interface BootstrapManifest {
     fastChecks: string[];
     extendedChecks: string[];
     nightlyCron: string;
+    codeqlLanguages: Array<"javascript-typescript" | "python" | "ruby" | "c-cpp" | "csharp" | "rust">;
     prGovernance?: {
       enforceAfter: string;
     };

--- a/tests/github-provision.test.ts
+++ b/tests/github-provision.test.ts
@@ -3,6 +3,46 @@ import { describe, expect, it } from "vitest";
 import { applyGitHub, planGitHub } from "../src/github/provision.js";
 import { DEFAULT_ISSUE_LABELS, normalizeManifest } from "../src/manifest.js";
 
+const PUBLIC_REPO_ENDPOINT = "/repos/acme/example";
+const CODE_SCANNING_ENDPOINT = `${PUBLIC_REPO_ENDPOINT}/code-scanning/analyses?ref=refs%2Fheads%2Fmain&tool_name=CodeQL&per_page=100`;
+
+function publicManifest(createRepo?: boolean) {
+  return normalizeManifest({
+    project: { name: "example", owner: "acme", visibility: "public" },
+    archetype: { kind: "node-ts-service" },
+    ...(createRepo === undefined ? {} : { github: { createRepo } })
+  });
+}
+
+function publicRepo(scanning?: "enabled" | "disabled") {
+  return {
+    name: "example",
+    full_name: "acme/example",
+    private: false,
+    visibility: "public",
+    ...(scanning
+      ? {
+          security_and_analysis: {
+            secret_scanning: { status: scanning },
+            secret_scanning_push_protection: { status: scanning }
+          }
+        }
+      : {})
+  };
+}
+
+function publicPlanClient(
+  resolve: (endpoint: string) => unknown | Promise<unknown>,
+  repo: unknown = publicRepo()
+) {
+  return {
+    isAvailable: async () => true,
+    isAuthenticated: async () => true,
+    tryApi: async (_method: string, endpoint: string) => endpoint === PUBLIC_REPO_ENDPOINT ? repo : resolve(endpoint),
+    api: async (_method: string, endpoint: string) => endpoint === "/users/acme" ? { login: "acme", type: "Organization" } : {}
+  };
+}
+
 describe("GitHub provisioning", () => {
   it("produces a static plan when gh is unavailable", async () => {
     const manifest = normalizeManifest({
@@ -395,39 +435,18 @@ describe("GitHub provisioning", () => {
   });
 
   it("plans existing public repository security drift", async () => {
-    const manifest = normalizeManifest({
-      project: { name: "example", owner: "acme", visibility: "public" },
-      archetype: { kind: "node-ts-service" }
-    });
-    const client = {
-      isAvailable: async () => true,
-      isAuthenticated: async () => true,
-      tryApi: async (method: string, endpoint: string) => {
-        if (endpoint === "/repos/acme/example") {
-          return {
-            name: "example",
-            full_name: "acme/example",
-            private: false,
-            visibility: "public",
-            security_and_analysis: {
-              secret_scanning: { status: "disabled" },
-              secret_scanning_push_protection: { status: "disabled" }
-            }
-          };
-        }
-        if (endpoint === "/repos/acme/example/private-vulnerability-reporting") return { enabled: false };
-        if (endpoint === "/repos/acme/example/code-scanning/analyses?ref=refs%2Fheads%2Fmain&tool_name=CodeQL&per_page=100") {
+    const client = publicPlanClient(
+      (endpoint) => {
+        if (endpoint === `${PUBLIC_REPO_ENDPOINT}/private-vulnerability-reporting`) return { enabled: false };
+        if (endpoint === CODE_SCANNING_ENDPOINT) {
           return [{ error: "", category: ".github/workflows/security.yml:codeql/language:javascript-typescript" }];
         }
         return undefined;
       },
-      api: async (method: string, endpoint: string) => {
-        if (endpoint === "/users/acme") return { login: "acme", type: "Organization" };
-        return {};
-      }
-    };
+      publicRepo("disabled")
+    );
 
-    const actions = await planGitHub(manifest, client as never);
+    const actions = await planGitHub(publicManifest(), client as never);
     const security = actions.find((action) => action.id === "security-baseline");
 
     expect(security?.description).toContain("Dependabot security updates");
@@ -436,48 +455,28 @@ describe("GitHub provisioning", () => {
   });
 
   it("reports synchronized public security state from dedicated endpoints", async () => {
-    const manifest = normalizeManifest({
-      project: { name: "example", owner: "acme", visibility: "public" },
-      archetype: { kind: "node-ts-service" }
-    });
     let fixesPaused = false;
-    const client = {
-      isAvailable: async () => true,
-      isAuthenticated: async () => true,
-      tryApi: async (method: string, endpoint: string) => {
-        if (endpoint === "/repos/acme/example") {
-          return {
-            name: "example",
-            full_name: "acme/example",
-            private: false,
-            visibility: "public",
-            security_and_analysis: {
-              secret_scanning: { status: "enabled" },
-              secret_scanning_push_protection: { status: "enabled" }
-            }
-          };
-        }
-        if (endpoint === "/repos/acme/example/vulnerability-alerts") return {};
-        if (endpoint === "/repos/acme/example/automated-security-fixes") return { enabled: true, paused: fixesPaused };
-        if (endpoint === "/repos/acme/example/private-vulnerability-reporting") return { enabled: true };
-        if (endpoint === "/repos/acme/example/code-scanning/analyses?ref=refs%2Fheads%2Fmain&tool_name=CodeQL&per_page=100") {
+    const client = publicPlanClient(
+      (endpoint) => {
+        if (endpoint === `${PUBLIC_REPO_ENDPOINT}/vulnerability-alerts`) return {};
+        if (endpoint === `${PUBLIC_REPO_ENDPOINT}/automated-security-fixes`) return { enabled: true, paused: fixesPaused };
+        if (endpoint === `${PUBLIC_REPO_ENDPOINT}/private-vulnerability-reporting`) return { enabled: true };
+        if (endpoint === CODE_SCANNING_ENDPOINT) {
           return [{ error: "", category: ".github/workflows/security.yml:codeql/language:javascript-typescript" }];
         }
-        if (endpoint === "/repos/acme/example/actions/variables/DEPENDENCY_REVIEW_ENABLED") return { name: "DEPENDENCY_REVIEW_ENABLED", value: "true" };
+        if (endpoint === `${PUBLIC_REPO_ENDPOINT}/actions/variables/DEPENDENCY_REVIEW_ENABLED`) {
+          return { name: "DEPENDENCY_REVIEW_ENABLED", value: "true" };
+        }
         return undefined;
       },
-      api: async (method: string, endpoint: string) => {
-        if (endpoint === "/users/acme") return { login: "acme", type: "Organization" };
-        return {};
-      }
-    };
+      publicRepo("enabled")
+    );
 
-    const actions = await planGitHub(manifest, client as never);
-
+    const actions = await planGitHub(publicManifest(), client as never);
     expect(actions).toContainEqual(expect.objectContaining({ id: "security-baseline-sync" }));
 
     fixesPaused = true;
-    const pausedActions = await planGitHub(manifest, client as never);
+    const pausedActions = await planGitHub(publicManifest(), client as never);
     expect(pausedActions).toContainEqual(expect.objectContaining({
       id: "security-baseline",
       description: expect.stringContaining("Dependabot security updates")
@@ -485,30 +484,14 @@ describe("GitHub provisioning", () => {
   });
 
   it("reports an unsupported private-reporting planning capability without aborting", async () => {
-    const manifest = normalizeManifest({
-      project: { name: "example", owner: "acme", visibility: "public" },
-      archetype: { kind: "node-ts-service" }
-    });
-    const client = {
-      isAvailable: async () => true,
-      isAuthenticated: async () => true,
-      tryApi: async (method: string, endpoint: string) => {
-        if (endpoint === "/repos/acme/example") {
-          return { name: "example", full_name: "acme/example", private: false, visibility: "public" };
-        }
-        if (endpoint === "/repos/acme/example/private-vulnerability-reporting") {
-          throw new Error("gh: private vulnerability reporting is not available for this plan (HTTP 422)");
-        }
-        return undefined;
-      },
-      api: async (method: string, endpoint: string) => {
-        if (endpoint === "/users/acme") return { login: "acme", type: "Organization" };
-        return {};
+    const client = publicPlanClient((endpoint) => {
+      if (endpoint === `${PUBLIC_REPO_ENDPOINT}/private-vulnerability-reporting`) {
+        throw new Error("gh: private vulnerability reporting is not available for this plan (HTTP 422)");
       }
-    };
+      return undefined;
+    });
 
-    const actions = await planGitHub(manifest, client as never);
-
+    const actions = await planGitHub(publicManifest(), client as never);
     expect(actions).toContainEqual(expect.objectContaining({
       id: "security-baseline-unverified",
       description: expect.stringContaining("approved waiver")
@@ -516,41 +499,19 @@ describe("GitHub provisioning", () => {
   });
 
   it("does not report synchronization when code scanning cannot be verified", async () => {
-    const manifest = normalizeManifest({
-      project: { name: "example", owner: "acme", visibility: "public" },
-      archetype: { kind: "node-ts-service" }
-    });
-    const client = {
-      isAvailable: async () => true,
-      isAuthenticated: async () => true,
-      tryApi: async (method: string, endpoint: string) => {
-        if (endpoint === "/repos/acme/example") {
-          return {
-            name: "example",
-            full_name: "acme/example",
-            private: false,
-            visibility: "public",
-            security_and_analysis: {
-              secret_scanning: { status: "enabled" },
-              secret_scanning_push_protection: { status: "enabled" }
-            }
-          };
-        }
-        if (endpoint === "/repos/acme/example/vulnerability-alerts") return {};
-        if (endpoint === "/repos/acme/example/automated-security-fixes") return { enabled: true, paused: false };
-        if (endpoint === "/repos/acme/example/private-vulnerability-reporting") return { enabled: true };
-        if (endpoint === "/repos/acme/example/actions/variables/DEPENDENCY_REVIEW_ENABLED") return { value: "true" };
-        if (endpoint === "/repos/acme/example/code-scanning/analyses?ref=refs%2Fheads%2Fmain&tool_name=CodeQL&per_page=100") return [];
+    const client = publicPlanClient(
+      (endpoint) => {
+        if (endpoint === `${PUBLIC_REPO_ENDPOINT}/vulnerability-alerts`) return {};
+        if (endpoint === `${PUBLIC_REPO_ENDPOINT}/automated-security-fixes`) return { enabled: true, paused: false };
+        if (endpoint === `${PUBLIC_REPO_ENDPOINT}/private-vulnerability-reporting`) return { enabled: true };
+        if (endpoint === `${PUBLIC_REPO_ENDPOINT}/actions/variables/DEPENDENCY_REVIEW_ENABLED`) return { value: "true" };
+        if (endpoint === CODE_SCANNING_ENDPOINT) return [];
         return undefined;
       },
-      api: async (method: string, endpoint: string) => {
-        if (endpoint === "/users/acme") return { login: "acme", type: "Organization" };
-        return {};
-      }
-    };
+      publicRepo("enabled")
+    );
 
-    const actions = await planGitHub(manifest, client as never);
-
+    const actions = await planGitHub(publicManifest(), client as never);
     expect(actions).toContainEqual(expect.objectContaining({
       id: "security-baseline-unverified",
       description: expect.stringContaining("successful CodeQL analysis for every configured language")
@@ -559,30 +520,14 @@ describe("GitHub provisioning", () => {
   });
 
   it("reports unavailable code scanning as unverified instead of aborting planning", async () => {
-    const manifest = normalizeManifest({
-      project: { name: "example", owner: "acme", visibility: "public" },
-      archetype: { kind: "node-ts-service" }
-    });
-    const client = {
-      isAvailable: async () => true,
-      isAuthenticated: async () => true,
-      tryApi: async (method: string, endpoint: string) => {
-        if (endpoint === "/repos/acme/example") {
-          return { name: "example", full_name: "acme/example", private: false, visibility: "public" };
-        }
-        if (endpoint.includes("/code-scanning/analyses?")) {
-          throw new Error("gh: GitHub Advanced Security must be enabled (HTTP 403)");
-        }
-        return undefined;
-      },
-      api: async (method: string, endpoint: string) => {
-        if (endpoint === "/users/acme") return { login: "acme", type: "Organization" };
-        return {};
+    const client = publicPlanClient((endpoint) => {
+      if (endpoint.includes("/code-scanning/analyses?")) {
+        throw new Error("gh: GitHub Advanced Security must be enabled (HTTP 403)");
       }
-    };
+      return undefined;
+    });
 
-    const actions = await planGitHub(manifest, client as never);
-
+    const actions = await planGitHub(publicManifest(), client as never);
     expect(actions).toContainEqual(expect.objectContaining({
       id: "security-baseline-unverified",
       description: expect.stringContaining("code scanning is unavailable on the current plan")
@@ -590,40 +535,22 @@ describe("GitHub provisioning", () => {
   });
 
   it("fails closed on ambiguous security planning authorization and validation errors", async () => {
-    const manifest = normalizeManifest({
-      project: { name: "example", owner: "acme", visibility: "public" },
-      archetype: { kind: "node-ts-service" }
+    const inaccessible = publicPlanClient((endpoint) => {
+      if (endpoint.includes("/code-scanning/analyses?")) {
+        throw new Error("gh: Resource not accessible by integration (HTTP 403)");
+      }
+      return undefined;
     });
-    const baseClient = {
-      isAvailable: async () => true,
-      isAuthenticated: async () => true,
-      api: async (method: string, endpoint: string) => endpoint === "/users/acme"
-        ? { login: "acme", type: "Organization" }
-        : {}
-    };
-    const repo = { name: "example", full_name: "acme/example", private: false, visibility: "public" };
+    await expect(planGitHub(publicManifest(), inaccessible as never))
+      .rejects.toThrow("Resource not accessible");
 
-    await expect(planGitHub(manifest, {
-      ...baseClient,
-      tryApi: async (method: string, endpoint: string) => {
-        if (endpoint === "/repos/acme/example") return repo;
-        if (endpoint.includes("/code-scanning/analyses?")) {
-          throw new Error("gh: Resource not accessible by integration (HTTP 403)");
-        }
-        return undefined;
+    const invalid = publicPlanClient((endpoint) => {
+      if (endpoint === `${PUBLIC_REPO_ENDPOINT}/private-vulnerability-reporting`) {
+        throw new Error("gh: Validation Failed (HTTP 422)");
       }
-    } as never)).rejects.toThrow("Resource not accessible");
-
-    await expect(planGitHub(manifest, {
-      ...baseClient,
-      tryApi: async (method: string, endpoint: string) => {
-        if (endpoint === "/repos/acme/example") return repo;
-        if (endpoint === "/repos/acme/example/private-vulnerability-reporting") {
-          throw new Error("gh: Validation Failed (HTTP 422)");
-        }
-        return undefined;
-      }
-    } as never)).rejects.toThrow("Validation Failed");
+      return undefined;
+    });
+    await expect(planGitHub(publicManifest(), invalid as never)).rejects.toThrow("Validation Failed");
   });
 
   it("applies public security controls and reports unsupported capabilities distinctly", async () => {

--- a/tests/github-provision.test.ts
+++ b/tests/github-provision.test.ts
@@ -394,6 +394,317 @@ describe("GitHub provisioning", () => {
     expect(actions.map((action) => action.id)).toContain("auto-merge-plan-limited");
   });
 
+  it("plans existing public repository security drift", async () => {
+    const manifest = normalizeManifest({
+      project: { name: "example", owner: "acme", visibility: "public" },
+      archetype: { kind: "node-ts-service" }
+    });
+    const client = {
+      isAvailable: async () => true,
+      isAuthenticated: async () => true,
+      tryApi: async (method: string, endpoint: string) => {
+        if (endpoint === "/repos/acme/example") {
+          return {
+            name: "example",
+            full_name: "acme/example",
+            private: false,
+            visibility: "public",
+            security_and_analysis: {
+              secret_scanning: { status: "disabled" },
+              secret_scanning_push_protection: { status: "disabled" }
+            }
+          };
+        }
+        if (endpoint === "/repos/acme/example/private-vulnerability-reporting") return { enabled: false };
+        if (endpoint === "/repos/acme/example/code-scanning/analyses?ref=refs%2Fheads%2Fmain&tool_name=CodeQL&per_page=100") {
+          return [{ error: "", category: ".github/workflows/security.yml:codeql/language:javascript-typescript" }];
+        }
+        return undefined;
+      },
+      api: async (method: string, endpoint: string) => {
+        if (endpoint === "/users/acme") return { login: "acme", type: "Organization" };
+        return {};
+      }
+    };
+
+    const actions = await planGitHub(manifest, client as never);
+    const security = actions.find((action) => action.id === "security-baseline");
+
+    expect(security?.description).toContain("Dependabot security updates");
+    expect(security?.description).toContain("secret scanning");
+    expect(security?.description).toContain("private vulnerability reporting");
+  });
+
+  it("reports synchronized public security state from dedicated endpoints", async () => {
+    const manifest = normalizeManifest({
+      project: { name: "example", owner: "acme", visibility: "public" },
+      archetype: { kind: "node-ts-service" }
+    });
+    let fixesPaused = false;
+    const client = {
+      isAvailable: async () => true,
+      isAuthenticated: async () => true,
+      tryApi: async (method: string, endpoint: string) => {
+        if (endpoint === "/repos/acme/example") {
+          return {
+            name: "example",
+            full_name: "acme/example",
+            private: false,
+            visibility: "public",
+            security_and_analysis: {
+              secret_scanning: { status: "enabled" },
+              secret_scanning_push_protection: { status: "enabled" }
+            }
+          };
+        }
+        if (endpoint === "/repos/acme/example/vulnerability-alerts") return {};
+        if (endpoint === "/repos/acme/example/automated-security-fixes") return { enabled: true, paused: fixesPaused };
+        if (endpoint === "/repos/acme/example/private-vulnerability-reporting") return { enabled: true };
+        if (endpoint === "/repos/acme/example/code-scanning/analyses?ref=refs%2Fheads%2Fmain&tool_name=CodeQL&per_page=100") {
+          return [{ error: "", category: ".github/workflows/security.yml:codeql/language:javascript-typescript" }];
+        }
+        if (endpoint === "/repos/acme/example/actions/variables/DEPENDENCY_REVIEW_ENABLED") return { name: "DEPENDENCY_REVIEW_ENABLED", value: "true" };
+        return undefined;
+      },
+      api: async (method: string, endpoint: string) => {
+        if (endpoint === "/users/acme") return { login: "acme", type: "Organization" };
+        return {};
+      }
+    };
+
+    const actions = await planGitHub(manifest, client as never);
+
+    expect(actions).toContainEqual(expect.objectContaining({ id: "security-baseline-sync" }));
+
+    fixesPaused = true;
+    const pausedActions = await planGitHub(manifest, client as never);
+    expect(pausedActions).toContainEqual(expect.objectContaining({
+      id: "security-baseline",
+      description: expect.stringContaining("Dependabot security updates")
+    }));
+  });
+
+  it("reports an unsupported private-reporting planning capability without aborting", async () => {
+    const manifest = normalizeManifest({
+      project: { name: "example", owner: "acme", visibility: "public" },
+      archetype: { kind: "node-ts-service" }
+    });
+    const client = {
+      isAvailable: async () => true,
+      isAuthenticated: async () => true,
+      tryApi: async (method: string, endpoint: string) => {
+        if (endpoint === "/repos/acme/example") {
+          return { name: "example", full_name: "acme/example", private: false, visibility: "public" };
+        }
+        if (endpoint === "/repos/acme/example/private-vulnerability-reporting") {
+          throw new Error("gh: private vulnerability reporting is not available for this plan (HTTP 422)");
+        }
+        return undefined;
+      },
+      api: async (method: string, endpoint: string) => {
+        if (endpoint === "/users/acme") return { login: "acme", type: "Organization" };
+        return {};
+      }
+    };
+
+    const actions = await planGitHub(manifest, client as never);
+
+    expect(actions).toContainEqual(expect.objectContaining({
+      id: "security-baseline-unverified",
+      description: expect.stringContaining("approved waiver")
+    }));
+  });
+
+  it("does not report synchronization when code scanning cannot be verified", async () => {
+    const manifest = normalizeManifest({
+      project: { name: "example", owner: "acme", visibility: "public" },
+      archetype: { kind: "node-ts-service" }
+    });
+    const client = {
+      isAvailable: async () => true,
+      isAuthenticated: async () => true,
+      tryApi: async (method: string, endpoint: string) => {
+        if (endpoint === "/repos/acme/example") {
+          return {
+            name: "example",
+            full_name: "acme/example",
+            private: false,
+            visibility: "public",
+            security_and_analysis: {
+              secret_scanning: { status: "enabled" },
+              secret_scanning_push_protection: { status: "enabled" }
+            }
+          };
+        }
+        if (endpoint === "/repos/acme/example/vulnerability-alerts") return {};
+        if (endpoint === "/repos/acme/example/automated-security-fixes") return { enabled: true, paused: false };
+        if (endpoint === "/repos/acme/example/private-vulnerability-reporting") return { enabled: true };
+        if (endpoint === "/repos/acme/example/actions/variables/DEPENDENCY_REVIEW_ENABLED") return { value: "true" };
+        if (endpoint === "/repos/acme/example/code-scanning/analyses?ref=refs%2Fheads%2Fmain&tool_name=CodeQL&per_page=100") return [];
+        return undefined;
+      },
+      api: async (method: string, endpoint: string) => {
+        if (endpoint === "/users/acme") return { login: "acme", type: "Organization" };
+        return {};
+      }
+    };
+
+    const actions = await planGitHub(manifest, client as never);
+
+    expect(actions).toContainEqual(expect.objectContaining({
+      id: "security-baseline-unverified",
+      description: expect.stringContaining("successful CodeQL analysis for every configured language")
+    }));
+    expect(actions).not.toContainEqual(expect.objectContaining({ id: "security-baseline-sync" }));
+  });
+
+  it("reports unavailable code scanning as unverified instead of aborting planning", async () => {
+    const manifest = normalizeManifest({
+      project: { name: "example", owner: "acme", visibility: "public" },
+      archetype: { kind: "node-ts-service" }
+    });
+    const client = {
+      isAvailable: async () => true,
+      isAuthenticated: async () => true,
+      tryApi: async (method: string, endpoint: string) => {
+        if (endpoint === "/repos/acme/example") {
+          return { name: "example", full_name: "acme/example", private: false, visibility: "public" };
+        }
+        if (endpoint.includes("/code-scanning/analyses?")) {
+          throw new Error("gh: GitHub Advanced Security must be enabled (HTTP 403)");
+        }
+        return undefined;
+      },
+      api: async (method: string, endpoint: string) => {
+        if (endpoint === "/users/acme") return { login: "acme", type: "Organization" };
+        return {};
+      }
+    };
+
+    const actions = await planGitHub(manifest, client as never);
+
+    expect(actions).toContainEqual(expect.objectContaining({
+      id: "security-baseline-unverified",
+      description: expect.stringContaining("code scanning is unavailable on the current plan")
+    }));
+  });
+
+  it("fails closed on ambiguous security planning authorization and validation errors", async () => {
+    const manifest = normalizeManifest({
+      project: { name: "example", owner: "acme", visibility: "public" },
+      archetype: { kind: "node-ts-service" }
+    });
+    const baseClient = {
+      isAvailable: async () => true,
+      isAuthenticated: async () => true,
+      api: async (method: string, endpoint: string) => endpoint === "/users/acme"
+        ? { login: "acme", type: "Organization" }
+        : {}
+    };
+    const repo = { name: "example", full_name: "acme/example", private: false, visibility: "public" };
+
+    await expect(planGitHub(manifest, {
+      ...baseClient,
+      tryApi: async (method: string, endpoint: string) => {
+        if (endpoint === "/repos/acme/example") return repo;
+        if (endpoint.includes("/code-scanning/analyses?")) {
+          throw new Error("gh: Resource not accessible by integration (HTTP 403)");
+        }
+        return undefined;
+      }
+    } as never)).rejects.toThrow("Resource not accessible");
+
+    await expect(planGitHub(manifest, {
+      ...baseClient,
+      tryApi: async (method: string, endpoint: string) => {
+        if (endpoint === "/repos/acme/example") return repo;
+        if (endpoint === "/repos/acme/example/private-vulnerability-reporting") {
+          throw new Error("gh: Validation Failed (HTTP 422)");
+        }
+        return undefined;
+      }
+    } as never)).rejects.toThrow("Validation Failed");
+  });
+
+  it("applies public security controls and reports unsupported capabilities distinctly", async () => {
+    const manifest = normalizeManifest({
+      project: { name: "example", owner: "acme", visibility: "public" },
+      archetype: { kind: "node-ts-service" },
+      github: { createRepo: false }
+    });
+    const calls: Array<{ method: string; endpoint: string; payload?: unknown }> = [];
+    const client = {
+      isAvailable: async () => true,
+      isAuthenticated: async () => true,
+      tryApi: async (method: string, endpoint: string) => {
+        if (endpoint === "/repos/acme/example") {
+          return { id: 42, name: "example", full_name: "acme/example", private: false, visibility: "public" };
+        }
+        if (endpoint.startsWith("/repos/acme/example/labels/")) return undefined;
+        return undefined;
+      },
+      api: async (method: string, endpoint: string, payload?: unknown) => {
+        calls.push({ method, endpoint, payload });
+        if (endpoint === "/users/acme") return { login: "acme", type: "Organization" };
+        if (endpoint === "/repos/acme/example/private-vulnerability-reporting" && method === "PUT") {
+          throw new Error("gh: private vulnerability reporting is not available for this plan (HTTP 422)");
+        }
+        return {};
+      }
+    };
+
+    const actions = await applyGitHub(manifest, client as never);
+
+    expect(calls).toContainEqual(expect.objectContaining({
+      method: "PATCH",
+      endpoint: "/repos/acme/example",
+      payload: expect.objectContaining({
+        security_and_analysis: expect.objectContaining({
+          secret_scanning: { status: "enabled" },
+          secret_scanning_push_protection: { status: "enabled" }
+        })
+      })
+    }));
+    const securityPatch = calls.find((call) =>
+      call.method === "PATCH" && call.endpoint === "/repos/acme/example" &&
+      call.payload && typeof call.payload === "object" && "security_and_analysis" in call.payload
+    );
+    expect(securityPatch?.payload).not.toHaveProperty("security_and_analysis.dependabot_security_updates");
+    expect(calls).toContainEqual(expect.objectContaining({ method: "PUT", endpoint: "/repos/acme/example/vulnerability-alerts" }));
+    expect(calls).toContainEqual(expect.objectContaining({ method: "PUT", endpoint: "/repos/acme/example/automated-security-fixes" }));
+    expect(calls).toContainEqual(expect.objectContaining({
+      method: "POST",
+      endpoint: "/repos/acme/example/actions/variables",
+      payload: { name: "DEPENDENCY_REVIEW_ENABLED", value: "true" }
+    }));
+    expect(actions.map((action) => action.id)).toContain("security-private-reporting-unsupported");
+    expect(actions.find((action) => action.id === "security-private-reporting-unsupported")?.description).toContain("remediation");
+  });
+
+  it("fails closed on ambiguous GitHub security authorization or validation errors", async () => {
+    const manifest = normalizeManifest({
+      project: { name: "example", owner: "acme", visibility: "public" },
+      archetype: { kind: "node-ts-service" },
+      github: { createRepo: false }
+    });
+    const client = {
+      isAvailable: async () => true,
+      isAuthenticated: async () => true,
+      tryApi: async (method: string, endpoint: string) => endpoint === "/repos/acme/example"
+        ? { name: "example", full_name: "acme/example", private: false, visibility: "public" }
+        : undefined,
+      api: async (method: string, endpoint: string, payload?: unknown) => {
+        if (endpoint === "/users/acme") return { login: "acme", type: "Organization" };
+        if (endpoint === "/repos/acme/example" && method === "PATCH" && payload && typeof payload === "object" && "security_and_analysis" in payload) {
+          throw new Error("gh: Validation Failed (HTTP 422)");
+        }
+        return {};
+      }
+    };
+
+    await expect(applyGitHub(manifest, client as never)).rejects.toThrow("Validation Failed");
+  });
+
   it("defaults GitHub review protection to require approval from someone other than the last pusher", () => {
     const manifest = normalizeManifest({
       project: {

--- a/tests/manifest.test.ts
+++ b/tests/manifest.test.ts
@@ -810,4 +810,22 @@ describe("normalizeManifest", () => {
       }
     });
   });
+
+  it("rejects CodeQL languages that require a compiled build contract", () => {
+    expect(() => normalizeManifest({
+      project: { name: "go-service", owner: "acme", visibility: "public" },
+      archetype: { kind: "generic-empty" },
+      ci: { codeqlLanguages: ["go"] }
+    } as never)).toThrow();
+  });
+
+  it("accepts compiled CodeQL languages supported by no-build analysis", () => {
+    const manifest = normalizeManifest({
+      project: { name: "compiled-service", owner: "acme", visibility: "public" },
+      archetype: { kind: "generic-empty" },
+      ci: { codeqlLanguages: ["c-cpp", "csharp", "rust"] }
+    });
+
+    expect(manifest.ci.codeqlLanguages).toEqual(["c-cpp", "csharp", "rust"]);
+  });
 });

--- a/tests/render.test.ts
+++ b/tests/render.test.ts
@@ -219,6 +219,7 @@ describe("renderManagedFiles", () => {
   it("projects SECURITY.md for public repositories unless explicitly disabled", () => {
     const publicManifest = normalizeManifest({
       project: { name: "public-policy", owner: "acme", visibility: "public" },
+      ci: { codeqlLanguages: ["javascript-typescript"] },
       archetype: { kind: "generic-empty" }
     });
     expect(renderManagedFiles(publicManifest).some((file) => file.path === "SECURITY.md")).toBe(true);
@@ -226,6 +227,7 @@ describe("renderManagedFiles", () => {
     const optedOutManifest = normalizeManifest({
       project: { name: "public-policy", owner: "acme", visibility: "public" },
       repo: { docs: { security: false } },
+      ci: { codeqlLanguages: ["javascript-typescript"] },
       archetype: { kind: "generic-empty" }
     });
     expect(renderManagedFiles(optedOutManifest).some((file) => file.path === "SECURITY.md")).toBe(false);
@@ -235,11 +237,75 @@ describe("renderManagedFiles", () => {
     const manifest = normalizeManifest({
       project: { name: "partial-docs-policy", owner: "acme", visibility: "public" },
       repo: { docs: { readme: true } },
+      ci: { codeqlLanguages: ["javascript-typescript"] },
       archetype: { kind: "generic-empty" }
     });
 
     expect(manifest.repo.docs).toEqual({ readme: true, contributing: true });
     expect(renderManagedFiles(manifest).some((file) => file.path === "SECURITY.md")).toBe(true);
+  });
+
+  it("requires explicit CodeQL languages for public generic repositories", () => {
+    const manifest = normalizeManifest({
+      project: { name: "polyglot", owner: "acme", visibility: "public" },
+      archetype: { kind: "generic-empty" }
+    });
+
+    expect(() => renderManagedFiles(manifest)).toThrow("configure ci.codeqlLanguages");
+  });
+
+  it("projects a pinned, fork-safe public security workflow and response model", () => {
+    const manifest = normalizeManifest({
+      project: { name: "public-security", owner: "acme", visibility: "public" },
+      archetype: { kind: "node-ts-service" }
+    });
+    const files = renderManagedFiles(manifest);
+    const workflow = files.find((file) => file.path === ".github/workflows/security.yml");
+    const policy = files.find((file) => file.path === "SECURITY.md");
+    const model = files.find((file) => file.path === "docs/bootstrap/security.md");
+
+    expect(workflow).toBeDefined();
+    expect(parseDocument(workflow?.contents ?? "").errors).toEqual([]);
+    expect(workflow?.contents).toContain("pull_request:");
+    expect(workflow?.contents).not.toContain("pull_request_target");
+    expect(workflow?.contents).toContain("permissions:\n  contents: read");
+    expect(workflow?.contents).toContain("if: github.event_name == 'pull_request' && vars.DEPENDENCY_REVIEW_ENABLED == 'true'\n    runs-on: ubuntu-latest");
+    expect(workflow?.contents).toContain("dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0");
+    expect(workflow?.contents).toContain("codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a # v4");
+    expect(workflow?.contents).toContain('language: ["javascript-typescript"]');
+    expect(workflow?.contents).toContain("languages: ${{ matrix.language }}\n          build-mode: none");
+    expect(workflow?.contents).toContain('category: "/language:${{ matrix.language }}"');
+    expect(workflow?.contents).toContain("anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0");
+    expect(workflow?.contents).toContain("if: github.event_name == 'push' || github.event_name == 'schedule'");
+    expect(workflow?.contents).not.toContain("workflow_dispatch");
+    expect(workflow?.contents).not.toContain("secrets.");
+    expect(policy?.contents).toContain("/security/advisories/new");
+    expect(policy?.contents).toContain("Private security contact requested");
+    expect(policy?.contents).toContain("3 business days");
+    expect(policy?.contents).toContain("10 business days");
+    expect(model?.contents).toContain("Pull requests, including forks, are untrusted input");
+    expect(model?.contents).toContain("GitHub-hosted isolation");
+    expect(model?.contents).toContain("private-vulnerability-reporting");
+
+    expect(workflow?.contents).toContain("sbom:\n    if: github.event_name == 'push' || github.event_name == 'schedule'\n    runs-on: ubuntu-latest\n    permissions:\n      contents: write");
+  });
+
+  it("quotes the default branch in the public security workflow", () => {
+    const manifest = normalizeManifest({
+      project: {
+        name: "public-security",
+        owner: "acme",
+        visibility: "public",
+        defaultBranch: "release,2026"
+      },
+      archetype: { kind: "node-ts-service" }
+    });
+    const workflow = renderManagedFiles(manifest).find((file) => file.path === ".github/workflows/security.yml");
+
+    expect(workflow?.contents).toContain('branches: ["release,2026"]');
+    expect(parseDocument(workflow?.contents ?? "").toJS()).toMatchObject({
+      on: { push: { branches: ["release,2026"] } }
+    });
   });
 
   it("renders version 2 docs, templates, environment, and workflow switches", () => {
@@ -285,6 +351,7 @@ describe("renderManagedFiles", () => {
       },
       ci: {
         policy: "experimental",
+        codeqlLanguages: ["python"],
         workflows: {
           prFastCi: true,
           extendedValidation: false,

--- a/tests/smoke.test.ts
+++ b/tests/smoke.test.ts
@@ -277,6 +277,7 @@ describe("repo smoke", () => {
         fastChecks: ["secrets", "unit-tests"],
         extendedChecks: ["template-review", "fixture-regression"],
         nightlyCron: "0 7 * * *",
+        codeqlLanguages: ["python"],
         workflows: {
           prFastCi: true,
           extendedValidation: true,


### PR DESCRIPTION
## Summary

- Project a pinned, fork-safe public security workflow: dependency review is pull-request-only, while per-language CodeQL and SPDX JSON SBOM jobs run only on trusted events using GitHub-hosted isolation.
- Generate the public security policy, response targets, operating model, and accepted ADR, including a detail-free fallback for requesting a confidential reporting channel.
- Plan and apply dependency alerts, security updates, secret scanning, push protection, private reporting, and exact CodeQL evidence while distinguishing explicit plan limits from fail-closed authorization or validation errors.

This is the projection and provisioning slice of issue #60. Deterministic conformance validation will follow in a dependent PR.

## Governing Issue

Refs #60

## Validation

- [x] Relevant local checks passed
- [x] Agent-authored changes passed `autoreview` against the intended PR diff with no accepted/actionable findings
- Autoreview command and result: `/Users/johnteneyckjr./.codex/skills/autoreview/scripts/autoreview --mode commit --engine codex --model gpt-5.6-terra --thinking high --no-web-search --stream-engine-output --parallel-tests 'TMPDIR=/tmp npm run check' --json-output /private/tmp/bootstrap-60-projection-autoreview-commit.json` — clean at `5122f457f236b92a94142d867f76a7b905105b09`, no actionable findings, confidence 0.91; 182 tests passed in parallel.
- [x] Required PR checks are expected to satisfy `CI Gate`
- [x] Skipped checks are explained below

Additional verification:

- `npm run check` — 23 files, 182 tests passed.
- `npm run build` — passed.
- `bash scripts/ci/check-action-pins.sh` — passed; 42 immutable third-party action references validated in the tracked workflows.
- `git diff --check` — passed.

## Bootstrap Governance

- [x] Changes are scoped to the linked issue
- [x] Contributor or PR guidance changes are reflected in `CONTRIBUTING.md`, `.github/PULL_REQUEST_TEMPLATE.md`, and `docs/bootstrap/onboarding.md` when applicable
- [x] PR author enabled auto-merge where GitHub allows it, or GitHub plan-limit evidence/unavailable reason is recorded and the fallback merge-readiness policy applies
- [x] No real secrets, runtime auth, or machine-local env files are committed

Material change: yes
ADR: docs/decisions/ADR-0005-public-repository-security-baseline.md

## Merge Automation

- [x] PR author enabled auto-merge with `gh pr merge --auto --squash`, or the reason it is unavailable/unsafe is noted below

## Notes

- Public security jobs use GitHub-hosted isolation. The earlier self-hosted activation path was removed because repository projection cannot prove the remote runner authorization boundary first.
- Dependency review remains skipped until GitHub provisioning enables dependency alerts and sets `DEPENDENCY_REVIEW_ENABLED=true`; this PR does not mutate live repository settings.
- GitHub API capability exceptions are endpoint-specific. Ambiguous authorization and validation failures remain hard errors.
- The PR is intentionally below the 800-line governance threshold after excluding documentation and tests; issue #60 remains open for the conformance slice.
