### PR TITLE
ci: harden Dependabot dependency refreshes

### DIFF
--- a/.github/workflows/ai-attestation-reusable.yml
+++ b/.github/workflows/ai-attestation-reusable.yml
@@ -34,7 +34,7 @@ jobs:
     outputs:
       sha: ${{ steps.meta.outputs.sha }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 1
 

--- a/.github/workflows/extended-validation.yml
+++ b/.github/workflows/extended-validation.yml
@@ -31,7 +31,7 @@ jobs:
       ci: ${{ steps.preset.outputs.ci || steps.filter.outputs.ci || 'false' }}
       extended: ${{ steps.preset.outputs.extended || steps.filter.outputs.extended || 'false' }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         if: github.event_name == 'push'
         with:
           fetch-depth: 0
@@ -84,7 +84,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.app == 'true' || needs.changes.outputs.ci == 'true'
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Run fast checks
         run: bash scripts/ci/run-fast-checks.sh
@@ -96,7 +96,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.extended == 'true' || needs.changes.outputs.app == 'true'
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Run extended validation
         run: bash scripts/ci/run-extended-validation.sh
@@ -106,7 +106,7 @@ jobs:
     runs-on: ['self-hosted', 'linux', 'shell-only', 'public']
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - name: Scan repository for secret patterns
         run: bash scripts/check-detect-secrets.sh --all-files
 

--- a/.github/workflows/full-release-validation-reusable.yml
+++ b/.github/workflows/full-release-validation-reusable.yml
@@ -22,7 +22,7 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           ref: ${{ inputs.target_ref }}
           fetch-depth: 0

--- a/.github/workflows/issue-hygiene.yml
+++ b/.github/workflows/issue-hygiene.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ['self-hosted', 'linux', 'shell-only', 'public']
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '20'

--- a/.github/workflows/pr-fast-ci.yml
+++ b/.github/workflows/pr-fast-ci.yml
@@ -66,18 +66,57 @@ jobs:
       github.event.pull_request.draft == false &&
       (needs.changes.outputs.app == 'true' || needs.changes.outputs.ci == 'true')
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Run fast checks
         run: bash scripts/ci/run-fast-checks.sh
 
+  verify-dependabot-commits:
+    name: Verify Dependabot-only Commits
+    runs-on: ['self-hosted', 'linux', 'shell-only', 'public']
+    timeout-minutes: 5
+    if: github.event.pull_request.draft == false
+    outputs:
+      bot_only: ${{ steps.verify.outputs.bot_only }}
+    env:
+      PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+      PR_COMMITS_URL: ${{ github.event.pull_request.commits_url }}
+      GITHUB_TOKEN: ${{ github.token }}
+    steps:
+      - id: verify
+        name: Require every PR commit to be Dependabot
+        run: |
+          set -euo pipefail
+          page=1
+          commits_seen=0
+          bot_only=false
+          if [[ "$PR_AUTHOR" == "dependabot[bot]" ]]; then
+            bot_only=true
+            while :; do
+              response="$(curl --fail-with-body --silent --show-error --location --header "Authorization: Bearer $GITHUB_TOKEN" --header "Accept: application/vnd.github+json" "$PR_COMMITS_URL?per_page=100&page=$page")"
+              jq -e 'type == "array"' <<<"$response" >/dev/null
+              count="$(jq 'length' <<<"$response")"
+              [[ "$count" -gt 0 ]] || break
+              commits_seen=$((commits_seen + count))
+              if ! jq -e 'all(.[]; .author != null and .author.login == "dependabot[bot]" and .committer != null and .committer.login == "web-flow" and .commit.verification.verified == true and .commit.verification.reason == "valid")' <<<"$response" >/dev/null; then
+                bot_only=false
+              fi
+              [[ "$count" -lt 100 ]] && break
+              page=$((page + 1))
+            done
+            [[ "$commits_seen" -gt 0 ]] || bot_only=false
+          fi
+          echo "Verified $commits_seen PR commit(s); Dependabot-only=$bot_only"
+          echo "bot_only=$bot_only" >> "$GITHUB_OUTPUT"
+
   validate-pr-description:
     name: Validate PR Description
     runs-on: ['self-hosted', 'linux', 'shell-only', 'public']
     timeout-minutes: 5
-    if: github.event.pull_request.draft == false
+    if: github.event.pull_request.draft == false && needs.verify-dependabot-commits.outputs.bot_only != 'true'
+    needs: verify-dependabot-commits
     env:
       PR_BODY: ${{ github.event.pull_request.body }}
     steps:
@@ -129,7 +168,7 @@ jobs:
     timeout-minutes: 10
     if: github.event.pull_request.draft == false
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Scan repository for secret patterns
@@ -139,7 +178,8 @@ jobs:
     name: Validate PR Governance
     runs-on: ['self-hosted', 'linux', 'shell-only', 'public']
     timeout-minutes: 5
-    if: github.event.pull_request.draft == false
+    if: github.event.pull_request.draft == false && needs.verify-dependabot-commits.outputs.bot_only != 'true'
+    needs: verify-dependabot-commits
     env:
       PR_TITLE: ${{ github.event.pull_request.title }}
       PR_BODY: ${{ github.event.pull_request.body }}
@@ -151,7 +191,7 @@ jobs:
       PR_REVIEWS_URL: ${{ github.event.pull_request.url }}/reviews
       GITHUB_TOKEN: ${{ github.token }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Validate title, DCO, size, ADR, and reviewer evidence
@@ -163,7 +203,7 @@ jobs:
     timeout-minutes: 5
     if: github.event.pull_request.draft == false
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Require immutable third-party action pins
@@ -176,6 +216,7 @@ jobs:
     needs:
       - changes
       - fast-checks
+      - verify-dependabot-commits
       - validate-pr-description
       - validate-secrets
       - validate-pr-governance
@@ -186,6 +227,7 @@ jobs:
           RESULTS: >-
             changes=${{ needs.changes.result }}
             fast-checks=${{ needs.fast-checks.result }}
+            verify-dependabot-commits=${{ needs.verify-dependabot-commits.result }}
             validate-pr-description=${{ needs.validate-pr-description.result }}
             validate-secrets=${{ needs.validate-secrets.result }}
             validate-pr-governance=${{ needs.validate-pr-governance.result }}

--- a/.github/workflows/release-postpublish-reusable.yml
+++ b/.github/workflows/release-postpublish-reusable.yml
@@ -21,7 +21,7 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           ref: ${{ inputs.tag }}
           fetch-depth: 0

--- a/.github/workflows/release-postpublish.yml
+++ b/.github/workflows/release-postpublish.yml
@@ -20,7 +20,7 @@ on:
 
 jobs:
   postpublish:
-    uses: OMT-Global/bootstrap/.github/workflows/release-postpublish-reusable.yml@d9c5bc7e50f4bcc97e4b4d3d2efc64e4ab3dca50
+    uses: OMT-Global/bootstrap/.github/workflows/release-postpublish-reusable.yml@05296606785553deb8f36e4f18313076dfc9646d
     with:
       tag: ${{ inputs.tag }}
       channel: ${{ inputs.channel }}

--- a/.github/workflows/release-preflight-reusable.yml
+++ b/.github/workflows/release-preflight-reusable.yml
@@ -30,7 +30,7 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           ref: ${{ inputs.target_ref }}
           fetch-depth: 0

--- a/.github/workflows/release-preflight.yml
+++ b/.github/workflows/release-preflight.yml
@@ -24,7 +24,7 @@ on:
 
 jobs:
   preflight:
-    uses: OMT-Global/bootstrap/.github/workflows/release-preflight-reusable.yml@d9c5bc7e50f4bcc97e4b4d3d2efc64e4ab3dca50
+    uses: OMT-Global/bootstrap/.github/workflows/release-preflight-reusable.yml@05296606785553deb8f36e4f18313076dfc9646d
     with:
       version: ${{ inputs.version }}
       channel: ${{ inputs.channel }}

--- a/.github/workflows/release-publish-reusable.yml
+++ b/.github/workflows/release-publish-reusable.yml
@@ -39,7 +39,7 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           ref: ${{ inputs.tag }}
           fetch-depth: 0

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -28,7 +28,7 @@ on:
 
 jobs:
   publish:
-    uses: OMT-Global/bootstrap/.github/workflows/release-publish-reusable.yml@d9c5bc7e50f4bcc97e4b4d3d2efc64e4ab3dca50
+    uses: OMT-Global/bootstrap/.github/workflows/release-publish-reusable.yml@05296606785553deb8f36e4f18313076dfc9646d
     with:
       tag: ${{ inputs.tag }}
       channel: ${{ inputs.channel }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,7 +100,7 @@ jobs:
       DOCKYARD_SPARKLE_SIGN_UPDATE: ${{ secrets.DOCKYARD_SPARKLE_SIGN_UPDATE }}
       SPARKLE_FRAMEWORK_PATH: ${{ secrets.SPARKLE_FRAMEWORK_PATH }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
       - name: Derive release metadata

--- a/.github/workflows/security-pr.yml
+++ b/.github/workflows/security-pr.yml
@@ -43,7 +43,7 @@ jobs:
       contents: read
       pull-requests: read
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4
         with:
           fail-on-severity: high
@@ -61,8 +61,8 @@ jobs:
       contents: read
       security-events: write
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a # v4
         with:
           languages: ${{ inputs.codeql-languages }}
       - name: Repo build hook
@@ -72,7 +72,7 @@ jobs:
           else
             echo "No scripts/ci/run-security-build.sh hook; continuing without a custom build."
           fi
-      - uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4
+      - uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a # v4
 
   osv:
     name: osv
@@ -86,7 +86,7 @@ jobs:
       contents: read
       security-events: write
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - name: Repo OSV hook
         run: |
           if [[ -x scripts/ci/run-osv.sh ]]; then
@@ -108,7 +108,7 @@ jobs:
       contents: read
       security-events: write
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - name: Repo Semgrep hook
         env:
           SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -18,7 +18,7 @@ jobs:
       contents: read
       pull-requests: read
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
         with:
           fail-on-severity: high
@@ -34,7 +34,7 @@ jobs:
       contents: read
       security-events: write
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a # v4
         with:
           languages: ${{ matrix.language }}
@@ -49,7 +49,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
         with:
           path: .

--- a/src/archetypes.ts
+++ b/src/archetypes.ts
@@ -1566,7 +1566,7 @@ function publicSecurityWorkflow(manifest: BootstrapManifest): string {
           contents: read
           pull-requests: read
         steps:
-          - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+          - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
           - uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
             with:
               fail-on-severity: high
@@ -1582,7 +1582,7 @@ function publicSecurityWorkflow(manifest: BootstrapManifest): string {
           contents: read
           security-events: write
         steps:
-          - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+          - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
           - uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a # v4
             with:
               languages: \${{ matrix.language }}
@@ -1597,7 +1597,7 @@ function publicSecurityWorkflow(manifest: BootstrapManifest): string {
         permissions:
           contents: write
         steps:
-          - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+          - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
           - uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
             with:
               path: .
@@ -1877,7 +1877,7 @@ function releasePreflightReusableWorkflow(): string {
           run:
             shell: bash
         steps:
-          - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+          - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
             with:
               ref: \${{ inputs.target_ref }}
               fetch-depth: 0
@@ -1966,7 +1966,7 @@ function fullReleaseValidationReusableWorkflow(): string {
           run:
             shell: bash
         steps:
-          - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+          - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
             with:
               ref: \${{ inputs.target_ref }}
               fetch-depth: 0
@@ -2044,7 +2044,7 @@ function releasePublishReusableWorkflow(): string {
           run:
             shell: bash
         steps:
-          - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+          - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
             with:
               ref: \${{ inputs.tag }}
               fetch-depth: 0
@@ -2191,7 +2191,7 @@ function releasePostpublishReusableWorkflow(): string {
           run:
             shell: bash
         steps:
-          - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+          - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
             with:
               ref: \${{ inputs.tag }}
               fetch-depth: 0
@@ -2549,18 +2549,57 @@ ${yamlList(paths.ci, 18)}
           github.event.pull_request.draft == false &&
           (needs.changes.outputs.app == 'true' || needs.changes.outputs.ci == 'true')
         steps:
-          - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+          - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
             with:
               ref: \${{ github.event.pull_request.head.sha }}
 ${indentBlock(setupSteps(manifest), 10)}
           - name: Run fast checks
             run: bash scripts/ci/run-fast-checks.sh
 
+      verify-dependabot-commits:
+        name: Verify Dependabot-only Commits
+        runs-on: ${shellRunner}
+        timeout-minutes: 5
+        if: github.event.pull_request.draft == false
+        outputs:
+          bot_only: \${{ steps.verify.outputs.bot_only }}
+        env:
+          PR_AUTHOR: \${{ github.event.pull_request.user.login }}
+          PR_COMMITS_URL: \${{ github.event.pull_request.commits_url }}
+          GITHUB_TOKEN: \${{ github.token }}
+        steps:
+          - id: verify
+            name: Require every PR commit to be Dependabot
+            run: |
+              set -euo pipefail
+              page=1
+              commits_seen=0
+              bot_only=false
+              if [[ "$PR_AUTHOR" == "dependabot[bot]" ]]; then
+                bot_only=true
+                while :; do
+                  response="$(curl --fail-with-body --silent --show-error --location --header "Authorization: Bearer $GITHUB_TOKEN" --header "Accept: application/vnd.github+json" "$PR_COMMITS_URL?per_page=100&page=$page")"
+                  jq -e 'type == "array"' <<<"$response" >/dev/null
+                  count="$(jq 'length' <<<"$response")"
+                  [[ "$count" -gt 0 ]] || break
+                  commits_seen=$((commits_seen + count))
+                  if ! jq -e 'all(.[]; .author != null and .author.login == "dependabot[bot]" and .committer != null and .committer.login == "web-flow" and .commit.verification.verified == true and .commit.verification.reason == "valid")' <<<"$response" >/dev/null; then
+                    bot_only=false
+                  fi
+                  [[ "$count" -lt 100 ]] && break
+                  page=$((page + 1))
+                done
+                [[ "$commits_seen" -gt 0 ]] || bot_only=false
+              fi
+              echo "Verified $commits_seen PR commit(s); Dependabot-only=$bot_only"
+              echo "bot_only=$bot_only" >> "$GITHUB_OUTPUT"
+
       validate-pr-description:
         name: Validate PR Description
         runs-on: ${shellRunner}
         timeout-minutes: 5
-        if: github.event.pull_request.draft == false
+        if: github.event.pull_request.draft == false && needs.verify-dependabot-commits.outputs.bot_only != 'true'
+        needs: verify-dependabot-commits
         env:
           PR_BODY: \${{ github.event.pull_request.body }}
         steps:
@@ -2612,7 +2651,7 @@ ${indentBlock(setupSteps(manifest), 10)}
         timeout-minutes: 10
         if: github.event.pull_request.draft == false
         steps:
-          - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+          - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
             with:
               ref: \${{ github.event.pull_request.head.sha }}
           - name: Scan repository for secret patterns
@@ -2622,7 +2661,8 @@ ${indentBlock(setupSteps(manifest), 10)}
         name: Validate PR Governance
         runs-on: ${shellRunner}
         timeout-minutes: 5
-        if: github.event.pull_request.draft == false
+        if: github.event.pull_request.draft == false && needs.verify-dependabot-commits.outputs.bot_only != 'true'
+        needs: verify-dependabot-commits
         env:
           PR_TITLE: \${{ github.event.pull_request.title }}
           PR_BODY: \${{ github.event.pull_request.body }}
@@ -2634,7 +2674,7 @@ ${indentBlock(setupSteps(manifest), 10)}
           PR_REVIEWS_URL: \${{ github.event.pull_request.url }}/reviews
           GITHUB_TOKEN: \${{ github.token }}
         steps:
-          - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+          - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
             with:
               ref: \${{ github.event.pull_request.head.sha }}
           - name: Validate title, DCO, size, ADR, and reviewer evidence
@@ -2646,7 +2686,7 @@ ${indentBlock(setupSteps(manifest), 10)}
         timeout-minutes: 5
         if: github.event.pull_request.draft == false
         steps:
-          - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+          - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
             with:
               ref: \${{ github.event.pull_request.head.sha }}
           - name: Require immutable third-party action pins
@@ -2659,6 +2699,7 @@ ${indentBlock(setupSteps(manifest), 10)}
         needs:
           - changes
           - fast-checks
+          - verify-dependabot-commits
           - validate-pr-description
           - validate-secrets
           - validate-pr-governance
@@ -2669,6 +2710,7 @@ ${indentBlock(setupSteps(manifest), 10)}
               RESULTS: >-
                 changes=\${{ needs.changes.result }}
                 fast-checks=\${{ needs.fast-checks.result }}
+                verify-dependabot-commits=\${{ needs.verify-dependabot-commits.result }}
                 validate-pr-description=\${{ needs.validate-pr-description.result }}
                 validate-secrets=\${{ needs.validate-secrets.result }}
                 validate-pr-governance=\${{ needs.validate-pr-governance.result }}
@@ -2710,7 +2752,7 @@ function issueHygieneWorkflow(manifest: BootstrapManifest): string {
         runs-on: ${shellRunner}
         timeout-minutes: 10
         steps:
-          - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+          - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
           - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
             with:
               node-version: '${manifest.ci.nodeVersion}'
@@ -2775,7 +2817,7 @@ function extendedWorkflow(manifest: BootstrapManifest): string {
           ci: \${{ steps.preset.outputs.ci || steps.filter.outputs.ci || 'false' }}
           extended: \${{ steps.preset.outputs.extended || steps.filter.outputs.extended || 'false' }}
         steps:
-          - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+          - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
             if: github.event_name == 'push'
             with:
               fetch-depth: 0
@@ -2809,7 +2851,7 @@ ${yamlList(paths.extended, 18)}
         needs: changes
         if: needs.changes.outputs.app == 'true' || needs.changes.outputs.ci == 'true'
         steps:
-          - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+          - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 ${indentBlock(setupSteps(manifest), 10)}
           - name: Run fast checks
             run: bash scripts/ci/run-fast-checks.sh
@@ -2821,7 +2863,7 @@ ${indentBlock(setupSteps(manifest), 10)}
         needs: changes
         if: needs.changes.outputs.extended == 'true' || needs.changes.outputs.app == 'true'
         steps:
-          - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+          - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 ${indentBlock(setupSteps(manifest), 10)}
           - name: Run extended validation
             run: bash scripts/ci/run-extended-validation.sh
@@ -2831,7 +2873,7 @@ ${indentBlock(setupSteps(manifest), 10)}
         runs-on: ${shellRunner}
         timeout-minutes: 10
         steps:
-          - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+          - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
           - name: Scan repository for secret patterns
             run: bash scripts/check-detect-secrets.sh --all-files
 
@@ -3365,7 +3407,7 @@ function claudeWorkflow(manifest: BootstrapManifest): string {
         runs-on: ubuntu-latest
         timeout-minutes: 30
         steps:
-          - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+          - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
           - name: Run Claude Code
             uses: anthropics/claude-code-action@e90deca47693f9457b72f2b53c17d7c445a87342 # v1
             with:

--- a/tests/conformance.test.ts
+++ b/tests/conformance.test.ts
@@ -366,12 +366,12 @@ describe("runConformance", () => {
       workflowPath,
       workflow
         .replace(
-          "    steps:\n      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4\n      - uses: github/codeql-action/init@",
-          "    steps:\n      - run: exit 1\n      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4\n      - uses: github/codeql-action/init@"
+          "    steps:\n      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4\n      - uses: github/codeql-action/init@",
+          "    steps:\n      - run: exit 1\n      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4\n      - uses: github/codeql-action/init@"
         )
         .replace(
-          "      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4\n      - uses: anchore/sbom-action@",
-          "      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4\n        with:\n          repository: attacker/decoy\n      - uses: anchore/sbom-action@"
+          "      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4\n      - uses: anchore/sbom-action@",
+          "      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4\n        with:\n          repository: attacker/decoy\n      - uses: anchore/sbom-action@"
         )
     );
 
@@ -571,7 +571,7 @@ describe("runConformance", () => {
       "      contents: write",
       "    steps:",
       "      - if: false",
-      "        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4",
+      "        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4",
       "      - if: false",
       "        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0",
       "  codeql:",
@@ -580,7 +580,7 @@ describe("runConformance", () => {
       "      contents: read",
       "    steps:",
       "      - if: false",
-      "        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4",
+      "        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4",
       "      - if: false",
       "        uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a # v4",
       "        with:",
@@ -591,7 +591,7 @@ describe("runConformance", () => {
       "    if: github.event_name == 'push' || github.event_name == 'schedule'",
       "    steps:",
       "      - if: false",
-      "        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4",
+      "        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4",
       "      - if: false",
       "        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0",
       "        env:",

--- a/tests/dependabot-verifier.test.ts
+++ b/tests/dependabot-verifier.test.ts
@@ -1,0 +1,125 @@
+import { execFileSync } from "node:child_process";
+import { chmodSync, existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+import { parseDocument } from "yaml";
+
+import { renderManagedFiles } from "../src/archetypes.js";
+import { normalizeManifest } from "../src/manifest.js";
+
+const tempDirectories: string[] = [];
+
+afterEach(() => {
+  for (const directory of tempDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+function renderedVerifierScript(): string {
+  const manifest = normalizeManifest({
+    project: { name: "dependabot-verifier", owner: "acme" },
+    archetype: { kind: "generic-empty" }
+  });
+  const workflow = renderManagedFiles(manifest).find((file) => file.path === ".github/workflows/pr-fast-ci.yml");
+  const parsed = parseDocument(workflow?.contents ?? "").toJS() as {
+    jobs: { "verify-dependabot-commits": { steps: Array<{ run: string }> } };
+  };
+
+  return parsed.jobs["verify-dependabot-commits"].steps[0].run;
+}
+
+function runVerifier(
+  pages: string[],
+  prAuthor = "dependabot[bot]"
+): { botOnly: boolean; requests: string[] } {
+  const directory = mkdtempSync(join(tmpdir(), "bootstrap-dependabot-verifier-"));
+  tempDirectories.push(directory);
+
+  const curlPath = join(directory, "curl");
+  const outputPath = join(directory, "github-output");
+  const requestLogPath = join(directory, "requests.log");
+  writeFileSync(
+    curlPath,
+    `#!/usr/bin/env bash
+set -euo pipefail
+url="\${*: -1}"
+printf '%s\\n' "$url" >> "$MOCK_CURL_LOG"
+page="\${url##*page=}"
+key="MOCK_PAGE_$page"
+printf '%s' "\${!key:-[]}"
+`
+  );
+  chmodSync(curlPath, 0o755);
+
+  const pageEnvironment = Object.fromEntries(pages.map((page, index) => [`MOCK_PAGE_${index + 1}`, page]));
+  execFileSync("bash", ["-c", renderedVerifierScript()], {
+    env: {
+      ...process.env,
+      ...pageEnvironment,
+      PATH: `${directory}:${process.env.PATH ?? ""}`,
+      PR_AUTHOR: prAuthor,
+      PR_COMMITS_URL: "https://api.github.test/repos/acme/demo/pulls/1/commits",
+      GITHUB_TOKEN: "",
+      GITHUB_OUTPUT: outputPath,
+      MOCK_CURL_LOG: requestLogPath
+    }
+  });
+
+  return {
+    botOnly: readFileSync(outputPath, "utf8").trim() === "bot_only=true",
+    requests: existsSync(requestLogPath) ? readFileSync(requestLogPath, "utf8").trim().split("\n") : []
+  };
+}
+
+const dependabotCommit = {
+  author: { login: "dependabot[bot]" },
+  committer: { login: "web-flow" },
+  commit: { verification: { verified: true, reason: "valid" } }
+};
+
+describe("Dependabot commit verification", () => {
+  it("accepts a non-empty Dependabot-only commit response", () => {
+    expect(runVerifier([JSON.stringify([dependabotCommit])]).botOnly).toBe(true);
+  });
+
+  it("rejects a non-Dependabot PR even when every commit impersonates Dependabot", () => {
+    const result = runVerifier([JSON.stringify([dependabotCommit])], "contributor");
+
+    expect(result.botOnly).toBe(false);
+    expect(result.requests).toEqual([]);
+  });
+
+  it.each([
+    ["unsigned", { ...dependabotCommit, commit: { verification: { verified: false, reason: "unsigned" } } }],
+    ["wrong committer", { ...dependabotCommit, committer: { login: "maintainer" } }],
+    ["missing committer", { ...dependabotCommit, committer: null }]
+  ])("rejects a %s commit that otherwise impersonates Dependabot", (_name, commit) => {
+    expect(runVerifier([JSON.stringify([commit])]).botOnly).toBe(false);
+  });
+
+  it.each([
+    ["empty", []],
+    ["mixed author", [dependabotCommit, { ...dependabotCommit, author: { login: "maintainer" } }]],
+    ["unlinked author", [dependabotCommit, { ...dependabotCommit, author: null }]]
+  ])("fails closed for a %s response", (_name, commits) => {
+    expect(runVerifier([JSON.stringify(commits)]).botOnly).toBe(false);
+  });
+
+  it("checks later pages before granting the exemption", () => {
+    const firstPage = Array.from({ length: 100 }, () => dependabotCommit);
+    const result = runVerifier([
+      JSON.stringify(firstPage),
+      JSON.stringify([{ author: { login: "maintainer" } }])
+    ]);
+
+    expect(result.botOnly).toBe(false);
+    expect(result.requests).toHaveLength(2);
+    expect(result.requests[1]).toContain("page=2");
+  });
+
+  it("rejects a non-array API response", () => {
+    expect(() => runVerifier([JSON.stringify({ message: "rate limited" })])).toThrow();
+  });
+});

--- a/tests/render.test.ts
+++ b/tests/render.test.ts
@@ -57,6 +57,17 @@ describe("renderManagedFiles", () => {
       expect(prWorkflow?.contents).toContain("PR_GOVERNANCE_ENFORCE_AFTER:");
       expect(prWorkflow?.contents).toContain("['self-hosted', 'linux'");
       expect(prWorkflow?.contents).toContain("validate-pr-description:");
+      expect(prWorkflow?.contents).toContain("verify-dependabot-commits:");
+      expect(prWorkflow?.contents).toContain("Require every PR commit to be Dependabot");
+      expect(prWorkflow?.contents).toContain("PR_AUTHOR: ${{ github.event.pull_request.user.login }}");
+      expect(prWorkflow?.contents).toContain('[[ "$PR_AUTHOR" == "dependabot[bot]" ]]');
+      expect(prWorkflow?.contents).toContain(".author != null and .author.login == \"dependabot[bot]\"");
+      expect(prWorkflow?.contents).toContain('.committer.login == "web-flow"');
+      expect(prWorkflow?.contents).toContain(".commit.verification.verified == true");
+      expect(prWorkflow?.contents).toContain('.commit.verification.reason == "valid"');
+      expect(prWorkflow?.contents).toContain('[[ "$commits_seen" -gt 0 ]] || bot_only=false');
+      expect(prWorkflow?.contents).toContain("page=$((page + 1))");
+      expect(prWorkflow?.contents).toContain("needs.verify-dependabot-commits.outputs.bot_only != 'true'");
       expect(prWorkflow?.contents).toContain("PR body must close/link an issue");
       expect(prWorkflow?.contents).toContain("refs?|part[[:space:]]+of");
       expect(prWorkflow?.contents).toContain("[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+#");
@@ -64,6 +75,8 @@ describe("renderManagedFiles", () => {
       expect(prWorkflow?.contents).toContain("auto_merge_evidence=");
       expect(prWorkflow?.contents).toContain('<<<"$auto_merge_evidence"');
       expect(prWorkflow?.contents).toContain("validate-pr-governance:");
+      expect(prWorkflow?.contents).toContain("- verify-dependabot-commits");
+      expect(prWorkflow?.contents).toContain("verify-dependabot-commits=${{ needs.verify-dependabot-commits.result }}");
       expect(prWorkflow?.contents).toContain("pull-requests: read");
       expect(prWorkflow?.contents).toContain("PR_COMMITS_URL:");
       expect(files.find((file) => file.path === "scripts/ci/check-pr-governance.sh")?.contents).toContain("PRS-DCO-001");


### PR DESCRIPTION
## Summary

- Consolidate the pending immutable workflow dependency updates from PRs #102-#106.
- Require an authenticated Dependabot PR plus GitHub-verified Dependabot commit provenance before skipping human-only metadata gates.
- Keep checked-in workflows, canonical renderer output, CodeQL action versions, and regression fixtures synchronized.

## Governing Issue

Closes #108.

## Validation

- [x] `TMPDIR=/tmp npm run check` (24 test files, 204 tests passed)
- [x] `npm run build`
- [x] `bash scripts/ci/check-action-pins.sh` (42 immutable pins passed)
- [x] Ruby parse of every checked-in workflow YAML file
- [x] `git diff --check origin/main...HEAD`
- [x] Exact-branch autoreview against current `origin/main` completed cleanly with no accepted/actionable findings (confidence 0.90).
- [x] Required PR checks are expected to satisfy `CI Gate`.

Autoreview command and result: `/Users/johnteneyckjr./.codex/skills/autoreview/scripts/autoreview --mode branch --base origin/main --stream-engine-output` — clean, no findings.

## Bootstrap Governance

- [x] Changes are scoped to issue #108's dependency refresh and governance-bypass repair.
- [x] Generated workflows and `src/archetypes.ts` carry the same policy and pins.
- [x] No secrets, runtime auth, or machine-local environment files are committed.
- [x] The reviewer-found PR-owner, signed-commit provenance, and CodeQL init/analyze consistency blockers were accepted and fixed.

Material change: yes
ADR: docs/decisions/ADR-0005-public-repository-security-baseline.md

## Merge Automation

- [x] Auto-merge is enabled with squash merge for the reviewed head.

## Notes

This PR supersedes #102, #103, #104, #105, and #106. Those branches mix valid dependency bumps with generated-file drift or insufficient Dependabot provenance checks; they should close only after this replacement merges.
