### PR TITLE
feat: validate public security baseline

### DIFF
--- a/docs/bootstrap/conformance.md
+++ b/docs/bootstrap/conformance.md
@@ -26,6 +26,13 @@ sensitive, and pass the versioned JSON snapshot to conformance.
   "schemaVersion": 1,
   "observations": [
     {
+      "control": "dependency-graph",
+      "status": "supported",
+      "evidence": "enabled",
+      "remediation": "Keep the dependency graph and pull-request review enabled.",
+      "dependencyReviewEnabled": true
+    },
+    {
       "control": "secret-scanning",
       "status": "supported",
       "evidence": "enabled",
@@ -40,6 +47,10 @@ sensitive, and pass the versioned JSON snapshot to conformance.
   ]
 }
 ```
+
+Set `dependencyReviewEnabled: true` only when the authorized inspection also
+verifies the repository variable `DEPENDENCY_REVIEW_ENABLED=true`. A supported
+dependency graph without that typed activation evidence remains `unverified`.
 
 ```sh
 bootstrap conform \
@@ -63,12 +74,23 @@ An exception changes a governed deviation to severity `pass` and classification
 | Required managed artifacts | `repository-files` | `repo.managed-artifacts` |
 | Action and reusable-workflow pins | `supply-chain` | `github.workflows.actions` |
 | Language-profile conflict | `language-profile` | `repo.profile` |
+| Public security projection and fork safety | `security-baseline` | `repo.security` |
 | GitHub capability observation | `github-capability` | `github.<control>` |
 
 Repository classification retains its existing target:
 `repository-classification` / `repo.class`. Exception-validation results report
 whether the exception record itself is conformant; they are not labeled as a
 waiver unless they are applied to a matching control.
+
+Public security jobs require GitHub-hosted isolation. CodeQL conformance also
+requires a per-language matrix and matching analysis categories so remote
+planning can verify a successful default-branch result for every configured
+language.
+
+The managed public security workflow rejects every `secrets` context reference,
+including references in trusted-only jobs. Its CodeQL and SBOM contracts need no
+external credential, and the strict ban prevents later event or condition drift
+from exposing a dormant secret reference to pull-request execution.
 
 Pinned action and Docker references retain a safe, single-line readable version
 or release label. This label may use non-SemVer identifiers such as `bookworm`,

--- a/docs/bootstrap/security.md
+++ b/docs/bootstrap/security.md
@@ -8,7 +8,7 @@
 
 ## Required Controls
 
-- Dependency graph, Dependabot alerts and security updates, secret scanning, push protection, code scanning, and private vulnerability reporting are required capability observations for public repositories. Dependency review stays skipped until provisioning enables its prerequisite and activation variable.
+- Dependency graph, Dependabot alerts and security updates, secret scanning, push protection, code scanning, and private vulnerability reporting are required capability observations for public repositories. The dependency-graph observation must also record `dependencyReviewEnabled: true` after provisioning verifies `DEPENDENCY_REVIEW_ENABLED=true`.
 - `.github/dependabot.yml` keeps both dependency and GitHub Actions pins updateable.
 - `.github/workflows/security.yml` performs dependency review, CodeQL analysis for `javascript-typescript`, and SPDX JSON SBOM generation using immutable action SHAs.
 - `SECURITY.md` directs reporters to a private advisory and defines acknowledgement, update, remediation, and coordinated-disclosure targets.
@@ -19,4 +19,4 @@ The security workflow uses `pull_request`, never `pull_request_target`. Its top-
 
 ## Capability Evidence
 
-Capture authorized observations for these controls and pass them to `bootstrap conform --github-capabilities <path>`: `dependency-graph`, `dependabot-alerts`, `dependabot-security-updates`, `secret-scanning`, `push-protection`, `code-scanning`, and `private-vulnerability-reporting`. Unsupported controls remain warnings with remediation; available but disabled controls are blocking misconfigurations. Current typed exceptions may waive only their matching `github.<control>` scope.
+Capture authorized observations for these controls and pass them to `bootstrap conform --github-capabilities <path>`: `dependency-graph`, `dependabot-alerts`, `dependabot-security-updates`, `secret-scanning`, `push-protection`, `code-scanning`, and `private-vulnerability-reporting`. Record `dependencyReviewEnabled: true` only after verifying the repository activation variable. Unsupported controls remain warnings with remediation; available but disabled controls are blocking misconfigurations. Current typed exceptions may waive only their matching `github.<control>` scope.

--- a/docs/decisions/ADR-0005-public-repository-security-baseline.md
+++ b/docs/decisions/ADR-0005-public-repository-security-baseline.md
@@ -25,7 +25,7 @@ Every public repository receives these Bootstrap-managed surfaces:
 
 All third-party actions remain pinned to immutable commits with readable release metadata. The public security workflow uses read-only top-level permissions and contains no secret references. Every job uses GitHub-hosted isolation. Jobs that require `security-events: write` or `contents: write` are explicitly unreachable from pull requests.
 
-Conformance adds stable local baseline and fork-safety rules. It also expects authorized observations for dependency graph, Dependabot alerts and security updates, secret scanning, push protection, code scanning, and private vulnerability reporting. A missing observation is `unverified`, an unsupported plan capability is `unsupported`, and an available but disabled capability is `misconfigured`. Only a current typed exception matching `security-baseline` / `repo.security` or `github-capability` / `github.<control>` can waive the corresponding deviation.
+Conformance adds stable local baseline and fork-safety rules. It also expects authorized observations for dependency graph, Dependabot alerts and security updates, secret scanning, push protection, code scanning, and private vulnerability reporting. A supported dependency-graph observation must separately record `dependencyReviewEnabled: true` after verifying the activation variable; absence remains `unverified` and `false` is `misconfigured`. A missing observation is `unverified`, an unsupported plan capability is `unsupported`, and an available but disabled capability is `misconfigured`. Only a current typed exception matching `security-baseline` / `repo.security` or `github-capability` / `github.<control>` can waive the corresponding deviation.
 
 ## Consequences
 

--- a/src/archetypes.ts
+++ b/src/archetypes.ts
@@ -3187,7 +3187,7 @@ function securityModelDoc(manifest: BootstrapManifest): string {
 
     ## Required Controls
 
-    - Dependency graph, Dependabot alerts and security updates, secret scanning, push protection, code scanning, and private vulnerability reporting are required capability observations for public repositories. Dependency review stays skipped until provisioning enables its prerequisite and activation variable.
+    - Dependency graph, Dependabot alerts and security updates, secret scanning, push protection, code scanning, and private vulnerability reporting are required capability observations for public repositories. The dependency-graph observation must also record \`dependencyReviewEnabled: true\` after provisioning verifies \`DEPENDENCY_REVIEW_ENABLED=true\`.
     - \`.github/dependabot.yml\` keeps both dependency and GitHub Actions pins updateable.
     - \`.github/workflows/security.yml\` performs dependency review, CodeQL analysis for \`${codeQlLanguages(manifest)}\`, and SPDX JSON SBOM generation using immutable action SHAs.
     - \`SECURITY.md\` directs reporters to a private advisory and defines acknowledgement, update, remediation, and coordinated-disclosure targets.
@@ -3198,7 +3198,7 @@ function securityModelDoc(manifest: BootstrapManifest): string {
 
     ## Capability Evidence
 
-    Capture authorized observations for these controls and pass them to \`bootstrap conform --github-capabilities <path>\`: \`dependency-graph\`, \`dependabot-alerts\`, \`dependabot-security-updates\`, \`secret-scanning\`, \`push-protection\`, \`code-scanning\`, and \`private-vulnerability-reporting\`. Unsupported controls remain warnings with remediation; available but disabled controls are blocking misconfigurations. Current typed exceptions may waive only their matching \`github.<control>\` scope.
+    Capture authorized observations for these controls and pass them to \`bootstrap conform --github-capabilities <path>\`: \`dependency-graph\`, \`dependabot-alerts\`, \`dependabot-security-updates\`, \`secret-scanning\`, \`push-protection\`, \`code-scanning\`, and \`private-vulnerability-reporting\`. Record \`dependencyReviewEnabled: true\` only after verifying the repository activation variable. Unsupported controls remain warnings with remediation; available but disabled controls are blocking misconfigurations. Current typed exceptions may waive only their matching \`github.<control>\` scope.
   `;
 }
 

--- a/src/conformance.ts
+++ b/src/conformance.ts
@@ -40,13 +40,21 @@ export const githubCapabilitySnapshotSchema = z.object({
     control: z.string().regex(/^[a-z][a-z0-9-]*$/),
     status: z.enum(["supported", "unsupported", "misconfigured"]),
     evidence: capabilityReportTextSchema,
-    remediation: capabilityReportTextSchema
+    remediation: capabilityReportTextSchema,
+    dependencyReviewEnabled: z.boolean().optional()
   }))
 }).superRefine((snapshot, context) => {
   const seen = new Set<string>();
   snapshot.observations.forEach((observation, index) => {
     if (seen.has(observation.control)) {
       context.addIssue({ code: "custom", path: ["observations", index, "control"], message: `Duplicate capability observation: ${observation.control}` });
+    }
+    if (observation.dependencyReviewEnabled !== undefined && observation.control !== "dependency-graph") {
+      context.addIssue({
+        code: "custom",
+        path: ["observations", index, "dependencyReviewEnabled"],
+        message: "dependencyReviewEnabled is valid only for the dependency-graph observation."
+      });
     }
     seen.add(observation.control);
   });
@@ -70,8 +78,22 @@ export interface ConformanceOptions {
 const waiverTargets = {
   requiredFiles: { policy: "repository-files", scope: "repo.managed-artifacts" },
   actionPins: { policy: "supply-chain", scope: "github.workflows.actions" },
-  languageProfile: { policy: "language-profile", scope: "repo.profile" }
+  languageProfile: { policy: "language-profile", scope: "repo.profile" },
+  securityBaseline: { policy: "security-baseline", scope: "repo.security" }
 } as const;
+
+const publicSecurityCapabilityControls = [
+  "code-scanning",
+  "dependabot-alerts",
+  "dependabot-security-updates",
+  "dependency-graph",
+  "private-vulnerability-reporting",
+  "push-protection",
+  "secret-scanning"
+] as const;
+
+const trustedSecurityJobCondition = "github.event_name == 'push' || github.event_name == 'schedule'";
+const dependencyReviewJobCondition = "github.event_name == 'pull_request' && vars.DEPENDENCY_REVIEW_ENABLED == 'true'";
 
 function result(
   ruleId: string,
@@ -228,6 +250,603 @@ function validReleaseMetadata(value: string | undefined): boolean {
   return /[A-Za-z0-9]/.test(normalized);
 }
 
+function dependabotUpdatesActions(contents: string): boolean {
+  const document = parseDocument(contents, { prettyErrors: false });
+  if (document.errors.length > 0) return false;
+  const version = resolveYamlNode(
+    yamlMappingEntry(asYamlNode(document.contents), "version", document)?.valueNode,
+    document
+  );
+  if (!isScalar(version) || version.value !== 2) return false;
+  const updates = resolveYamlNode(
+    yamlMappingEntry(asYamlNode(document.contents), "updates", document)?.valueNode,
+    document
+  );
+  if (!isSeq(updates)) return false;
+  return updates.items.some((rawUpdate) => {
+    const update = resolveYamlNode(asYamlNode(rawUpdate), document);
+    if (!isMap(update)) return false;
+    const ecosystem = resolveYamlNode(yamlMappingEntry(update, "package-ecosystem", document)?.valueNode, document);
+    if (!isScalar(ecosystem) || ecosystem.value !== "github-actions") return false;
+    const directory = resolveYamlNode(yamlMappingEntry(update, "directory", document)?.valueNode, document);
+    const schedule = resolveYamlNode(yamlMappingEntry(update, "schedule", document)?.valueNode, document);
+    const interval = isMap(schedule)
+      ? resolveYamlNode(yamlMappingEntry(schedule, "interval", document)?.valueNode, document)
+      : undefined;
+    const limitEntry = yamlMappingEntry(update, "open-pull-requests-limit", document);
+    const limit = resolveYamlNode(limitEntry?.valueNode, document);
+    const enabledLimit = limitEntry === undefined ||
+      (isScalar(limit) && typeof limit.value === "number" && Number.isSafeInteger(limit.value) && limit.value > 0);
+    return enabledLimit &&
+      isScalar(directory) && directory.value === "/" &&
+      isScalar(interval) && typeof interval.value === "string" && ["daily", "weekly", "monthly"].includes(interval.value);
+  });
+}
+
+function mappingPermissionsAreReadOnly(map: Node | null | undefined, document: Document): boolean {
+  const resolved = resolveYamlNode(map, document);
+  if (isScalar(resolved) && resolved.value === "read-all") return true;
+  if (!isMap(resolved)) return false;
+  let hasContentsRead = false;
+  for (const pair of resolved.items) {
+    const key = resolveYamlNode(asYamlNode(pair.key), document);
+    const value = resolveYamlNode(asYamlNode(pair.value), document);
+    if (!isScalar(key) || typeof key.value !== "string" || !isScalar(value) || typeof value.value !== "string") {
+      return false;
+    }
+    if (key.value === "contents" && value.value === "read") hasContentsRead = true;
+    if (value.value !== "read" && value.value !== "none") return false;
+  }
+  return hasContentsRead;
+}
+
+function jobCondition(jobs: Node | null | undefined, jobName: string, document: Document): string | undefined {
+  const job = resolveYamlNode(yamlMappingEntry(jobs, jobName, document)?.valueNode, document);
+  if (!isMap(job)) return undefined;
+  const condition = resolveYamlNode(yamlMappingEntry(job, "if", document)?.valueNode, document);
+  return isScalar(condition) && typeof condition.value === "string" ? condition.value : undefined;
+}
+
+function jobNode(jobs: Node | null | undefined, jobName: string, document: Document): Node | null | undefined {
+  return resolveYamlNode(yamlMappingEntry(jobs, jobName, document)?.valueNode, document);
+}
+
+function jobField(jobs: Node | null | undefined, jobName: string, field: string, document: Document): Node | null | undefined {
+  const job = jobNode(jobs, jobName, document);
+  return isMap(job) ? resolveYamlNode(yamlMappingEntry(job, field, document)?.valueNode, document) : undefined;
+}
+
+function jobHasExactActionSequence(
+  jobs: Node | null | undefined,
+  jobName: string,
+  actions: Array<{ prefix: string; requiredInputs?: string[]; optionalInputs?: string[] }>,
+  document: Document
+): boolean {
+  const steps = jobField(jobs, jobName, "steps", document);
+  if (!isSeq(steps) || steps.items.length !== actions.length) return false;
+  for (const [index, rawStep] of steps.items.entries()) {
+    const step = resolveYamlNode(asYamlNode(rawStep), document);
+    if (!isMap(step)) return false;
+    const allowedKeys = new Set(["name", "uses", "with"]);
+    for (const pair of step.items) {
+      const key = resolveYamlNode(asYamlNode(pair.key), document);
+      if (!isScalar(key) || typeof key.value !== "string" || !allowedKeys.has(key.value)) return false;
+    }
+    const uses = resolveYamlNode(yamlMappingEntry(step, "uses", document)?.valueNode, document);
+    const action = actions[index];
+    if (!action || !isScalar(uses) || typeof uses.value !== "string" || !uses.value.startsWith(action.prefix)) return false;
+    const requiredInputs = new Set(action.requiredInputs ?? []);
+    const allowedInputs = new Set([...requiredInputs, ...(action.optionalInputs ?? [])]);
+    const withEntry = yamlMappingEntry(step, "with", document);
+    if (allowedInputs.size === 0) {
+      if (withEntry) return false;
+      continue;
+    }
+    const withMap = resolveYamlNode(withEntry?.valueNode, document);
+    if (!isMap(withMap)) return false;
+    const actualInputs = new Set<string>();
+    for (const pair of withMap.items) {
+      const key = resolveYamlNode(asYamlNode(pair.key), document);
+      if (!isScalar(key) || typeof key.value !== "string" || !allowedInputs.has(key.value)) return false;
+      actualInputs.add(key.value);
+    }
+    if ([...requiredInputs].some((input) => !actualInputs.has(input))) return false;
+  }
+  return true;
+}
+
+function jobActionField(
+  jobs: Node | null | undefined,
+  jobName: string,
+  actionPrefix: string,
+  field: string,
+  document: Document
+): unknown {
+  const steps = jobField(jobs, jobName, "steps", document);
+  if (!isSeq(steps)) return undefined;
+  for (const rawStep of steps.items) {
+    const step = resolveYamlNode(asYamlNode(rawStep), document);
+    if (!isMap(step) || yamlMappingEntry(step, "if", document)) continue;
+    const uses = resolveYamlNode(yamlMappingEntry(step, "uses", document)?.valueNode, document);
+    if (!isScalar(uses) || typeof uses.value !== "string" || !uses.value.startsWith(actionPrefix)) continue;
+    const withMap = resolveYamlNode(yamlMappingEntry(step, "with", document)?.valueNode, document);
+    const value = isMap(withMap)
+      ? resolveYamlNode(yamlMappingEntry(withMap, field, document)?.valueNode, document)
+      : undefined;
+    return isScalar(value) ? value.value : undefined;
+  }
+  return undefined;
+}
+
+function yamlStringSequenceIncludes(node: Node | null | undefined, expected: string, document: Document): boolean {
+  const resolved = resolveYamlNode(node, document);
+  if (isScalar(resolved)) return resolved.value === expected;
+  if (!isSeq(resolved)) return false;
+  return resolved.items.some((item) => {
+    const value = resolveYamlNode(asYamlNode(item), document);
+    return isScalar(value) && value.value === expected;
+  });
+}
+
+function cronFieldValues(field: string, minimum: number, maximum: number, names?: string[]): Set<number> | undefined {
+  const values = new Set<number>();
+  const numericValue = (raw: string | undefined): number | undefined => {
+    if (raw === undefined) return undefined;
+    if (/^\d+$/.test(raw)) return Number(raw);
+    const namedIndex = names?.indexOf(raw.toUpperCase()) ?? -1;
+    return namedIndex >= 0 ? minimum + namedIndex : undefined;
+  };
+  for (const component of field.split(",")) {
+    const segments = component.split("/");
+    if (segments.length > 2) return undefined;
+    const base = segments[0] ?? "";
+    const stepText = segments[1];
+    if (base.length === 0) return undefined;
+    if (stepText !== undefined && (!/^\d+$/.test(stepText) || Number(stepText) < 1 || Number(stepText) > maximum - minimum + 1)) {
+      return undefined;
+    }
+    const step = stepText === undefined ? 1 : Number(stepText);
+    let start: number;
+    let end: number;
+    if (base === "*") {
+      start = minimum;
+      end = maximum;
+    } else {
+      const range = base.match(/^([A-Za-z]+|\d+)(?:-([A-Za-z]+|\d+))?$/);
+      if (!range) return undefined;
+      const parsedStart = numericValue(range[1]);
+      const parsedEnd = range[2] === undefined
+        ? stepText === undefined ? parsedStart : maximum
+        : numericValue(range[2]);
+      if (parsedStart === undefined || parsedEnd === undefined) return undefined;
+      start = parsedStart;
+      end = parsedEnd;
+    }
+    if (start < minimum || end > maximum || start > end) return undefined;
+    for (let value = start; value <= end; value += step) values.add(value);
+  }
+  return values.size > 0 ? values : undefined;
+}
+
+function validGitHubCron(value: string): boolean {
+  const fields = value.trim().split(/\s+/);
+  if (fields.length !== 5) return false;
+  const ranges = [[0, 59], [0, 23], [1, 31], [1, 12], [0, 7]] as const;
+  const names: Array<string[] | undefined> = [
+    undefined,
+    undefined,
+    undefined,
+    ["JAN", "FEB", "MAR", "APR", "MAY", "JUN", "JUL", "AUG", "SEP", "OCT", "NOV", "DEC"],
+    ["SUN", "MON", "TUE", "WED", "THU", "FRI", "SAT"]
+  ];
+  const expanded = fields.map((field, index) => {
+    const range = ranges[index];
+    return range === undefined ? undefined : cronFieldValues(field, range[0], range[1], names[index]);
+  });
+  if (expanded.some((values) => values === undefined)) return false;
+  const months = expanded[3] as Set<number>;
+  const hours = expanded[1] as Set<number>;
+  const minutes = expanded[0] as Set<number>;
+  const daysOfMonth = expanded[2] as Set<number>;
+  const daysOfWeek = new Set([...(expanded[4] as Set<number>)].map((day) => day === 7 ? 0 : day));
+  const dailyMinutes = [...hours]
+    .flatMap((hour) => [...minutes].map((minute) => hour * 60 + minute))
+    .sort((left, right) => left - right);
+  const firstDailyMinute = dailyMinutes[0];
+  if (firstDailyMinute === undefined) return false;
+  for (let index = 0; index < dailyMinutes.length; index += 1) {
+    const current = dailyMinutes[index];
+    const next = dailyMinutes[index + 1] ?? firstDailyMinute + 24 * 60;
+    if (current === undefined || next - current < 5) return false;
+  }
+  const dayOfMonthWildcard = fields[2] === "*";
+  const dayOfWeekWildcard = fields[4] === "*";
+  for (let year = 2000; year < 2400; year += 1) {
+    for (const month of months) {
+      const daysInMonth = new Date(Date.UTC(year, month, 0)).getUTCDate();
+      for (let day = 1; day <= daysInMonth; day += 1) {
+        const dayOfWeek = new Date(Date.UTC(year, month - 1, day)).getUTCDay();
+        const dayMatches = daysOfMonth.has(day);
+        const weekMatches = daysOfWeek.has(dayOfWeek);
+        if ((dayOfMonthWildcard && dayOfWeekWildcard) ||
+          (dayOfMonthWildcard && weekMatches) ||
+          (dayOfWeekWildcard && dayMatches) ||
+          (!dayOfMonthWildcard && !dayOfWeekWildcard && (dayMatches || weekMatches))) {
+          return true;
+        }
+      }
+    }
+  }
+  return false;
+}
+
+function hasRunnableSchedule(events: Node | null | undefined, document: Document): boolean {
+  const schedule = resolveYamlNode(yamlMappingEntry(events, "schedule", document)?.valueNode, document);
+  if (!isSeq(schedule) || schedule.items.length === 0) return false;
+  return schedule.items.every((rawEntry) => {
+    const entry = resolveYamlNode(asYamlNode(rawEntry), document);
+    if (!isMap(entry)) return false;
+    const cron = resolveYamlNode(yamlMappingEntry(entry, "cron", document)?.valueNode, document);
+    const timezoneEntry = yamlMappingEntry(entry, "timezone", document);
+    const timezone = resolveYamlNode(timezoneEntry?.valueNode, document);
+    if (timezoneEntry) {
+      if (!isScalar(timezone) || typeof timezone.value !== "string") return false;
+      try {
+        new Intl.DateTimeFormat("en-US", { timeZone: timezone.value }).format();
+      } catch {
+        return false;
+      }
+    }
+    return isScalar(cron) && typeof cron.value === "string" && validGitHubCron(cron.value);
+  });
+}
+
+function hasUnfilteredEvent(events: Node | null | undefined, eventName: string, document: Document): boolean {
+  const event = yamlMappingEntry(events, eventName, document);
+  if (!event) return false;
+  const value = resolveYamlNode(event.valueNode, document);
+  return value === undefined || value === null ||
+    (isScalar(value) && value.value === null) ||
+    (isMap(value) && value.items.length === 0);
+}
+
+function jobRunsOnGitHubHosted(jobs: Node | null | undefined, jobName: string, document: Document): boolean {
+  const runsOn = jobField(jobs, jobName, "runs-on", document);
+  return isScalar(runsOn) && typeof runsOn.value === "string" &&
+    new Set(["ubuntu-latest", "ubuntu-24.04", "ubuntu-22.04"]).has(runsOn.value);
+}
+
+function yamlStringSequenceValues(node: Node | null | undefined, document: Document): string[] | undefined {
+  const resolved = resolveYamlNode(node, document);
+  if (!isSeq(resolved)) return undefined;
+  const values: string[] = [];
+  for (const item of resolved.items) {
+    const value = resolveYamlNode(asYamlNode(item), document);
+    if (!isScalar(value) || typeof value.value !== "string") return undefined;
+    values.push(value.value);
+  }
+  return values;
+}
+
+function mappingHasPermission(map: Node | null | undefined, permission: string, expected: string, document: Document): boolean {
+  if (!isMap(map)) return false;
+  const value = resolveYamlNode(yamlMappingEntry(map, permission, document)?.valueNode, document);
+  return isScalar(value) && value.value === expected;
+}
+
+function yamlReferencesSecretContext(
+  rawNode: Node | null | undefined,
+  document: Document,
+  seen = new Set<Node>()
+): boolean {
+  const node = resolveYamlNode(rawNode, document);
+  if (!node || seen.has(node)) return false;
+  seen.add(node);
+  if (isScalar(node)) {
+    return typeof node.value === "string" && /\$\{\{(?:(?!\}\})[\s\S])*\bsecrets\b(?:(?!\}\})[\s\S])*\}\}/i.test(node.value);
+  }
+  if (isSeq(node)) {
+    return node.items.some((item) => yamlReferencesSecretContext(asYamlNode(item), document, seen));
+  }
+  if (isMap(node)) {
+    return node.items.some((pair) => {
+      const key = resolveYamlNode(asYamlNode(pair.key), document);
+      if (isScalar(key) && typeof key.value === "string" && key.value.toLowerCase() === "secrets") return true;
+      return yamlReferencesSecretContext(asYamlNode(pair.key), document, seen) ||
+        yamlReferencesSecretContext(asYamlNode(pair.value), document, seen);
+    });
+  }
+  return false;
+}
+
+async function publicSecurityResults(manifest: BootstrapManifest, targetDir: string): Promise<ConformanceResult[]> {
+  if (manifest.project.visibility !== "public") {
+    return [
+      result("PRS-SECURITY-BASELINE-001", "pass", ["public security projection not required for non-public repository"], "Retain explicit security controls appropriate to the repository visibility."),
+      result("PRS-FORK-SAFETY-001", "pass", ["public fork security workflow not projected"], "Re-evaluate fork safety before making the repository public.")
+    ];
+  }
+
+  const baselineFailures: { evidence: string; remediation: string }[] = [];
+  const forkFailures: { evidence: string; remediation: string }[] = [];
+  const securityDoc = await readTextIfExists(path.join(targetDir, "SECURITY.md"));
+  const expectedAdvisoryUrl = `https://github.com/${manifest.project.owner}/${manifest.project.name}/security/advisories/new`;
+  if (!securityDoc?.includes(expectedAdvisoryUrl)) {
+    baselineFailures.push({
+      evidence: "SECURITY.md does not provide the private vulnerability reporting route",
+      remediation: "Project SECURITY.md with the repository private-advisory URL and response targets."
+    });
+  }
+  if (!securityDoc?.includes("Private security contact requested")) {
+    baselineFailures.push({
+      evidence: "SECURITY.md does not provide the detail-free fallback contact request",
+      remediation: "Restore the managed fallback that requests a confidential channel without publishing vulnerability details."
+    });
+  }
+  if (!securityDoc?.includes("3 business days") || !securityDoc.includes("10 business days")) {
+    baselineFailures.push({
+      evidence: "SECURITY.md does not define acknowledgement and status-update targets",
+      remediation: "Project the managed 3-business-day acknowledgement and 10-business-day update targets."
+    });
+  }
+  if (!securityDoc?.includes("7 days for critical") || !securityDoc.includes("30 days for high") || !securityDoc.includes("90 days for moderate") || !/coordinate(?:d)? disclosure/i.test(securityDoc)) {
+    baselineFailures.push({
+      evidence: "SECURITY.md does not define all severity remediation and coordinated-disclosure targets",
+      remediation: "Restore the managed 7/30/90-day remediation targets and coordinated-disclosure commitment."
+    });
+  }
+
+  const dependabot = await readTextIfExists(path.join(targetDir, ".github/dependabot.yml"));
+  if (!manifest.ci.dependabot.enabled || !manifest.ci.dependabot.securityUpdates || !manifest.ci.dependabot.versionUpdates || !dependabot || !dependabotUpdatesActions(dependabot)) {
+    baselineFailures.push({
+      evidence: "Dependabot security updates and GitHub Actions pin updates are not fully projected",
+      remediation: "Enable Dependabot security and version updates and include the github-actions ecosystem."
+    });
+  }
+
+  const workflowPath = ".github/workflows/security.yml";
+  const workflow = await readTextIfExists(path.join(targetDir, workflowPath));
+  if (!workflow) {
+    baselineFailures.push({
+      evidence: `${workflowPath} is absent`,
+      remediation: "Run bootstrap apply repo to project the public security workflow."
+    });
+    forkFailures.push({
+      evidence: `${workflowPath} cannot be evaluated for fork safety`,
+      remediation: "Project the managed public security workflow before accepting fork contributions."
+    });
+  } else {
+    let document: Document;
+    let workflowValid = true;
+    try {
+      document = parseDocument(workflow, { prettyErrors: false });
+      if (document.errors.length > 0) throw document.errors[0];
+    } catch (error) {
+      workflowValid = false;
+      const detail = error instanceof Error ? error.message : String(error);
+      baselineFailures.push({ evidence: `${workflowPath} is invalid YAML: ${safeEvidence(detail)}`, remediation: "Repair the managed security workflow YAML." });
+      forkFailures.push({ evidence: `${workflowPath} cannot be evaluated safely`, remediation: "Repair the workflow YAML before accepting fork contributions." });
+      document = parseDocument("{}");
+    }
+
+    const root = asYamlNode(document.contents);
+    const jobs = resolveYamlNode(yamlMappingEntry(root, "jobs", document)?.valueNode, document);
+    const requiredJobActionSequences = [
+      {
+        job: "dependency-review",
+        actions: [
+          { prefix: "actions/checkout@" },
+          { prefix: "actions/dependency-review-action@", requiredInputs: ["fail-on-severity"], optionalInputs: ["vulnerability-check", "warn-only"] }
+        ]
+      },
+      {
+        job: "codeql",
+        actions: [
+          { prefix: "actions/checkout@" },
+          { prefix: "github/codeql-action/init@", requiredInputs: ["languages", "build-mode"] },
+          { prefix: "github/codeql-action/analyze@", requiredInputs: ["category"], optionalInputs: ["upload"] }
+        ]
+      },
+      {
+        job: "sbom",
+        actions: [
+          { prefix: "actions/checkout@" },
+          { prefix: "anchore/sbom-action@", requiredInputs: ["path", "format", "artifact-name", "upload-release-assets"], optionalInputs: ["upload-artifact"] }
+        ]
+      }
+    ];
+    const requiredJobNames = new Set(requiredJobActionSequences.map((requirement) => requirement.job));
+    for (const requirement of requiredJobActionSequences) {
+      if (!workflowValid || !jobHasExactActionSequence(jobs, requirement.job, requirement.actions, document)) {
+        baselineFailures.push({
+          evidence: `${workflowPath} job ${requirement.job} does not preserve its required action sequence`,
+          remediation: `Restore the managed checkout and ${requirement.job} steps in executable order.`
+        });
+      }
+      if (jobField(jobs, requirement.job, "needs", document) !== undefined) {
+        baselineFailures.push({
+          evidence: `${workflowPath} job ${requirement.job} declares a dependency that can suppress its required event lane`,
+          remediation: `Remove needs from the managed ${requirement.job} job.`
+        });
+      }
+      const continueOnError = jobField(jobs, requirement.job, "continue-on-error", document);
+      if (continueOnError !== undefined && (!isScalar(continueOnError) || continueOnError.value !== false)) {
+        baselineFailures.push({
+          evidence: `${workflowPath} job ${requirement.job} can ignore security failures`,
+          remediation: `Remove continue-on-error from the managed ${requirement.job} job.`
+        });
+      }
+    }
+    const dependencyReviewContract = {
+      failOnSeverity: jobActionField(jobs, "dependency-review", "actions/dependency-review-action@", "fail-on-severity", document),
+      vulnerabilityCheck: jobActionField(jobs, "dependency-review", "actions/dependency-review-action@", "vulnerability-check", document),
+      warnOnly: jobActionField(jobs, "dependency-review", "actions/dependency-review-action@", "warn-only", document)
+    };
+    if (dependencyReviewContract.failOnSeverity !== "high" ||
+      (dependencyReviewContract.vulnerabilityCheck !== undefined && dependencyReviewContract.vulnerabilityCheck !== true) ||
+      (dependencyReviewContract.warnOnly !== undefined && dependencyReviewContract.warnOnly !== false)) {
+      baselineFailures.push({
+        evidence: `${workflowPath} dependency review inputs do not enforce blocking vulnerability checks`,
+        remediation: "Restore fail-on-severity: high, keep vulnerability-check enabled, and keep warn-only disabled."
+      });
+    }
+    const codeqlStrategy = jobField(jobs, "codeql", "strategy", document);
+    const codeqlMatrix = isMap(codeqlStrategy)
+      ? resolveYamlNode(yamlMappingEntry(codeqlStrategy, "matrix", document)?.valueNode, document)
+      : undefined;
+    const codeqlMatrixLanguages = isMap(codeqlMatrix)
+      ? yamlStringSequenceValues(yamlMappingEntry(codeqlMatrix, "language", document)?.valueNode, document)
+      : undefined;
+    const codeqlLanguagesMatch = codeqlMatrixLanguages !== undefined &&
+      codeqlMatrixLanguages.length === manifest.ci.codeqlLanguages.length &&
+      codeqlMatrixLanguages.every((language, index) => language === manifest.ci.codeqlLanguages[index]);
+    const codeqlMatrixHasOverrides = isMap(codeqlMatrix) &&
+      (yamlMappingEntry(codeqlMatrix, "exclude", document) !== undefined || yamlMappingEntry(codeqlMatrix, "include", document) !== undefined);
+    if (!codeqlLanguagesMatch || codeqlMatrixHasOverrides || jobActionField(jobs, "codeql", "github/codeql-action/init@", "languages", document) !== "${{ matrix.language }}") {
+      baselineFailures.push({
+        evidence: `${workflowPath} CodeQL languages do not match ci.codeqlLanguages`,
+        remediation: "Configure the repository CodeQL languages explicitly and restore the managed per-language matrix and init step."
+      });
+    }
+    if (jobActionField(jobs, "codeql", "github/codeql-action/init@", "build-mode", document) !== "none") {
+      baselineFailures.push({
+        evidence: `${workflowPath} CodeQL build mode is not the managed no-build contract`,
+        remediation: "Restore build-mode: none and use only supported ci.codeqlLanguages values."
+      });
+    }
+    if (jobActionField(jobs, "codeql", "github/codeql-action/analyze@", "category", document) !== "/language:${{ matrix.language }}") {
+      baselineFailures.push({
+        evidence: `${workflowPath} CodeQL analysis category does not preserve per-language evidence`,
+        remediation: "Restore the managed /language:${{ matrix.language }} analysis category."
+      });
+    }
+    const codeqlUpload = jobActionField(jobs, "codeql", "github/codeql-action/analyze@", "upload", document);
+    if (codeqlUpload !== undefined && codeqlUpload !== true) {
+      baselineFailures.push({
+        evidence: `${workflowPath} CodeQL analysis upload is disabled`,
+        remediation: "Remove upload: false from the managed CodeQL analyze step so default-branch results remain verifiable."
+      });
+    }
+    const sbomContract = {
+      path: jobActionField(jobs, "sbom", "anchore/sbom-action@", "path", document),
+      format: jobActionField(jobs, "sbom", "anchore/sbom-action@", "format", document),
+      artifactName: jobActionField(jobs, "sbom", "anchore/sbom-action@", "artifact-name", document),
+      uploadReleaseAssets: jobActionField(jobs, "sbom", "anchore/sbom-action@", "upload-release-assets", document),
+      uploadArtifact: jobActionField(jobs, "sbom", "anchore/sbom-action@", "upload-artifact", document)
+    };
+    if (sbomContract.path !== "." || sbomContract.format !== "spdx-json" || sbomContract.artifactName !== "sbom.spdx.json" ||
+      sbomContract.uploadReleaseAssets !== false || (sbomContract.uploadArtifact !== undefined && sbomContract.uploadArtifact !== true)) {
+      baselineFailures.push({
+        evidence: `${workflowPath} SBOM inputs do not preserve the managed SPDX JSON artifact contract`,
+        remediation: "Restore path '.', format spdx-json, artifact-name sbom.spdx.json, upload-artifact true, and upload-release-assets false."
+      });
+    }
+
+    const events = resolveYamlNode(yamlMappingEntry(root, "on", document)?.valueNode, document);
+    if (!hasUnfilteredEvent(events, "pull_request", document)) {
+      forkFailures.push({ evidence: `${workflowPath} does not use an unfiltered fork-safe pull_request event`, remediation: "Use an unfiltered pull_request trigger for pre-merge dependency review." });
+    }
+    if (yamlMappingEntry(events, "pull_request_target", document)) {
+      forkFailures.push({ evidence: `${workflowPath} uses pull_request_target`, remediation: "Remove pull_request_target from the public security workflow." });
+    }
+    if (isMap(events)) {
+      const allowedEvents = new Set(["pull_request", "push", "schedule"]);
+      for (const pair of events.items) {
+        const eventName = resolveYamlNode(asYamlNode(pair.key), document);
+        if (isScalar(eventName) && typeof eventName.value === "string" && !allowedEvents.has(eventName.value)) {
+          forkFailures.push({ evidence: `${workflowPath} includes unapproved event ${eventName.value}`, remediation: "Limit the public security workflow to pull_request, push, and schedule." });
+        }
+      }
+    }
+    const push = resolveYamlNode(yamlMappingEntry(events, "push", document)?.valueNode, document);
+    const pushBranches = isMap(push)
+      ? yamlMappingEntry(push, "branches", document)?.valueNode
+      : undefined;
+    const pushBranchValues = yamlStringSequenceValues(pushBranches, document);
+    const pushKeys = isMap(push)
+      ? push.items.flatMap((pair) => {
+          const key = resolveYamlNode(asYamlNode(pair.key), document);
+          return isScalar(key) && typeof key.value === "string" ? [key.value] : [];
+        })
+      : [];
+    const effectiveDefaultBranchPush = pushBranchValues?.length === 1 &&
+      pushBranchValues[0] === manifest.project.defaultBranch &&
+      pushKeys.length === 1 && pushKeys[0] === "branches";
+    if (!effectiveDefaultBranchPush) {
+      baselineFailures.push({ evidence: `${workflowPath} does not scan every trusted push to ${manifest.project.defaultBranch}`, remediation: "Use only the exact default branch filter and remove negation and path filters from the trusted push trigger." });
+    }
+    if (!hasRunnableSchedule(events, document)) {
+      baselineFailures.push({ evidence: `${workflowPath} has no runnable scheduled security scan`, remediation: "Restore at least one valid five-field cron schedule." });
+    }
+    const permissions = resolveYamlNode(yamlMappingEntry(root, "permissions", document)?.valueNode, document);
+    if (!mappingPermissionsAreReadOnly(permissions, document)) {
+      forkFailures.push({ evidence: `${workflowPath} top-level permissions are not read-only`, remediation: "Set top-level workflow permissions to contents: read and grant trusted jobs narrowly scoped permissions." });
+    }
+    if (yamlReferencesSecretContext(root, document)) {
+      forkFailures.push({ evidence: `${workflowPath} references GitHub Actions secrets`, remediation: "Remove secret inputs from every workflow reachable by fork pull requests." });
+    }
+    if (jobCondition(jobs, "dependency-review", document) !== dependencyReviewJobCondition) {
+      forkFailures.push({ evidence: "dependency-review is not restricted to the activated pull_request lane", remediation: "Restrict dependency review to pull_request after GitHub provisioning activates the dependency graph control." });
+    }
+    if (!jobRunsOnGitHubHosted(jobs, "dependency-review", document)) {
+      forkFailures.push({ evidence: "dependency-review does not use GitHub-hosted isolation", remediation: "Run untrusted public fork validation on a GitHub-hosted runner." });
+    }
+    const dependencyPermissions = jobField(jobs, "dependency-review", "permissions", document);
+    if (!mappingPermissionsAreReadOnly(dependencyPermissions, document)) {
+      forkFailures.push({ evidence: "dependency-review job permissions are not read-only", remediation: "Restrict the pull-request job to read-only contents and pull-request permissions." });
+    }
+    for (const trustedJob of ["codeql", "sbom"]) {
+      if (jobCondition(jobs, trustedJob, document) !== trustedSecurityJobCondition) {
+        forkFailures.push({ evidence: `${trustedJob} is not restricted to approved trusted events`, remediation: `Restrict ${trustedJob} to push and schedule events.` });
+      }
+      if (!jobRunsOnGitHubHosted(jobs, trustedJob, document)) {
+        baselineFailures.push({ evidence: `${trustedJob} has no approved security executor boundary`, remediation: `Use GitHub-hosted isolation for ${trustedJob}.` });
+      }
+    }
+    const codeqlPermissions = jobField(jobs, "codeql", "permissions", document);
+    if (!mappingHasPermission(codeqlPermissions, "contents", "read", document) || !mappingHasPermission(codeqlPermissions, "security-events", "write", document)) {
+      baselineFailures.push({ evidence: "codeql lacks contents: read or security-events: write", remediation: "Grant the trusted CodeQL job contents: read and security-events: write so it can upload analysis." });
+    }
+    const sbomPermissions = jobField(jobs, "sbom", "permissions", document);
+    if (!mappingHasPermission(sbomPermissions, "contents", "write", document)) {
+      baselineFailures.push({ evidence: "sbom lacks contents: write", remediation: "Grant the trusted SBOM job contents: write so the pinned action can upload its workflow artifact." });
+    }
+    if (isMap(jobs)) {
+      for (const pair of jobs.items) {
+        const name = resolveYamlNode(asYamlNode(pair.key), document);
+        const job = resolveYamlNode(asYamlNode(pair.value), document);
+        if (!isScalar(name) || typeof name.value !== "string" || !isMap(job)) continue;
+        const condition = jobCondition(jobs, name.value, document);
+        const excludedFromPullRequests = condition === trustedSecurityJobCondition;
+        if (!requiredJobNames.has(name.value)) {
+          baselineFailures.push({ evidence: `${workflowPath} includes unmanaged job ${name.value}`, remediation: "Remove unmanaged jobs from the public security workflow." });
+        }
+        if (!excludedFromPullRequests && name.value !== "dependency-review") {
+          forkFailures.push({ evidence: `${name.value} may run on pull_request`, remediation: "Make dependency-review the only pull-request-reachable security job." });
+        }
+        if (!excludedFromPullRequests) {
+          if (name.value !== "dependency-review" && !jobRunsOnGitHubHosted(jobs, name.value, document)) {
+            forkFailures.push({ evidence: `${name.value} does not use GitHub-hosted isolation`, remediation: "Run every pull-request-reachable job on an approved GitHub-hosted runner." });
+          }
+          const jobPermissions = resolveYamlNode(yamlMappingEntry(job, "permissions", document)?.valueNode, document);
+          if (!mappingPermissionsAreReadOnly(jobPermissions, document)) {
+            forkFailures.push({ evidence: `${name.value} has non-read-only pull-request permissions`, remediation: "Restrict every pull-request-reachable job to read-only permissions." });
+          }
+        }
+      }
+    }
+  }
+
+  return [
+    ...(baselineFailures.length === 0
+      ? [result("PRS-SECURITY-BASELINE-001", "pass", ["security policy, dependency updates, code scanning, and SBOM projection validated"], "Keep the managed public security baseline current.")]
+      : baselineFailures.map((failure) => result("PRS-SECURITY-BASELINE-001", "blocking", [failure.evidence], failure.remediation))),
+    ...(forkFailures.length === 0
+      ? [result("PRS-FORK-SAFETY-001", "pass", ["pull-request security lane is read-only and does not reference secrets"], "Keep privileged security jobs unreachable from fork pull requests.")]
+      : forkFailures.map((failure) => result("PRS-FORK-SAFETY-001", "blocking", [failure.evidence], failure.remediation)))
+  ];
+}
+
 async function actionPinResults(manifest: BootstrapManifest, targetDir: string): Promise<ConformanceResult[]> {
   const shaPattern = /^[0-9a-f]{40}$/;
   const inventory = await workflowFiles(targetDir);
@@ -361,15 +980,64 @@ export async function runConformance(manifest: BootstrapManifest, targetDir: str
   results.push(...requiredFileResults.map((entry) => applyWaiver(entry, requiredFilesWaiver)));
   const actionPinsWaiver = findWaiver(manifest, validExceptionIds, waiverTargets.actionPins);
   results.push(...(await actionPinResults(manifest, targetDir)).map((entry) => applyWaiver(entry, actionPinsWaiver)));
+  const securityBaselineWaiver = findWaiver(manifest, validExceptionIds, waiverTargets.securityBaseline);
+  results.push(...(await publicSecurityResults(manifest, targetDir)).map((entry) => applyWaiver(entry, securityBaselineWaiver)));
 
   const githubCapabilities = githubCapabilitySnapshotSchema.parse(options.githubCapabilities ?? { schemaVersion: 1, observations: [] });
+  if (manifest.project.visibility === "public") {
+    const observedControls = new Set(githubCapabilities.observations.map((entry) => entry.control));
+    for (const control of publicSecurityCapabilityControls) {
+      if (observedControls.has(control)) continue;
+      const missingObservation = result(
+        "PRS-SECURITY-CAPABILITY-001",
+        "warning",
+        [`${control}: no authorized observation provided`],
+        `Capture ${control} in a versioned GitHub capability snapshot.`,
+        "unverified"
+      );
+      const capabilityWaiver = findWaiver(manifest, validExceptionIds, {
+        policy: "github-capability",
+        scope: `github.${control}`
+      });
+      results.push(applyWaiver(missingObservation, capabilityWaiver));
+    }
+  }
   for (const capability of githubCapabilities.observations) {
+    const dependencyReviewActivationUnverified = capability.control === "dependency-graph" &&
+      capability.status === "supported" && capability.dependencyReviewEnabled === undefined;
+    const dependencyReviewActivationDisabled = capability.control === "dependency-graph" &&
+      capability.status === "supported" && capability.dependencyReviewEnabled === false;
+    const severity = dependencyReviewActivationUnverified
+      ? "warning"
+      : dependencyReviewActivationDisabled
+        ? "blocking"
+        : capability.status === "supported"
+          ? "pass"
+          : capability.status === "unsupported"
+            ? "warning"
+            : "blocking";
+    const classification = dependencyReviewActivationUnverified
+      ? "unverified"
+      : dependencyReviewActivationDisabled
+        ? "misconfigured"
+        : capability.status === "supported"
+          ? "conformant"
+          : capability.status;
+    const activationEvidence = capability.control === "dependency-graph" && capability.status === "supported"
+      ? [capability.dependencyReviewEnabled === true
+          ? "dependency review activation: enabled"
+          : capability.dependencyReviewEnabled === false
+            ? "dependency review activation: disabled"
+            : "dependency review activation: no authorized observation provided"]
+      : [];
     const capabilityResult = result(
       "PRS-GITHUB-CAPABILITY-001",
-      capability.status === "supported" ? "pass" : capability.status === "unsupported" ? "warning" : "blocking",
-      [`${capability.control}: ${capability.evidence}`],
-      capability.remediation,
-      capability.status === "supported" ? "conformant" : capability.status
+      severity,
+      [`${capability.control}: ${capability.evidence}`, ...activationEvidence],
+      dependencyReviewActivationUnverified || dependencyReviewActivationDisabled
+        ? "Verify the dependency graph and record DEPENDENCY_REVIEW_ENABLED=true in the authorized capability observation."
+        : capability.remediation,
+      classification
     );
     const capabilityWaiver = findWaiver(manifest, validExceptionIds, {
       policy: "github-capability",

--- a/tests/conformance.test.ts
+++ b/tests/conformance.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
+import { mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
@@ -26,11 +26,13 @@ describe("runConformance", () => {
     expect(report.results.map((entry) => entry.ruleId)).toEqual([
       "PRS-ACTION-PIN-001",
       "PRS-CLASS-001",
+      "PRS-FORK-SAFETY-001",
       "PRS-LICENSE-001",
       "PRS-MATURITY-001",
       "PRS-OWNERSHIP-001",
       "PRS-PROFILE-001",
-      "PRS-REQUIRED-FILE-001"
+      "PRS-REQUIRED-FILE-001",
+      "PRS-SECURITY-BASELINE-001"
     ]);
     expect(report.results.every((entry) => entry.classification.length > 0)).toBe(true);
   });
@@ -128,6 +130,510 @@ describe("runConformance", () => {
     expect(report.results).toContainEqual(expect.objectContaining({ ruleId: "PRS-ACTION-PIN-001", severity: "pass", classification: "waived" }));
   });
 
+  it("validates the complete public security baseline and authorized capability observations", async () => {
+    const directory = await fixtureDirectory();
+    const manifest = normalizeManifest({
+      project: { name: "public-security", owner: "acme", visibility: "public", maturity: "stable" },
+      repo: { class: "service" },
+      archetype: { kind: "node-ts-service" },
+      release: { reusableWorkflowRef: "a".repeat(40) }
+    });
+    await applyRepo(manifest, directory);
+    const controls = [
+      "code-scanning",
+      "dependabot-alerts",
+      "dependabot-security-updates",
+      "dependency-graph",
+      "private-vulnerability-reporting",
+      "push-protection",
+      "secret-scanning"
+    ];
+
+    const report = await runConformance(manifest, directory, {
+      githubCapabilities: {
+        schemaVersion: 1,
+        observations: controls.map((control) => ({
+          control,
+          status: "supported",
+          evidence: "enabled",
+          remediation: "Keep enabled.",
+          ...(control === "dependency-graph" ? { dependencyReviewEnabled: true } : {})
+        }))
+      }
+    });
+
+    expect(report.results).toContainEqual(expect.objectContaining({ ruleId: "PRS-SECURITY-BASELINE-001", severity: "pass", classification: "conformant" }));
+    expect(report.results).toContainEqual(expect.objectContaining({ ruleId: "PRS-FORK-SAFETY-001", severity: "pass", classification: "conformant" }));
+    expect(report.results.filter((entry) => entry.ruleId === "PRS-SECURITY-CAPABILITY-001")).toEqual([]);
+    expect(report.results.filter((entry) => entry.ruleId === "PRS-GITHUB-CAPABILITY-001")).toHaveLength(controls.length);
+  });
+
+  it("requires typed activation evidence for a supported dependency graph", async () => {
+    const directory = await fixtureDirectory();
+    const manifest = normalizeManifest({
+      project: { name: "public-security", owner: "acme", visibility: "public", maturity: "stable" },
+      repo: { class: "service" },
+      archetype: { kind: "node-ts-service" },
+      release: { reusableWorkflowRef: "a".repeat(40) }
+    });
+    await applyRepo(manifest, directory);
+    const observation = {
+      control: "dependency-graph",
+      status: "supported" as const,
+      evidence: "enabled",
+      remediation: "Keep enabled."
+    };
+
+    const unverified = await runConformance(manifest, directory, {
+      githubCapabilities: { schemaVersion: 1, observations: [observation] }
+    });
+    expect(unverified.results).toContainEqual(expect.objectContaining({
+      ruleId: "PRS-GITHUB-CAPABILITY-001",
+      severity: "warning",
+      classification: "unverified",
+      evidence: expect.arrayContaining(["dependency review activation: no authorized observation provided"])
+    }));
+
+    const disabled = await runConformance(manifest, directory, {
+      githubCapabilities: { schemaVersion: 1, observations: [{ ...observation, dependencyReviewEnabled: false }] }
+    });
+    expect(disabled.results).toContainEqual(expect.objectContaining({
+      ruleId: "PRS-GITHUB-CAPABILITY-001",
+      severity: "blocking",
+      classification: "misconfigured",
+      evidence: expect.arrayContaining(["dependency review activation: disabled"])
+    }));
+
+    const enabled = await runConformance(manifest, directory, {
+      githubCapabilities: { schemaVersion: 1, observations: [{ ...observation, dependencyReviewEnabled: true }] }
+    });
+    expect(enabled.results).toContainEqual(expect.objectContaining({
+      ruleId: "PRS-GITHUB-CAPABILITY-001",
+      severity: "pass",
+      classification: "conformant",
+      evidence: expect.arrayContaining(["dependency review activation: enabled"])
+    }));
+  });
+
+  it("accepts equivalent unfiltered event syntax and stable versioned GitHub-hosted runners", async () => {
+    const directory = await fixtureDirectory();
+    const manifest = normalizeManifest({
+      project: { name: "public-security", owner: "acme", visibility: "public", maturity: "stable" },
+      repo: { class: "service" },
+      archetype: { kind: "node-ts-service" },
+      release: { reusableWorkflowRef: "a".repeat(40) }
+    });
+    await applyRepo(manifest, directory);
+    const workflowPath = path.join(directory, ".github/workflows/security.yml");
+    const workflow = await readFile(workflowPath, "utf8");
+    await writeFile(
+      workflowPath,
+      workflow
+        .replace("  pull_request:\n", "  pull_request: {}\n")
+        .replaceAll("runs-on: ubuntu-latest", "runs-on: ubuntu-24.04")
+        .replace("    - cron: '23 6 * * 1'", "    - cron: '23 6 * JAN 7'")
+        .replace("permissions:\n  contents: read", "permissions: read-all")
+    );
+
+    const report = await runConformance(manifest, directory);
+
+    expect(report.results).toContainEqual(expect.objectContaining({ ruleId: "PRS-SECURITY-BASELINE-001", severity: "pass" }));
+    expect(report.results).toContainEqual(expect.objectContaining({ ruleId: "PRS-FORK-SAFETY-001", severity: "pass" }));
+  });
+
+  it("rejects reusable workflow secret inheritance on trusted security events", async () => {
+    const directory = await fixtureDirectory();
+    const manifest = normalizeManifest({
+      project: { name: "public-security", owner: "acme", visibility: "public", maturity: "stable" },
+      repo: { class: "service" },
+      archetype: { kind: "node-ts-service" },
+      release: { reusableWorkflowRef: "a".repeat(40) }
+    });
+    await applyRepo(manifest, directory);
+    const workflowPath = path.join(directory, ".github/workflows/security.yml");
+    const workflow = await readFile(workflowPath, "utf8");
+    await writeFile(workflowPath, `${workflow}\n  secret-forwarder:\n    if: github.event_name == 'push' || github.event_name == 'schedule'\n    uses: acme/security/.github/workflows/scan.yml@${"b".repeat(40)} # v1\n    secrets: inherit\n  fork-self-hosted:\n    runs-on: self-hosted\n    permissions:\n      contents: read\n    steps:\n      - run: echo unsafe\n`);
+
+    const report = await runConformance(manifest, directory);
+
+    expect(report.results).toContainEqual(expect.objectContaining({
+      ruleId: "PRS-FORK-SAFETY-001",
+      severity: "blocking",
+      evidence: [".github/workflows/security.yml references GitHub Actions secrets"]
+    }));
+    expect(report.results).toContainEqual(expect.objectContaining({
+      ruleId: "PRS-FORK-SAFETY-001",
+      severity: "blocking",
+      evidence: ["fork-self-hosted does not use GitHub-hosted isolation"]
+    }));
+    expect(report.results).toContainEqual(expect.objectContaining({
+      ruleId: "PRS-SECURITY-BASELINE-001",
+      severity: "blocking",
+      evidence: [".github/workflows/security.yml includes unmanaged job fork-self-hosted"]
+    }));
+  });
+
+  it("rejects CodeQL analysis with result upload disabled", async () => {
+    const directory = await fixtureDirectory();
+    const manifest = normalizeManifest({
+      project: { name: "public-security", owner: "acme", visibility: "public", maturity: "stable" },
+      repo: { class: "service" },
+      archetype: { kind: "node-ts-service" },
+      release: { reusableWorkflowRef: "a".repeat(40) }
+    });
+    await applyRepo(manifest, directory);
+    const workflowPath = path.join(directory, ".github/workflows/security.yml");
+    const workflow = await readFile(workflowPath, "utf8");
+    await writeFile(
+      workflowPath,
+      workflow.replace(
+        '          category: "/language:${{ matrix.language }}"',
+        '          category: "/language:${{ matrix.language }}"\n          upload: false'
+      )
+    );
+
+    const report = await runConformance(manifest, directory);
+
+    expect(report.results).toContainEqual(expect.objectContaining({
+      ruleId: "PRS-SECURITY-BASELINE-001",
+      severity: "blocking",
+      evidence: [".github/workflows/security.yml CodeQL analysis upload is disabled"]
+    }));
+  });
+
+  it("rejects fail-open security action inputs and unsupported cron cadence", async () => {
+    const directory = await fixtureDirectory();
+    const manifest = normalizeManifest({
+      project: { name: "public-security", owner: "acme", visibility: "public", maturity: "stable" },
+      repo: { class: "service" },
+      archetype: { kind: "node-ts-service" },
+      release: { reusableWorkflowRef: "a".repeat(40) }
+    });
+    await applyRepo(manifest, directory);
+    const workflowPath = path.join(directory, ".github/workflows/security.yml");
+    const workflow = await readFile(workflowPath, "utf8");
+    await writeFile(
+      workflowPath,
+      workflow
+        .replace("  dependency-review:\n", "  dependency-review:\n    continue-on-error: true\n")
+        .replace("  codeql:\n", "  codeql:\n    continue-on-error: true\n")
+        .replace("  sbom:\n", "  sbom:\n    continue-on-error: true\n")
+        .replace(
+          "          fail-on-severity: high",
+          "          fail-on-severity: high\n          vulnerability-check: false\n          warn-only: true"
+        )
+        .replace(
+          "          upload-release-assets: false",
+          "          upload-release-assets: false\n          upload-artifact: false"
+        )
+        .replace("    - cron: '23 6 * * 1'", "    - cron: '23 6 * * 1'\n      timezone: Not/AZone")
+    );
+
+    const report = await runConformance(manifest, directory);
+    const evidence = report.results
+      .filter((entry) => entry.ruleId === "PRS-SECURITY-BASELINE-001")
+      .flatMap((entry) => entry.evidence)
+      .join(" ");
+
+    expect(evidence).toContain("dependency review inputs do not enforce blocking vulnerability checks");
+    expect(evidence).toContain("SBOM inputs do not preserve the managed SPDX JSON artifact contract");
+    expect(evidence).toContain("job dependency-review can ignore security failures");
+    expect(evidence).toContain("job codeql can ignore security failures");
+    expect(evidence).toContain("job sbom can ignore security failures");
+    expect(evidence).toContain("has no runnable scheduled security scan");
+
+    await writeFile(workflowPath, workflow.replace("    - cron: '23 6 * * 1'", "    - cron: '23 6 * * 1'\n    - cron: '*/1 * * * *'"));
+    const unsupportedCadence = await runConformance(manifest, directory);
+    expect(unsupportedCadence.results).toContainEqual(expect.objectContaining({
+      ruleId: "PRS-SECURITY-BASELINE-001",
+      severity: "blocking",
+      evidence: [".github/workflows/security.yml has no runnable scheduled security scan"]
+    }));
+  });
+
+  it("rejects unreachable managed actions and checkout source overrides", async () => {
+    const directory = await fixtureDirectory();
+    const manifest = normalizeManifest({
+      project: { name: "public-security", owner: "acme", visibility: "public", maturity: "stable" },
+      repo: { class: "service" },
+      archetype: { kind: "node-ts-service" },
+      release: { reusableWorkflowRef: "a".repeat(40) }
+    });
+    await applyRepo(manifest, directory);
+    const workflowPath = path.join(directory, ".github/workflows/security.yml");
+    const workflow = await readFile(workflowPath, "utf8");
+    await writeFile(
+      workflowPath,
+      workflow
+        .replace(
+          "    steps:\n      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4\n      - uses: github/codeql-action/init@",
+          "    steps:\n      - run: exit 1\n      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4\n      - uses: github/codeql-action/init@"
+        )
+        .replace(
+          "      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4\n      - uses: anchore/sbom-action@",
+          "      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4\n        with:\n          repository: attacker/decoy\n      - uses: anchore/sbom-action@"
+        )
+    );
+
+    const report = await runConformance(manifest, directory);
+    const evidence = report.results
+      .filter((entry) => entry.ruleId === "PRS-SECURITY-BASELINE-001")
+      .flatMap((entry) => entry.evidence)
+      .join(" ");
+
+    expect(evidence).toContain("job codeql does not preserve its required action sequence");
+    expect(evidence).toContain("job sbom does not preserve its required action sequence");
+  });
+
+  it("rejects dependency, matrix, trigger, and schedule suppression paths", async () => {
+    const directory = await fixtureDirectory();
+    const manifest = normalizeManifest({
+      project: { name: "public-security", owner: "acme", visibility: "public", maturity: "stable" },
+      repo: { class: "service" },
+      archetype: { kind: "node-ts-service" },
+      release: { reusableWorkflowRef: "a".repeat(40) }
+    });
+    await applyRepo(manifest, directory);
+    const workflowPath = path.join(directory, ".github/workflows/security.yml");
+    const workflow = await readFile(workflowPath, "utf8");
+    await writeFile(
+      workflowPath,
+      workflow
+        .replace('    branches: ["main"]', '    branches: ["main", "!main"]\n    paths-ignore: ["**"]')
+        .replace("    - cron: '23 6 * * 1'", "    - cron: '0 0 31 2 *'")
+        .replace("  codeql:\n", "  codeql:\n    needs: dependency-review\n")
+        .replace(
+          '        language: ["javascript-typescript"]',
+          '        language: ["javascript-typescript"]\n        exclude:\n          - language: javascript-typescript'
+        )
+        .replace("  sbom:\n", "  sbom:\n    needs: dependency-review\n")
+    );
+
+    const report = await runConformance(manifest, directory);
+    const evidence = report.results
+      .filter((entry) => entry.ruleId === "PRS-SECURITY-BASELINE-001")
+      .flatMap((entry) => entry.evidence)
+      .join(" ");
+
+    expect(evidence).toContain("job codeql declares a dependency");
+    expect(evidence).toContain("job sbom declares a dependency");
+    expect(evidence).toContain("CodeQL languages do not match ci.codeqlLanguages");
+    expect(evidence).toContain("does not scan every trusted push to main");
+    expect(evidence).toContain("has no runnable scheduled security scan");
+  });
+
+  it("rejects invalid or disabled GitHub Actions Dependabot updaters", async () => {
+    const directory = await fixtureDirectory();
+    const manifest = normalizeManifest({
+      project: { name: "dependabot-security", owner: "acme", visibility: "public", maturity: "stable" },
+      repo: { class: "service" },
+      archetype: { kind: "node-ts-service" },
+      release: { reusableWorkflowRef: "a".repeat(40) }
+    });
+    await applyRepo(manifest, directory);
+    const updater = (version: number, limit?: unknown, directory = "/") => [
+      `version: ${version}`,
+      "updates:",
+      "  - package-ecosystem: github-actions",
+      `    directory: ${directory}`,
+      "    schedule:",
+      "      interval: weekly",
+      ...(limit === undefined ? [] : [`    open-pull-requests-limit: ${typeof limit === "string" ? JSON.stringify(limit) : String(limit)}`])
+    ].join("\n");
+
+    await writeFile(path.join(directory, ".github/dependabot.yml"), updater(1));
+    const invalidVersion = await runConformance(manifest, directory);
+    expect(invalidVersion.results).toContainEqual(expect.objectContaining({
+      ruleId: "PRS-SECURITY-BASELINE-001",
+      severity: "blocking",
+      evidence: ["Dependabot security updates and GitHub Actions pin updates are not fully projected"]
+    }));
+
+    await writeFile(path.join(directory, ".github/dependabot.yml"), updater(2, 0));
+    const disabledUpdates = await runConformance(manifest, directory);
+    expect(disabledUpdates.results).toContainEqual(expect.objectContaining({
+      ruleId: "PRS-SECURITY-BASELINE-001",
+      severity: "blocking",
+      evidence: ["Dependabot security updates and GitHub Actions pin updates are not fully projected"]
+    }));
+
+    for (const invalidLimit of [false, -1, 1.5, "5", "not-a-number"]) {
+      await writeFile(path.join(directory, ".github/dependabot.yml"), updater(2, invalidLimit));
+      const invalidLimitReport = await runConformance(manifest, directory);
+      expect(invalidLimitReport.results).toContainEqual(expect.objectContaining({
+        ruleId: "PRS-SECURITY-BASELINE-001",
+        severity: "blocking",
+        evidence: ["Dependabot security updates and GitHub Actions pin updates are not fully projected"]
+      }));
+    }
+
+    await writeFile(path.join(directory, ".github/dependabot.yml"), updater(2, 11));
+    const largeValidLimit = await runConformance(manifest, directory);
+    expect(largeValidLimit.results).toContainEqual(expect.objectContaining({
+      ruleId: "PRS-SECURITY-BASELINE-001",
+      severity: "pass"
+    }));
+
+    await writeFile(path.join(directory, ".github/dependabot.yml"), updater(2, undefined, "/not-workflows"));
+    const wrongDirectory = await runConformance(manifest, directory);
+    expect(wrongDirectory.results).toContainEqual(expect.objectContaining({
+      ruleId: "PRS-SECURITY-BASELINE-001",
+      severity: "blocking",
+      evidence: ["Dependabot security updates and GitHub Actions pin updates are not fully projected"]
+    }));
+  });
+
+  it("blocks incomplete public security projection and fork-unsafe workflow fixtures", async () => {
+    const directory = await fixtureDirectory();
+    const manifest = normalizeManifest({
+      project: { name: "unsafe-security", owner: "acme", visibility: "public", maturity: "stable" },
+      repo: { class: "service", docs: { security: false } },
+      archetype: { kind: "node-ts-service" },
+      ci: { dependabot: { enabled: false, securityUpdates: false, versionUpdates: false } },
+      release: { reusableWorkflowRef: "a".repeat(40) }
+    });
+    await applyRepo(manifest, directory);
+    const unsafeReference = ["$", "{{", "toJSON", "(", "sec", "rets", ")", "}}"].join("");
+    await writeFile(path.join(directory, ".github/workflows/security.yml"), [
+      "on:",
+      "  pull_request_target:",
+      "permissions:",
+      "  contents: write",
+      "jobs:",
+      "  dependency-review:",
+      "    if: github.event_name == 'pull_request'",
+      "    steps:",
+      "      - uses: actions/dependency-review-action@v5",
+      "        env:",
+      `          FIXTURE: ${unsafeReference}`,
+      "  codeql:",
+      "    if: github.event_name == 'pull_request'",
+      "    steps: []",
+      "  sbom:",
+      "    if: github.event_name == 'pull_request'",
+      "    steps: []"
+    ].join("\n"));
+
+    const report = await runConformance(manifest, directory);
+    const baseline = report.results.filter((entry) => entry.ruleId === "PRS-SECURITY-BASELINE-001");
+    const forkSafety = report.results.filter((entry) => entry.ruleId === "PRS-FORK-SAFETY-001");
+    const capabilities = report.results.filter((entry) => entry.ruleId === "PRS-SECURITY-CAPABILITY-001");
+
+    expect(baseline.every((entry) => entry.severity === "blocking")).toBe(true);
+    expect(baseline.map((entry) => entry.evidence.join(" ")).join(" ")).toContain("SECURITY.md");
+    expect(baseline.map((entry) => entry.evidence.join(" ")).join(" ")).toContain("Dependabot");
+    expect(forkSafety.every((entry) => entry.severity === "blocking")).toBe(true);
+    expect(forkSafety.map((entry) => entry.evidence.join(" ")).join(" ")).toContain("pull_request_target");
+    expect(forkSafety.map((entry) => entry.evidence.join(" ")).join(" ")).toContain("references GitHub Actions secrets");
+    expect(capabilities).toHaveLength(7);
+    expect(capabilities.every((entry) => entry.severity === "warning" && entry.classification === "unverified")).toBe(true);
+  });
+
+  it("rejects dead trusted scans, wrong advisory routing, decoy actions, and writable pull-request jobs", async () => {
+    const directory = await fixtureDirectory();
+    const manifest = normalizeManifest({
+      project: { name: "security-target", owner: "acme", visibility: "public", maturity: "stable" },
+      repo: { class: "service" },
+      archetype: { kind: "node-ts-service" },
+      release: { reusableWorkflowRef: "a".repeat(40) }
+    });
+    await applyRepo(manifest, directory);
+    const trustedSecretReference = ["$", "{{", " sec", "rets", ".SBOM_TOKEN ", "}}"].join("");
+    await writeFile(path.join(directory, "SECURITY.md"), [
+      "https://github.com/wrong/repository/security/advisories/new",
+      "Acknowledge within 3 business days and update within 10 business days."
+    ].join("\n"));
+    await writeFile(path.join(directory, ".github/dependabot.yml"), [
+      "version: 2",
+      "updates:",
+      "  - package-ecosystem: github-actions",
+      "    directory: /",
+      "    schedule:",
+      "      interval: weekly",
+      "    open-pull-requests-limit: 0"
+    ].join("\n"));
+    await writeFile(path.join(directory, ".github/workflows/security.yml"), [
+      "on:",
+      "  pull_request:",
+      "    types: [closed]",
+      "  push:",
+      "    branches: [main]",
+      "  schedule:",
+      "    - cron: '99 99 99 99 99'",
+      "  merge_group:",
+      "permissions:",
+      "  contents: read",
+      "jobs:",
+      "  dependency-review:",
+      "    if: github.event_name == 'pull_request'",
+      "    runs-on: ubuntu-persistent",
+      "    permissions:",
+      "      contents: write",
+      "    steps:",
+      "      - if: false",
+      "        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4",
+      "      - if: false",
+      "        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0",
+      "  codeql:",
+      "    if: github.event_name == 'push' || github.event_name == 'schedule'",
+      "    permissions:",
+      "      contents: read",
+      "    steps:",
+      "      - if: false",
+      "        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4",
+      "      - if: false",
+      "        uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a # v4",
+      "        with:",
+      "          languages: javascript-typescript",
+      "      - if: false",
+      "        uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a # v4",
+      "  sbom:",
+      "    if: github.event_name == 'push' || github.event_name == 'schedule'",
+      "    steps:",
+      "      - if: false",
+      "        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4",
+      "      - if: false",
+      "        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0",
+      "        env:",
+      `          TOKEN: ${trustedSecretReference}`,
+      "  decoy:",
+      "    if: false",
+      "    permissions:",
+      "      contents: read",
+      "    steps:",
+      "      - uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0",
+      "      - uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a # v4",
+      "      - uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a # v4",
+      "      - uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0"
+    ].join("\n"));
+
+    const report = await runConformance(manifest, directory);
+    const baselineEvidence = report.results.filter((entry) => entry.ruleId === "PRS-SECURITY-BASELINE-001").flatMap((entry) => entry.evidence).join(" ");
+    const forkEvidence = report.results.filter((entry) => entry.ruleId === "PRS-FORK-SAFETY-001").flatMap((entry) => entry.evidence).join(" ");
+
+    expect(baselineEvidence).toContain("private vulnerability reporting route");
+    expect(baselineEvidence).toContain("detail-free fallback contact request");
+    expect(baselineEvidence).toContain("all severity remediation and coordinated-disclosure targets");
+    expect(baselineEvidence).toContain("Dependabot security updates and GitHub Actions pin updates are not fully projected");
+    expect(baselineEvidence).toContain("has no runnable scheduled security scan");
+    expect(baselineEvidence).toContain("job dependency-review does not preserve its required action sequence");
+    expect(baselineEvidence).toContain("job codeql does not preserve its required action sequence");
+    expect(baselineEvidence).toContain("job sbom does not preserve its required action sequence");
+    expect(baselineEvidence).toContain("CodeQL languages do not match ci.codeqlLanguages");
+    expect(baselineEvidence).toContain("CodeQL analysis category does not preserve per-language evidence");
+    expect(baselineEvidence).toContain("SBOM inputs do not preserve the managed SPDX JSON artifact contract");
+    expect(baselineEvidence).toContain("codeql lacks contents: read or security-events: write");
+    expect(baselineEvidence).toContain("sbom lacks contents: write");
+    expect(baselineEvidence).toContain("codeql has no approved security executor boundary");
+    expect(baselineEvidence).toContain("sbom has no approved security executor boundary");
+    expect(forkEvidence).toContain("does not use GitHub-hosted isolation");
+    expect(forkEvidence).toContain("references GitHub Actions secrets");
+    expect(forkEvidence).toContain("dependency-review job permissions are not read-only");
+    expect(forkEvidence).toContain("decoy may run on pull_request");
+    expect(forkEvidence).toContain("includes unapproved event merge_group");
+    expect(forkEvidence).toContain("does not use an unfiltered fork-safe pull_request event");
+  });
+
   it("rejects unsafe or multiline capability evidence", () => {
     const base = { schemaVersion: 1, observations: [{ control: "secret-scanning", status: "supported", evidence: "enabled", remediation: "Keep enabled." }] };
     expect(githubCapabilitySnapshotSchema.safeParse(base).success).toBe(true);
@@ -150,6 +656,10 @@ describe("runConformance", () => {
     expect(githubCapabilitySnapshotSchema.safeParse({
       ...base,
       observations: [{ ...base.observations[0], evidence: "   ", remediation: "\t" }]
+    }).success).toBe(false);
+    expect(githubCapabilitySnapshotSchema.safeParse({
+      ...base,
+      observations: [{ ...base.observations[0], dependencyReviewEnabled: true }]
     }).success).toBe(false);
   });
 


### PR DESCRIPTION
## Summary

- add deterministic conformance rules for the projected public-repository security baseline and fork-safe execution boundary
- validate managed dependency review, CodeQL, SBOM, Dependabot, schedule, permissions, runner, and secret-forwarding contracts fail closed
- classify authorized GitHub capability observations, including typed dependency-review activation evidence, without conflating unsupported and misconfigured controls
- document the capability snapshot and accepted ADR contract

## Governing Issue

Closes #60

## Validation

- [x] Relevant local checks passed
- [x] Agent-authored changes passed `autoreview` against the intended PR diff with no accepted/actionable findings
- Autoreview command and result: `/Users/johnteneyckjr./.codex/skills/autoreview/scripts/autoreview --mode commit --commit HEAD --engine codex --model gpt-5.6-terra --thinking high --no-web-search --stream-engine-output --parallel-tests 'TMPDIR=/tmp npm run check'`; clean with no findings at confidence 0.88 on commit `c8612e4`. Stable patch ID `2a94bcabef9906521fb808e95a2164583160f8b1` is identical for rebased commit `48cf6d5`.
- [x] Required PR checks are expected to satisfy `CI Gate`
- [x] Skipped checks are explained below
- `TMPDIR=/tmp npm run check` — 23 files and 193 tests passed on rebased `main`
- `npm run build` — passed
- `bash scripts/ci/check-action-pins.sh` — passed; 42 immutable third-party action pins validated
- `git diff --check origin/main...HEAD` — passed
- A redundant external autoreview replay on the rebased SHA was not sent because this run lacked separate external-disclosure authorization; the reviewed and rebased diffs have the same stable patch ID, and the full suite was rerun against current `main`.

## Bootstrap Governance

- [x] Changes are scoped to the linked issue
- [x] Contributor or PR guidance changes are reflected in `CONTRIBUTING.md`, `.github/PULL_REQUEST_TEMPLATE.md`, and `docs/bootstrap/onboarding.md` when applicable
- [x] PR author enabled auto-merge where GitHub allows it, or GitHub plan-limit evidence/unavailable reason is recorded and the fallback merge-readiness policy applies
- [x] No real secrets, runtime auth, or machine-local env files are committed

Material change: yes
ADR: docs/decisions/ADR-0005-public-repository-security-baseline.md

## Merge Automation

- [x] PR author enabled auto-merge with `gh pr merge --auto --squash`, or the reason it is unavailable/unsafe is noted below

## Notes

- This follow-up is rebased onto the squash merge of PR #100 and contains only the conformance/documentation slice.
